### PR TITLE
fix typo in #include of TinyGPS which leads to compile time error on …

### DIFF
--- a/src/esp32/esp32_gps.cpp
+++ b/src/esp32/esp32_gps.cpp
@@ -6,7 +6,7 @@
 #include <loop_functions.h>
 #include <loop_functions_extern.h>
 #include <clock.h>
-#include <TinyGPSplus.h>
+#include <TinyGPSPlus.h>
 
 #if defined(MODUL_FW_TBEAM)
     #define GPS_RX_PIN 34

--- a/src/loop_functions.cpp
+++ b/src/loop_functions.cpp
@@ -9,7 +9,7 @@
 #include "udp_functions.h"
 #include "configuration.h"
 
-#include "TinyGPSplus.h"
+#include "TinyGPSPlus.h"
 
 // TinyGPS
 extern TinyGPSPlus tinyGPSPLus;

--- a/src/lora_functions.cpp
+++ b/src/lora_functions.cpp
@@ -49,7 +49,7 @@ extern double mheardLon[MAX_MHEARD];
 double lat=0;
 double lon=0;
 
-#include "TinyGPSplus.h"
+#include "TinyGPSPlus.h"
 
 // TinyGPS
 extern TinyGPSPlus tinyGPSPLus;

--- a/src/nrf52/nrf52_main.cpp
+++ b/src/nrf52/nrf52_main.cpp
@@ -13,7 +13,7 @@
 #include <debugconf.h>
 #include <time.h>
 
-#include <TinyGPSplus.h>
+#include <TinyGPSPlus.h>
 
 #include "Adafruit_SHTC3.h"
 


### PR DESCRIPTION
Platformio Build failed on Linux (case-sensitive build-system)

wrong #include of TinyGPSplus.h instead of TinyGPSPlus.h