### PR TITLE
add boosted gain for sx126x chipsets (--setboostedgain on/off)

### DIFF
--- a/src/command_functions.cpp
+++ b/src/command_functions.cpp
@@ -347,6 +347,10 @@ void commandAction(char *msg_text, bool ble)
             Serial.printf("--softser on/off/send/app/baud/fixpegel/fixtemp\n");
             delay(100);
             Serial.printf("--spectrum   run spectral scan\n");
+            #if defined(SX126X_V3) || defined(SX1262_E290) || defined(SX1262X) || defined(SX126X)
+            delay(100);
+            Serial.printf("--setboostedgain    on/off  enable/disable boosted rx gain\n");
+            #endif
         }
 
         return;
@@ -1227,6 +1231,48 @@ void commandAction(char *msg_text, bool ble)
         
         return;
     }
+    #if defined(SX126X_V3) || defined(SX1262_E290) || defined(SX1262X) || defined(SX126X)
+    else
+    if(commandCheck(msg_text+2, (char*)"setboostedgain on") == 0)
+    {
+        bBOOSTEDGAIN = true;
+
+        meshcom_settings.node_sset2 |=  0x0800;
+
+        if(ble)
+        {
+            addBLECommandBack((char*)"--setboostedgain on");
+        }
+
+        save_settings();
+
+        Serial.println("Auto. Reboot after 5 sec.");
+
+        rebootAuto = millis() + 5 * 1000; // 5 Sekunden
+
+        return;
+    }
+    else
+    if(commandCheck(msg_text+2, (char*)"setboostedgain off") == 0)
+    {
+        bBOOSTEDGAIN = false;
+
+         meshcom_settings.node_sset2 &=  ~0x0800;
+
+        if(ble)
+        {
+            addBLECommandBack((char*)"--setboostedgain off");
+        }
+
+        save_settings();
+
+        Serial.println("Auto. Reboot after 5 sec.");
+
+        rebootAuto = millis() + 5 * 1000; // 5 Sekunden
+
+        return;
+    }
+    #endif
     else
     if(commandCheck(msg_text+2, (char*)"bledebug on") == 0)
     {

--- a/src/esp32/esp32_main.cpp
+++ b/src/esp32/esp32_main.cpp
@@ -416,6 +416,9 @@ void esp32setup()
     bSMALLDISPLAY =  meshcom_settings.node_sset2 & 0x0200;
     bSOFTSERON =  meshcom_settings.node_sset2 & 0x0400;
 
+    bBOOSTEDGAIN =  meshcom_settings.node_sset2 & 0x0800;
+
+
     bMHONLY =  meshcom_settings.node_sset3 & 0x0001;
 
     iButtonPin = BUTTON_PIN;
@@ -681,6 +684,16 @@ void esp32setup()
     if(bRadio)
     {
         lora_setcountry(meshcom_settings.node_country);
+
+        // set boosted gain
+        #if defined(SX126X_V3) || defined(SX1262_E290) || defined(SX1262X) || defined(SX126X)
+        Serial.printf("[LoRa]...RX_BOOSTED_GAIN: %d\n", (meshcom_settings.node_sset2 &  0x0800) == 0x0800);
+        if (radio.setRxBoostedGainMode(meshcom_settings.node_sset2 & 0x0800)  != RADIOLIB_ERR_NONE ) {
+            Serial.println(F("Boosted Gain is not available for this module!"));
+            while (true);
+        }
+        #endif
+
 
         // set carrier frequency
         Serial.printf("[LoRa]...RF_FREQUENCY: %.3f MHz\n", meshcom_settings.node_freq);

--- a/src/loop_functions.cpp
+++ b/src/loop_functions.cpp
@@ -70,6 +70,8 @@ bool bSHORTPATH = false;
 bool bGPSDEBUG = false;
 bool bSOFTSERDEBUG = false;
 
+bool bBOOSTEDGAIN = false;
+
 bool bBLElong = false;
 
 int iDisplayType = 0;

--- a/src/loop_functions_extern.h
+++ b/src/loop_functions_extern.h
@@ -61,6 +61,8 @@ extern bool bSOFTSERDEBUG;
 
 extern bool bBLElong;
 
+extern bool bBOOSTEDGAIN;
+
 extern bool bGATEWAY;
 extern bool bGATEWAY_NOPOS;
 extern bool bMESH;


### PR DESCRIPTION
add boosted gain for sx126x chipsets

can be enabled by  (--setboostedgain on/off)

used meshcom_settings.node_sset2  (0x0800) for storage of setting

@rainerfritz 
Please check if the BLE command thing is correct....if not i can modify it