### PR TITLE
Enable USB serial console for Heltec V3 (ESP32-S3)

### DIFF
--- a/variants/heltec_wifi_lora_32_V3/platformio.ini
+++ b/variants/heltec_wifi_lora_32_V3/platformio.ini
@@ -8,8 +8,10 @@ lib_ignore = Adafruit TCA8418, epdiy, es7210, ESP32-audioI2S, GxEPD2, lvgl, Sens
 lib_deps = 
 	${libs.lib_deps}
 	${esp32libs.lib_deps}
-build_flags = 
+build_flags =
 	${esp32.build_flags}
 	${common.build_flags}
+	-DARDUINO_USB_MODE=1
+	-DARDUINO_USB_CDC_ON_BOOT=1
 	-D BOARD_HELTEC_V3="heltec_v3"
 	-I variants/${this.__env__}


### PR DESCRIPTION
Add ARDUINO_USB_CDC_ON_BOOT=1 flag to enable serial output over USB on ESP32-S3 based boards. Without this flag, serial console is not available making debugging difficult.