### PR TITLE
Fix Heltec V2 OLED display not detected

### DIFF
--- a/src/command_functions.cpp
+++ b/src/command_functions.cpp
@@ -34,6 +34,12 @@
 #include "INA226.h"
 //TEST #include "compress_functions.h"
 
+// For display contrast control
+#if !defined(BOARD_E290) && !defined(BOARD_T_DECK) && !defined(BOARD_T_DECK_PLUS) && !defined(BOARD_TRACKER) && !defined(BOARD_T5_EPAPER) && !defined(BOARD_T_DECK_PRO)
+#include <U8g2lib.h>
+extern U8G2 *u8g2;
+#endif
+
 #if defined(ENABLE_BMX680)
 #include "bme680.h"
 #endif
@@ -713,6 +719,36 @@ void commandAction(char *umsg_text, bool ble)
         save_settings();
 
         sendDisplayHead(false);
+    }
+    else
+    if(commandCheck(msg_text+2, (char*)"contrast ") == 0)
+    {
+        #if !defined(BOARD_E290) && !defined(BOARD_T_DECK) && !defined(BOARD_T_DECK_PLUS) && !defined(BOARD_TRACKER) && !defined(BOARD_T5_EPAPER) && !defined(BOARD_T_DECK_PRO)
+        int contrast_value = atoi(msg_text + 11);  // "--" + "contrast " = 2 + 9 = 11
+        if(contrast_value < 0) contrast_value = 0;
+        if(contrast_value > 255) contrast_value = 255;
+
+        if(u8g2 != NULL)
+        {
+            u8g2->setContrast(contrast_value);
+            Serial.printf("[DISP]...Contrast set to %d\n", contrast_value);
+
+            if(ble)
+            {
+                char response[40];
+                snprintf(response, sizeof(response), "Contrast set to %d", contrast_value);
+                addBLECommandBack(response);
+            }
+        }
+        else
+        {
+            Serial.println("[DISP]...Display not initialized");
+        }
+        #else
+        Serial.println("[DISP]...Contrast not supported on this display");
+        #endif
+
+        bReturn = true;
     }
     else
     if(commandCheck(msg_text+2, (char*)"button on") == 0)

--- a/src/esp32/esp32_functions.cpp
+++ b/src/esp32/esp32_functions.cpp
@@ -65,6 +65,7 @@ void initDisplay()
     }
 
     u8g2->begin();
+    u8g2->setContrast(0);  // Default to minimum brightness
 
 #endif
 

--- a/src/esp32/esp32_main.cpp
+++ b/src/esp32/esp32_main.cpp
@@ -479,6 +479,22 @@ void esp32setup()
         }
     #endif
 
+    // Heltec V2: Enable Vext (GPIO 21) to power OLED and reset display
+    #if defined(BOARD_HELTEC)
+        Serial.println(F("[INIT]...Enabling Vext for OLED power"));
+        pinMode(21, OUTPUT);
+        digitalWrite(21, LOW);   // Vext ON (active low)
+        delay(50);
+
+        // Reset OLED (RST_OLED = GPIO 16)
+        Serial.println(F("[INIT]...Resetting OLED display"));
+        pinMode(16, OUTPUT);
+        digitalWrite(16, LOW);   // Reset active
+        delay(50);
+        digitalWrite(16, HIGH);  // Reset release
+        delay(50);
+    #endif
+
     #if not defined(BOARD_T_DECK_PRO)
         #ifndef BOARD_T5_EPAPER
             Wire.begin(I2C_SDA, I2C_SCL);


### PR DESCRIPTION
The Heltec V2 OLED requires:
1. Vext (GPIO 21) enabled to power the display
2. Explicit reset sequence on RST_OLED (GPIO 16)

Without these steps, the I2C communication fails with error -1.

Also adds:
- --contrast <0-255> command to adjust OLED brightness
- Default contrast set to 0 (dimmest) on boot