### PR TITLE
add spectrum scan and corresponding python script

### DIFF
--- a/extras/SpectrumScan.py
+++ b/extras/SpectrumScan.py
@@ -1,0 +1,173 @@
+#!/usr/bin/python3
+# -*- encoding: utf-8 -*-
+
+import argparse
+import serial
+import sys
+import numpy as np
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+
+from datetime import datetime
+from argparse import RawTextHelpFormatter
+
+# number of samples in each scanline
+SCAN_WIDTH = 33
+
+# scanline Serial start/end markers
+SCAN_MARK_START = 'SCAN '
+SCAN_MARK_FREQ = 'FREQ '
+SCAN_MARK_END = ' END'
+
+
+# default settings
+DEFAULT_PORT = '/dev/ttyACM0'
+DEFAULT_BAUDRATE = 115200
+DEFAULT_COLOR_MAP = 'viridis'
+DEFAULT_SCAN_LEN = 51
+DEFAULT_RSSI_OFFSET = -11
+
+# Print iterations progress
+# from https://stackoverflow.com/questions/3173320/text-progress-bar-in-terminal-with-block-characters
+def printProgressBar (iteration, total, prefix = '', suffix = '', decimals = 1, length = 50, fill = '█', printEnd = "\r"):
+    """
+    Call in a loop to create terminal progress bar
+    @params:
+        iteration   - Required  : current iteration (Int)
+        total       - Required  : total iterations (Int)
+        prefix      - Optional  : prefix string (Str)
+        suffix      - Optional  : suffix string (Str)
+        decimals    - Optional  : positive number of decimals in percent complete (Int)
+        length      - Optional  : character length of bar (Int)
+        fill        - Optional  : bar fill character (Str)
+        printEnd    - Optional  : end character (e.g. "\r", "\r\n") (Str)
+    """
+    percent = ("{0:." + str(decimals) + "f}").format(100 * (iteration / float(total)))
+    filledLength = int(length * iteration // total)
+    bar = fill * filledLength + '-' * (length - filledLength)
+    print(f'\r{prefix} |{bar}| {percent}% {suffix}', end = printEnd)
+    if iteration == total: 
+        print()
+
+
+def main():
+    parser = argparse.ArgumentParser(formatter_class=RawTextHelpFormatter, description='''
+        RadioLib SX126x_Spectrum_Scan plotter script. Displays output from SX126x_Spectrum_Scan example
+        as grayscale and 
+
+        Depends on pyserial and matplotlib, install by:
+        'python3 -m pip install pyserial matplotlib'
+    ''')
+    parser.add_argument('--port',
+        default=DEFAULT_PORT,
+        type=str,
+        help='COM port to connect to the device')
+    parser.add_argument('--speed',
+        default=DEFAULT_BAUDRATE,
+        type=int,
+        help=f'COM port baudrate (defaults to {DEFAULT_BAUDRATE})')
+    parser.add_argument('--map',
+        default=DEFAULT_COLOR_MAP,
+        type=str,
+        help=f'Matplotlib color map to use for the output (defaults to "{DEFAULT_COLOR_MAP}")')
+    parser.add_argument('--len',
+        default=DEFAULT_SCAN_LEN,
+        type=int,
+        help=f'Number of scanlines to record (defaults to {DEFAULT_SCAN_LEN})')
+    parser.add_argument('--offset',
+        default=DEFAULT_RSSI_OFFSET,
+        type=int,
+        help=f'Default RSSI offset in dBm (defaults to {DEFAULT_RSSI_OFFSET})')
+    parser.add_argument('--freq',
+        default=433,
+        type=float,
+        help=f'Default starting frequency in MHz')
+    args = parser.parse_args()
+
+    freq_mode = False
+    scan_len = args.len
+    if (args.freq != -1):
+        freq_mode = True
+    #    scan_len = 1000
+
+    #print("Scan Len: " + str(scan_len))
+
+    # create the color map and the result array
+    arr = np.zeros((SCAN_WIDTH, scan_len))
+
+    # scanline counter
+    row = 0
+
+    # list of frequencies in frequency mode
+    freq_list = []
+
+    # open the COM port
+    with serial.Serial(args.port, args.speed, timeout=None) as com:
+        com.write(b"--spectrum\r\n")
+        while(True):
+            # update the progress bar
+            printProgressBar(row, scan_len)
+
+            # read a single line
+            try:
+                line = com.readline().decode('utf-8')
+            except:
+                continue
+
+            if SCAN_MARK_FREQ in line:
+                new_freq = float(line.split(' ')[1])
+                if (len(freq_list) > 1) and (new_freq < freq_list[-1]):
+                    break
+
+                freq_list.append(new_freq)
+                #print('{:.3f}'.format(new_freq), end = '\r')
+                continue
+
+            # check the markers
+            if (SCAN_MARK_START in line) and (SCAN_MARK_END in line):
+                # get the values
+                scanline = line[len(SCAN_MARK_START):-len(SCAN_MARK_END)].split(',')
+                for col in range(SCAN_WIDTH):
+                    arr[col][row] = int(scanline[col])
+                
+                # increment the row counter
+                row = row + 1
+
+                # check if we're done
+                if (row >= scan_len):
+                    break
+    
+    # scale to the number of scans (sum of any given scanline)
+    num_samples = arr.sum(axis=0)[0]
+    arr *= (num_samples/arr.max())
+
+    if freq_mode:
+        scan_len = len(freq_list)
+
+    # create the figure
+    fig, ax = plt.subplots()
+
+    # display the result as heatmap
+    extent = [0, scan_len, -4*(SCAN_WIDTH + 1), args.offset]
+    if freq_mode:
+        extent[0] = freq_list[0]
+        extent[1] = freq_list[-1]
+    im = ax.imshow(arr[:,:scan_len], cmap=args.map, extent=extent)
+    fig.colorbar(im)
+
+    # set some properites and show 
+    timestamp = datetime.now().strftime('%y-%m-%d %H-%M-%S')
+    title = f'MeshCom SX126x Spectral Scan {timestamp}'
+    if freq_mode:
+        plt.xlabel("Frequency [MHz]")
+    else:
+        plt.xlabel("Time [sample]")
+    plt.ylabel("RSSI [dBm]")
+    ax.set_aspect('auto')
+    fig.suptitle(title)
+    fig.canvas.manager.set_window_title(title)
+    plt.savefig(f'{title.replace(" ", "_")}.png', dpi=300)
+    plt.show()
+
+if __name__ == "__main__":
+    main()

--- a/platformio.ini
+++ b/platformio.ini
@@ -39,6 +39,7 @@ monitor_speed = 115200
 [esp32libs]
 lib_deps = 
 	jgromes/RadioLib@7.1.2
+	;https://github.com/jgromes/RadioLib/
 	mbed-seeed/BluetoothSerial@0.0.0+sha.f56002898ee8
 	h2zero/NimBLE-Arduino@^1.4.2
 	plerup/EspSoftwareSerial@^8.2.0
@@ -82,6 +83,8 @@ src_filter =
 	-<SDWrapper/*>
 build_flags = 
 	-D MONITOR_SPEED=${upload_settings.monitor_speed}
+;	-D RADIOLIB_DEBUG_BASIC=1
+;	-D RADIOLIB_DEBUG_SPI=1
 board_build.partitions = partition-table.csv
 
 [env:heltec_wifi_lora_32_V2]
@@ -158,7 +161,7 @@ build_flags =
 	-D BOARD_SX1262="tbeam_SX1262"
 
 [env:vision-master-e290]
-platform = espressif32
+platform = espressif32@^6.9.0
 board = heltec_wifi_lora_32_V3
 framework = arduino
 monitor_speed = 115200

--- a/src/command_functions.cpp
+++ b/src/command_functions.cpp
@@ -9,6 +9,7 @@
 #include "configuration.h"
 #include "regex_functions.h"
 #include "lora_setchip.h"
+#include "spectral_scan.h"
 
 // Sensors
 #include "bmx280.h"
@@ -292,6 +293,22 @@ void commandAction(char *msg_text, bool ble)
         return;
     }
     else
+    if(commandCheck(msg_text+2, (char*)"spectrum") == 0)
+    {
+        
+        sx126x_spectral_scan();
+        
+        #ifdef ESP32
+            ESP.restart();
+        #endif
+        
+        #if defined NRF52_SERIES
+            NVIC_SystemReset();     // resets the device
+        #endif
+
+        return;
+    }
+    else
     if(commandCheck(msg_text+2, (char*)"help") == 0)
     {
 
@@ -326,6 +343,8 @@ void commandAction(char *msg_text, bool ble)
             Serial.printf("--info     show info\n--mheard   show MHeard\n--gateway on/off/pos/nopos\n--webserver on/off\n--mesh    on/off\n");
             delay(100);
             Serial.printf("--softser on/off/send/app/baud/fixpegel/fixtemp\n");
+            delay(100);
+            Serial.printf("--spectrum   run spectral scan\n");
         }
 
         return;

--- a/src/spectral_scan.cpp
+++ b/src/spectral_scan.cpp
@@ -1,0 +1,139 @@
+/*
+  RadioLib SX126x Spectrum Scan Example
+
+  This example shows how to perform a spectrum power scan using SX126x.
+  The output is in the form of scan lines, each line has 33 power bins.
+  First power bin corresponds to -11 dBm, the second to -15 dBm and so on.
+  Higher number of samples in a bin corresponds to more power received
+  at that level. The example performs frequency sweep over a given range.
+
+  To show the results in a plot, run the Python script
+  RadioLib/extras/SX126x_Spectrum_Scan/SpectrumScan.py
+
+  WARNING: This functionality is experimental and requires a binary patch
+  to be uploaded to the SX126x device. There may be some undocumented
+  side effects!
+
+  For default module settings, see the wiki page
+  https://github.com/jgromes/RadioLib/wiki/Default-configuration#sx126x---lora-modem
+
+  For full API reference, see the GitHub Pages
+  https://jgromes.github.io/RadioLib/
+*/
+#include "spectral_scan.h"
+
+
+#if defined(SX1262X) || defined(SX126X)  || defined(SX126X_V3) || defined(SX1262_E290)
+
+// include the library
+#include <RadioLib.h>
+
+// this file contains binary patch for the SX1262
+#include <modules/SX126x/patches/SX126x_patch_scan.h>
+
+
+// frequency range in MHz to scan
+const float freqStart = 430;
+const float freqEnd = 440.2;
+
+void sx1262_spectral_setup() {
+
+  // initialize SX1262 FSK modem at the initial frequency
+  Serial.print(F("[SX1262] Initializing ... "));
+  int state = radio.beginFSK(freqStart);
+  if(state == RADIOLIB_ERR_NONE) {
+    Serial.println(F("success!"));
+  } else {
+    Serial.print(F("failed, code "));
+    Serial.println(state);
+    while (true) { delay(10); }
+  }
+
+  // upload a patch to the SX1262 to enable spectral scan
+  // NOTE: this patch is uploaded into volatile memory,
+  //       and must be re-uploaded on every power up
+  Serial.print(F("[SX1262] Uploading patch ... "));
+  state = radio.uploadPatch(sx126x_patch_scan, sizeof(sx126x_patch_scan));
+  if(state == RADIOLIB_ERR_NONE) {
+    Serial.println(F("success!"));
+  } else {
+    Serial.print(F("failed, code "));
+    Serial.println(state);
+    while (true) { delay(10); }
+  }
+
+  // configure scan bandwidth to 234.4 kHz
+  // and disable the data shaping
+  Serial.print(F("[SX1262] Setting scan parameters ... "));
+  state = radio.setRxBandwidth(234.3);
+  state |= radio.setDataShaping(RADIOLIB_SHAPING_NONE);
+  if(state == RADIOLIB_ERR_NONE) {
+    Serial.println(F("success!"));
+  } else {
+    Serial.print(F("failed, code "));
+    Serial.println(state);
+    while (true) { delay(10); }
+  }
+}
+
+void sx126x_spectral_scan() {
+  
+  sx1262_spectral_setup();
+
+  // perform scan over the entire frequency range
+  float freq = freqStart;
+  while(freq <= freqEnd) {
+    Serial.print("FREQ ");
+    Serial.println(freq, 2);
+
+    // start spectral scan
+    // number of samples: 2048 (fewer samples = better temporal resolution)
+    Serial.print(F("[SX1262] Starting spectral scan ... "));
+    int state = radio.spectralScanStart(2048);
+    if(state == RADIOLIB_ERR_NONE) {
+      Serial.println(F("success!"));
+    } else {
+      Serial.print(F("failed, code "));
+      Serial.println(state);
+      while (true) { delay(10); }
+    }
+
+    // wait for spectral scan to finish
+    while(radio.spectralScanGetStatus() != RADIOLIB_ERR_NONE) {
+      delay(10);
+    }
+
+    // read the results
+    uint16_t results[RADIOLIB_SX126X_SPECTRAL_SCAN_RES_SIZE];
+    state = radio.spectralScanGetResult(results);
+    if(state == RADIOLIB_ERR_NONE) {
+      // we have some results, print it
+      Serial.print("SCAN ");
+      for(uint8_t i = 0; i < RADIOLIB_SX126X_SPECTRAL_SCAN_RES_SIZE; i++) {
+        Serial.print(results[i]);
+        Serial.print(',');
+      }
+      Serial.println(" END");
+    }
+
+    // wait a little bit before the next scan
+    delay(100);
+
+    // set the next frequency
+    // the frequency step should be slightly smaller
+    // or the same as the Rx bandwidth set in setup
+    freq += 0.2;
+    radio.setFrequency(freq);
+  }
+  
+}
+
+#else
+// DUMMY FOR NON-SX1262
+void sx126x_spectral_scan()
+{
+    Serial.print(F("Spectral scan not implemented for this plattform ... "));
+    return;
+}
+
+#endif

--- a/src/spectral_scan.h
+++ b/src/spectral_scan.h
@@ -1,0 +1,24 @@
+#ifndef _SPECTRAL_SCAN_H_
+#define _SPECTRAL_SCAN_H_
+
+#include <Arduino.h>
+#include "configuration.h"
+
+#ifdef SX1262X
+    #include <RadioLib.h>
+    extern SX1262 radio;
+#endif
+
+#ifdef SX126X
+    #include <RadioLib.h>
+    extern SX1268 radio;
+#endif
+
+#if defined(SX126X_V3) || defined(SX1262_E290)
+    #include <RadioLib.h>
+    extern SX1262 radio;
+#endif
+
+void sx126x_spectral_scan();
+
+#endif // _COMMAND_FUNCTIONS_H_


### PR DESCRIPTION
- added spectral scan for sx126X based devices
- spectrum scan (430-440 Mhz) is started by command "--spectrum"
-  there is a python script in extras/SpectrumScan.py that connects via usb-serial to the board and aquires 1 spectrum scan and plots it to a png file
- after that spectrum scan system is rebooted cause sx126X was/is in "patched-firmware" state and should go back to normal operation