### PR TITLE
add startMeshComUDP() in startWIFI() to get IP Adress on first try

### DIFF
--- a/src/udp_functions.cpp
+++ b/src/udp_functions.cpp
@@ -437,7 +437,7 @@ bool startWIFI()
   }
 
 #ifdef ESP32
-  WiFi.disconnect(true);
+  //WiFi.disconnect(true);
 	delay(500);
 
   // Scan for AP with best RSSI
@@ -507,6 +507,9 @@ bool startWIFI()
   }
 
   Serial.println("WIFI connect OK");
+
+  // run startMeshComUDP() to get IP Address
+  startMeshComUDP();
 
   return true;
 }


### PR DESCRIPTION
fixed issue that there were allways 2 WIFI connect attempts (cause first attempt missed having an ip address 
cause startMeshComUDP() was not called where the IP Address gets aquired )