### PR TITLE
Fix BLE WiFi password corruption when password length differs from SSID

### DIFF
--- a/src/phone_commands.cpp
+++ b/src/phone_commands.cpp
@@ -682,9 +682,7 @@ void readPhoneCommand(uint8_t conf_data[MAX_MSG_LEN_PHONE])
 				char ssid_arr [ssid_len +1] = {0};
 				char pwd_arr [pwd_len +1] = {0};
 
-				ssid_arr[ssid_len +1] = '\0';
-				pwd_arr[ssid_len +1] = '\0';
-				
+				// Removed buggy null terminator lines - arrays already zero-initialized
 				memcpy(ssid_arr, conf_data + 3, ssid_len);
 				memcpy(pwd_arr, conf_data + (4 + ssid_len), pwd_len);
 


### PR DESCRIPTION
The null terminator lines at lines 685-686 had two bugs:
1. Writing to index [len+1] on an array of size [len+1] is out of bounds
2. pwd_arr used ssid_len instead of pwd_len, corrupting passwords

Arrays are already zero-initialized with {0}, so these lines were removed.