### PR TITLE
fix compilation for case sensitive OSs

### DIFF
--- a/src/clock.cpp
+++ b/src/clock.cpp
@@ -60,7 +60,7 @@
 #if defined(USE_EEPROM) && (USE_EEPROM > 0)
 #  include <EEPROM.h>
 #endif
-#include "Clock.h"
+#include "clock.h"
 
 //---| globals |----------------------------------------------------------------
 /*static*/ const char* Clock::Months[] = {

--- a/src/esp32/esp32_gps.cpp
+++ b/src/esp32/esp32_gps.cpp
@@ -2,7 +2,7 @@
 
 #if defined (ENABLE_GPS)
 
-#include "esp32_GPS.h"
+#include "esp32_gps.h"
 #include <loop_functions.h>
 #include <loop_functions_extern.h>
 #include <clock.h>

--- a/src/esp32/esp32_main.cpp
+++ b/src/esp32/esp32_main.cpp
@@ -69,7 +69,7 @@ extern AXP20X_Class *axp;
 
 #endif
 
-#include <u8g2lib.h>
+#include <U8g2lib.h>
 
 #if defined(BOARD_HELTEC)
     extern U8G2_SSD1306_128X64_NONAME_F_HW_I2C u8g2;

--- a/src/nrf52/nrf52_main.cpp
+++ b/src/nrf52/nrf52_main.cpp
@@ -247,7 +247,7 @@ void interruptHandle3()
   }
 }
 
-#include <u8g2lib.h>
+#include <U8g2lib.h>
 
 extern U8G2_SH1106_128X64_NONAME_F_HW_I2C u8g2;
 


### PR DESCRIPTION
Due to Windows paths not being case sensitive, compilation fails on other OSs (Linux). This PR makes compilation work on all platforms.

TL;DR: I changed the includes to the actual filenames with the right capitalisation (and this should be done in the future too to avoid compilation problems).