### PR TITLE
Fix Heltec V2 battery voltage reading

### DIFF
--- a/src/batt_functions.cpp
+++ b/src/batt_functions.cpp
@@ -49,6 +49,12 @@ uint32_t vbat_pin = BATTERY_PIN;
 
 #endif
 
+#if defined(BOARD_HELTEC)
+
+uint32_t vbat_pin = BATTERY_PIN;
+
+#endif
+
 #if defined(BOARD_T_DECK) || defined(BOARD_T_DECK_PLUS)
 
 uint32_t vbat_pin = BATTERY_PIN;
@@ -64,7 +70,7 @@ uint32_t vbat_pin = BATTERY_PIN;
 #define DEFAULT_VREF    1100        //Use adc2_vref_to_gpio() to obtain a better estimate
 #define NO_OF_SAMPLES   64          //Multisampling
 
-#ifndef BOARD_TRACKER
+#if !defined(BOARD_TRACKER) && !defined(BOARD_HELTEC)
 //static
 esp_adc_cal_characteristics_t adc_chars[sizeof(esp_adc_cal_characteristics_t)];
 
@@ -102,7 +108,7 @@ adc_atten_t atten = ADC_ATTEN_DB_0;
 //static const
 adc_unit_t unit = ADC_UNIT_2;
 #elif defined(BOARD_TRACKER)
-#elif defined(BOARD_HELTEC) || defined(BOARD_STICK_V3)
+#elif defined(BOARD_STICK_V3)
 //static const
 adc_atten_t atten = ADC_ATTEN_DB_0;
 //static const
@@ -237,6 +243,10 @@ void init_batt(void)
 
 #elif defined(BOARD_T_DECK) || defined(BOARD_T_DECK_PLUS)
 // NONE
+
+#elif defined(BOARD_HELTEC)
+	// Heltec V2: simple analogRead on GPIO 37
+	pinMode(vbat_pin, INPUT);
 
 #else
 	//only for Test check_efuse();
@@ -384,6 +394,19 @@ float read_batt(void)
 			Serial.printf("%s [BATT]...reading: %u factor: %.4f voltage: %.2f mV\n", getTimeString().c_str(), analogValue, fBattFaktor, raw);
 		}
 
+	#elif defined(BOARD_HELTEC)
+		// Heltec V2: GPIO 37 via 220K/100K voltage divider (3.2:1 ratio)
+		analogReadResolution(12);
+
+		uint32_t adc_reading = 0;
+		for (int i = 0; i < 8; i++) {
+			adc_reading += analogReadMilliVolts(vbat_pin);
+		}
+		adc_reading /= 8;
+
+		// Multiply by voltage divider ratio: (220K + 100K) / 100K = 3.2
+		raw = (float)adc_reading * 3.2;
+
 	#else
 
 	int adc_value = 0;
@@ -415,7 +438,7 @@ float read_batt(void)
 	#elif defined(BOARD_TBEAM) || defined(BOARD_SX1268)
 		raw = raw * 10.7687;
 	#elif defined(BOARD_HELTEC)
-		raw = raw * 24.80;
+		// all done - millivolts computed directly in read path
 	#elif defined(BOARD_HELTEC_V3) || defined(BOARD_STICK_V3) || defined(BOARD_TRACKER) || defined(BOARD_HELTEC_V4)
 		// all done
 	#elif defined(BOARD_E22_S3)

--- a/src/batt_functions.cpp
+++ b/src/batt_functions.cpp
@@ -43,7 +43,7 @@ uint32_t vbat_pin = BATTERY_PIN;
 
 #endif
 
-#if defined(BOARD_HELTEC_V3) || defined(BOARD_STICK_V3)
+#if defined(BOARD_HELTEC_V3) || defined(BOARD_STICK_V3) || defined(BOARD_HELTEC_V4)
 
 uint32_t vbat_pin = BATTERY_PIN;
 
@@ -198,8 +198,8 @@ void init_batt(void)
 {
     Serial.println("[INIT]...init_batt");
 
-// getht für HELTEC V3 und für V3.2  wichtig für Display
-#if defined(BOARD_HELTEC_V3) || defined(BOARD_STICK_V3)
+// getht für HELTEC V3/V4 und für V3.2  wichtig für Display
+#if defined(BOARD_HELTEC_V3) || defined(BOARD_STICK_V3) || defined(BOARD_HELTEC_V4)
 	pinMode(36,OUTPUT);
 	digitalWrite(36, LOW);
 
@@ -334,7 +334,7 @@ float read_batt(void)
 			is_receiving = false;
 			return (float)0.0;
 		#endif
-	#elif defined(BOARD_HELTEC_V3) || defined(BOARD_STICK_V3)
+	#elif defined(BOARD_HELTEC_V3) || defined(BOARD_STICK_V3) || defined(BOARD_HELTEC_V4)
 
 		// ADC resolution
 		const int resolution = 12;
@@ -416,7 +416,7 @@ float read_batt(void)
 		raw = raw * 10.7687;
 	#elif defined(BOARD_HELTEC)
 		raw = raw * 24.80;
-	#elif defined(BOARD_HELTEC_V3) || defined(BOARD_STICK_V3) || defined(BOARD_TRACKER)
+	#elif defined(BOARD_HELTEC_V3) || defined(BOARD_STICK_V3) || defined(BOARD_TRACKER) || defined(BOARD_HELTEC_V4)
 		// all done
 	#elif defined(BOARD_E22_S3)
 		// all done

--- a/src/configuration_global.h
+++ b/src/configuration_global.h
@@ -27,7 +27,7 @@
 #define TLORA_PAGER 49
 #define T_DECK_PRO 50
 #define TBEAM_1W 51
-#define RESERVED 52
+#define HELTEC_V4 52
 
 #define DEFAULT_PREAMPLE_LENGTH 32
 

--- a/src/esp32/esp32_main.cpp
+++ b/src/esp32/esp32_main.cpp
@@ -59,6 +59,10 @@
 #include "esp32_functions.h"
 #include "tft_display_functions.h"
 
+#ifdef BOARD_HELTEC_V4
+    #include "pa_control.h"
+#endif
+
 #ifndef BOARD_TLORA_OLV216
     #include <lora_setchip.h>
 #endif
@@ -342,11 +346,18 @@ LLCC68 radio = new Module(LORA_CS, LORA_DIO0, LORA_RST, LORA_DIO1);
 #ifdef SX1262_E290
     // RadioModule SX1262
     // cs - irq - reset - interrupt gpio
-    // If you have RESET of the E22 connected to a GPIO on the ESP you must initialize the GPIO as output and perform a LOW - HIGH cycle, 
+    // If you have RESET of the E22 connected to a GPIO on the ESP you must initialize the GPIO as output and perform a LOW - HIGH cycle,
     // otherwise your E22 is in an undefined state. RESET can be connected, but is not a must. IF so, make RESET before INIT!
 
     //  begin(sck, miso, mosi, ss).
     SX1262 radio = new Module(PIN_LORA_NSS, PIN_LORA_DIO_1, PIN_LORA_NRST, PIN_LORA_BUSY);
+
+#endif
+
+#ifdef SX1262_V4
+    // RadioModule SX1262 for Heltec V4 (with external PA)
+    // Same pins as V3, but requires PA control during transmit
+    SX1262 radio = new Module(SX1262X_CS, SX1262X_IRQ, SX1262X_RST, SX1262X_GPIO);
 
 #endif
 
@@ -754,6 +765,11 @@ void esp32setup()
         SPI.begin(RF95_SCK, RF95_MISO, RF95_MOSI, RF95_NSS);
     #endif
 
+    #ifdef BOARD_HELTEC_V4
+        SPI.begin(RF95_SCK, RF95_MISO, RF95_MOSI, RF95_NSS);
+        initPAControl();
+    #endif
+
     bool bSETGPS_POWER=false;
 
     #if defined(ENABLE_GPS)
@@ -924,6 +940,10 @@ void esp32setup()
     Serial.print(F("[LoRa]...SX1262 E290 chip"));
     #endif
 
+    #ifdef SX1262_V4
+    Serial.print(F("[LoRa]...SX1262 V4 chip (with PA)"));
+    #endif
+
 
     #if defined (BOARD_TRACKER)
         SPI.begin(RADIO_SCLK_PIN, RADIO_MISO_PIN, RADIO_MOSI_PIN);
@@ -995,7 +1015,7 @@ void esp32setup()
     if(bRadio)
     {
         // set boosted gain
-        #if defined(SX1262_V3) || defined(SX126x_V3) || defined(SX1262_E290) || defined(SX1262X) || defined(SX126X)
+        #if defined(SX1262_V3) || defined(SX126x_V3) || defined(SX1262_E290) || defined(SX1262X) || defined(SX126X) || defined(SX1262_V4)
         Serial.printf("[LoRa]...RX_BOOSTED_GAIN: %d\n", (meshcom_settings.node_sset2 &  0x0800) == 0x0800);
         if (radio.setRxBoostedGainMode(meshcom_settings.node_sset2 & 0x0800)  != RADIOLIB_ERR_NONE ) {
             Serial.println(F("Boosted Gain is not available for this module!"));
@@ -1155,7 +1175,7 @@ void esp32setup()
         }
         #endif
 
-        #if defined(SX1262_V3) || defined(SX1262_E290)
+        #if defined(SX1262_V3) || defined(SX1262_E290) || defined(SX1262_V4)
 
             // set Receive Interupt
             bEnableInterruptReceive = true; //KBC 0801
@@ -1644,6 +1664,10 @@ void esp32loop()
                 // RF switch is powered down etc.
                 radio.finishTransmit();
 
+                #ifdef BOARD_HELTEC_V4
+                disablePATransmit();
+                #endif
+
                 #ifndef BOARD_TLORA_OLV216
                 // reset MeshCom now
                 if(bSetLoRaAPRS)
@@ -1705,12 +1729,19 @@ void esp32loop()
                 bEnableInterruptTransmit = true; //KBC 0801
                 radio.setPacketSentAction(setFlagSent); //KBC 0801
 
+                #ifdef BOARD_HELTEC_V4
+                enablePATransmit();
+                #endif
+
                 if(doTX())
                 {
                     //KBC 0801 bEnableInterruptTransmit = true;
                 }
                 else
                 {
+                    #ifdef BOARD_HELTEC_V4
+                    disablePATransmit();
+                    #endif
                     if(bLORADEBUG)
                         Serial.print(F("[LoRa]...Starting to listen again... "));
 

--- a/src/esp32/pa_control.cpp
+++ b/src/esp32/pa_control.cpp
@@ -1,10 +1,10 @@
 /**
- * PA Control implementation for Heltec V4
+ * PA Control implementation for Heltec V4 (868/915MHz with PA only)
  */
 
 #include "pa_control.h"
 
-#ifdef BOARD_HELTEC_V4
+#if defined(BOARD_HELTEC_V4) && defined(HELTEC_V4_HAS_PA)
 
 void initPAControl() {
     // Set up PA power enable - keeps PA powered

--- a/src/esp32/pa_control.cpp
+++ b/src/esp32/pa_control.cpp
@@ -1,0 +1,33 @@
+/**
+ * PA Control implementation for Heltec V4
+ */
+
+#include "pa_control.h"
+
+#ifdef BOARD_HELTEC_V4
+
+void initPAControl() {
+    // Set up PA power enable - keeps PA powered
+    pinMode(P_LORA_PA_POWER, OUTPUT);
+    digitalWrite(P_LORA_PA_POWER, HIGH);
+
+    // Set up PA enable - enables the PA circuit
+    pinMode(P_LORA_PA_EN, OUTPUT);
+    digitalWrite(P_LORA_PA_EN, HIGH);
+
+    // Set up PA TX enable - initially LOW (not transmitting)
+    pinMode(P_LORA_PA_TX_EN, OUTPUT);
+    digitalWrite(P_LORA_PA_TX_EN, LOW);
+
+    Serial.println(F("[PA  ]...Heltec V4 PA control initialized"));
+}
+
+void enablePATransmit() {
+    digitalWrite(P_LORA_PA_TX_EN, HIGH);
+}
+
+void disablePATransmit() {
+    digitalWrite(P_LORA_PA_TX_EN, LOW);
+}
+
+#endif

--- a/src/esp32/pa_control.h
+++ b/src/esp32/pa_control.h
@@ -1,0 +1,37 @@
+/**
+ * PA Control for Heltec V4
+ *
+ * The Heltec V4 has an external PA (Power Amplifier) that requires
+ * explicit GPIO control during LoRa transmissions.
+ *
+ * PA Pins:
+ * - P_LORA_PA_POWER (GPIO 7)  - PA power enable
+ * - P_LORA_PA_EN (GPIO 2)     - PA enable
+ * - P_LORA_PA_TX_EN (GPIO 46) - PA TX enable during transmission
+ */
+
+#pragma once
+
+#include <Arduino.h>
+
+#ifdef BOARD_HELTEC_V4
+
+/**
+ * Initialize PA control pins
+ * Call once during setup after SPI initialization
+ */
+void initPAControl();
+
+/**
+ * Enable PA for transmission
+ * Call before radio.startTransmit()
+ */
+void enablePATransmit();
+
+/**
+ * Disable PA after transmission
+ * Call after radio.finishTransmit()
+ */
+void disablePATransmit();
+
+#endif

--- a/src/esp32/pa_control.h
+++ b/src/esp32/pa_control.h
@@ -1,20 +1,23 @@
 /**
  * PA Control for Heltec V4
  *
- * The Heltec V4 has an external PA (Power Amplifier) that requires
- * explicit GPIO control during LoRa transmissions.
+ * The Heltec V4 868/915MHz version has an external PA (Power Amplifier)
+ * that requires explicit GPIO control during LoRa transmissions.
+ * The 433MHz version does NOT have a PA.
  *
- * PA Pins:
+ * PA Pins (868/915MHz only):
  * - P_LORA_PA_POWER (GPIO 7)  - PA power enable
  * - P_LORA_PA_EN (GPIO 2)     - PA enable
  * - P_LORA_PA_TX_EN (GPIO 46) - PA TX enable during transmission
+ *
+ * To enable PA control, define HELTEC_V4_HAS_PA in platformio.ini build flags.
  */
 
 #pragma once
 
 #include <Arduino.h>
 
-#ifdef BOARD_HELTEC_V4
+#if defined(BOARD_HELTEC_V4) && defined(HELTEC_V4_HAS_PA)
 
 /**
  * Initialize PA control pins

--- a/src/loop_functions.cpp
+++ b/src/loop_functions.cpp
@@ -215,7 +215,7 @@ U8G2 *u8g2;
 #if defined(BOARD_HELTEC)
     U8G2_SSD1306_128X64_NONAME_F_HW_I2C u8g2_1(U8G2_R0, 16, 15, 4);
     U8G2_SH1106_128X64_NONAME_F_HW_I2C u8g2_2(U8G2_R0, 16, 15, 4);
-#elif defined(BOARD_HELTEC_V3)
+#elif defined(BOARD_HELTEC_V3) || defined(BOARD_HELTEC_V4)
     U8G2_SSD1306_128X64_NONAME_1_SW_I2C u8g2_1(U8G2_R0, 18, 17, 21);
     U8G2_SH1106_128X64_NONAME_1_SW_I2C u8g2_2(U8G2_R0, 18, 17, 21);
 #elif defined(BOARD_STICK_V3)
@@ -567,10 +567,10 @@ int esp32_isSSD1306(int address)
 {
     byte buffer[1];
 
-    #if defined (BOARD_HELTEC_V3)
+    #if defined (BOARD_HELTEC_V3) || defined(BOARD_HELTEC_V4)
         return 1;
     #endif
-        
+
     #if defined (BOARD_STICK_V3)
         return 1;
     #endif

--- a/src/lora_functions.cpp
+++ b/src/lora_functions.cpp
@@ -38,10 +38,14 @@
     extern int transmissionState;
 #endif
 
-#if defined(SX1262_V3) || defined(SX1262_E290)
+#if defined(SX1262_V3) || defined(SX1262_E290) || defined(SX1262_V4)
     #include <RadioLib.h>
     extern SX1262 radio;
     extern int transmissionState;
+#endif
+
+#ifdef BOARD_HELTEC_V4
+    #include "esp32/pa_control.h"
 #endif
 
 #ifdef BOARD_T_ECHO
@@ -996,6 +1000,9 @@ bool doTX()
                         Radio.Send(lora_tx_buffer, sendlng);
                     #else
                         #ifndef BOARD_T5_EPAPER
+                        #ifdef BOARD_HELTEC_V4
+                        enablePATransmit();
+                        #endif
                         transmissionState = radio.startTransmit(lora_tx_buffer, sendlng);
                         #endif
                         bLED_RED = true;
@@ -1018,6 +1025,9 @@ bool doTX()
                     Radio.Send(lora_tx_buffer, sendlng);
                 #else
                     #ifndef BOARD_T5_EPAPER
+                    #ifdef BOARD_HELTEC_V4
+                    enablePATransmit();
+                    #endif
                     transmissionState = radio.startTransmit(lora_tx_buffer, sendlng);
                     #endif
                     bLED_ORANGE = true;
@@ -1079,6 +1089,9 @@ bool doTX()
                         Radio.Send(lora_tx_buffer, sendlng);
                     #else
                         #ifndef BOARD_T5_EPAPER
+                        #ifdef BOARD_HELTEC_V4
+                        enablePATransmit();
+                        #endif
                         transmissionState = radio.startTransmit(lora_tx_buffer, sendlng);
                         #endif
                         bLED_RED = true;

--- a/src/lora_setchip.cpp
+++ b/src/lora_setchip.cpp
@@ -37,7 +37,7 @@
     extern int transmissionState;
 #endif
 
-#if defined(SX1262_V3) || defined(SX1262_E290)
+#if defined(SX1262_V3) || defined(SX1262_E290) || defined(SX1262_V4)
     #include <RadioLib.h>
     extern SX1262 radio;
     extern int transmissionState;
@@ -661,7 +661,7 @@ bool lora_setchip_new(float rf_freq, float rf_bw, int rf_sf, int rf_cr, int rf_s
     }
 
     // CRC
-    #if defined(SX127X) || defined(SX1262_V3) || defined(SX1262_E290) || defined(SX126X) || defined(SX126x_V3) || defined(SX1262X)
+    #if defined(SX127X) || defined(SX1262_V3) || defined(SX1262_E290) || defined(SX126X) || defined(SX126x_V3) || defined(SX1262X) || defined(SX1262_V4)
     uint8_t icrc = 0;
     #if defined(SX127X)
         icrc = rf_crc;

--- a/variants/heltec_wifi_lora_32_V2/configuration.h
+++ b/variants/heltec_wifi_lora_32_V2/configuration.h
@@ -66,6 +66,8 @@ definitions for HELTEC_V2_1
 #define I2C_SDA 4       // getestet OE5HWN
 #define I2C_SCL 15      // getestet OE5HWN
 
+#define BATTERY_PIN 37  // Battery voltage via voltage divider on GPIO 37
+
 #define OneWire_GPIO 17 // getestet OE5HWN
 
 #define GPS_RX_PIN 23

--- a/variants/heltec_wifi_lora_32_V4/configuration.h
+++ b/variants/heltec_wifi_lora_32_V4/configuration.h
@@ -1,0 +1,101 @@
+/*
+    definitions for HELTEC_V4
+    Based on V3 configuration with PA control additions
+*/
+
+#pragma once
+
+#include <Arduino.h>
+#include <configuration_global.h>
+
+// HELTEC_V4 specific config
+#define MODUL_HARDWARE HELTEC_V4
+#define RF_FREQUENCY 433.175000 // Hz
+#define LORA_APRS_FREQUENCY 433.775000 // Hz
+#define SX1262_V4
+#define RX_TIMEOUT_VALUE 0      // continous rx with 0
+#define ENABLE_GPS
+#define ENABLE_BMX280
+#define ENABLE_BMP390
+#define ENABLE_AHT20
+#define ENABLE_SHT21
+#define ENABLE_BMX680
+#define ENABLE_MCP23017
+#define ENABLE_MC811
+#define ENABLE_RTC
+#define ENABLE_SOFTSER
+#define TX_POWER_MAX 22
+#define TX_POWER_MIN 2
+#define LORA_PREAMBLE_LENGTH DEFAULT_PREAMPLE_LENGTH  // Same for Tx and Rx
+
+#define WAIT_TX 5         // ticks waiting after Lora TX in doTX()
+
+#define CURRENT_LIMIT 140 // in mA
+#define TX_OUTPUT_POWER 22
+
+/**
+ * RadioLib Coding Rate: Allowed values range from 5 to 8.
+ * case 5: CR_4_5;
+    case 6: CR_4_6;
+    case 7: CR_4_7;
+    case 8: CR_4_8;
+*/
+#define LORA_CR 6
+
+// RadioLib LoRa Bandwidth Setting in kHz
+#define LORA_BANDWIDTH 250
+
+/** RadioLib Spreading Factor
+ * case 6: SF_6;
+    case 7: SF_7;
+    case 8: SF_8;
+    case 9: SF_9;
+    case 10: SF_10;
+    case 11: SF_11;
+    case 12: SF_12;
+*/
+#define LORA_SF 11
+
+#define RESET_OLED RST_OLED
+
+#define I2C_SDA 41 // I2C pins for this board
+#define I2C_SCL 42
+
+#define VEXT_ENABLE Vext // active low, powers the oled display and the lora antenna boost
+#define BUTTON_PIN 0
+
+#define BATTERY_PIN 1 // A battery voltage measurement pin
+#define ADC_MULTIPLIER 5.42  // V4 has different ADC calibration
+#define ADC_CTRL_PIN 37      // V4 has ADC control pin
+
+#define USE_SX1262
+
+#define LORA_DIO0 -1 // a No connect on the SX1262 module
+#define LORA_RESET 12
+#define LORA_DIO1 14 // SX1262 IRQ
+#define LORA_DIO2 13 // SX1262 BUSY
+#define LORA_DIO3    // Not connected on PCB, but internally on the TTGO SX1262
+
+#define RF95_SCK 9
+#define RF95_MISO 11
+#define RF95_MOSI 10
+#define RF95_NSS 8
+
+#define SX1262X_CS RF95_NSS
+#define SX1262X_IRQ LORA_DIO1
+#define SX1262X_RST LORA_RESET
+#define SX1262X_GPIO LORA_DIO2
+
+#define SDA_PIN 17
+#define SCL_PIN 18
+
+#define OneWire_GPIO 99
+
+// V4 has different GPS pins than V3
+#define GPS_RX_PIN 38
+#define GPS_TX_PIN 39
+
+// PA Control Pins (defined in platformio.ini build flags)
+// P_LORA_PA_POWER 7   - PA power enable
+// P_LORA_PA_EN    2   - PA enable
+// P_LORA_PA_TX_EN 46  - PA TX enable during transmission

--- a/variants/heltec_wifi_lora_32_V4/lv_conf.h
+++ b/variants/heltec_wifi_lora_32_V4/lv_conf.h
@@ -1,0 +1,713 @@
+/**
+ * @file lv_conf.h
+ * Configuration file for v8.3.0-dev
+ */
+
+/*
+ * Copy this file as `lv_conf.h`
+ * 1. simply next to the `lvgl` folder
+ * 2. or any other places and
+ *    - define `LV_CONF_INCLUDE_SIMPLE`
+ *    - add the path as include path
+ */
+
+/* clang-format off */
+#if 1 /*Set it to "1" to enable content*/
+
+#ifndef LV_CONF_H
+#define LV_CONF_H
+
+#include <stdint.h>
+
+/*====================
+   COLOR SETTINGS
+ *====================*/
+
+/*Color depth: 1 (1 byte per pixel), 8 (RGB332), 16 (RGB565), 32 (ARGB8888)*/
+#define LV_COLOR_DEPTH 16
+
+/*Swap the 2 bytes of RGB565 color. Useful if the display has an 8-bit interface (e.g. SPI)*/
+#define LV_COLOR_16_SWAP 1
+
+/*Enable more complex drawing routines to manage screens transparency.
+ *Can be used if the UI is above another layer, e.g. an OSD menu or video player.
+ *Requires `LV_COLOR_DEPTH = 32` colors and the screen's `bg_opa` should be set to non LV_OPA_COVER value*/
+#define LV_COLOR_SCREEN_TRANSP 0
+
+/* Adjust color mix functions rounding. GPUs might calculate color mix (blending) differently.
+ * 0: round down, 64: round up from x.75, 128: round up from half, 192: round up from x.25, 254: round up */
+#define LV_COLOR_MIX_ROUND_OFS (LV_COLOR_DEPTH == 32 ? 0: 128)
+
+/*Images pixels with this color will not be drawn if they are chroma keyed)*/
+#define LV_COLOR_CHROMA_KEY lv_color_hex(0x00ff00)         /*pure green*/
+
+/*=========================
+   MEMORY SETTINGS
+ *=========================*/
+
+/*1: use custom malloc/free, 0: use the built-in `lv_mem_alloc()` and `lv_mem_free()`*/
+#define LV_MEM_CUSTOM 1
+#if LV_MEM_CUSTOM == 0
+/*Size of the memory available for `lv_mem_alloc()` in bytes (>= 2kB)*/
+#define LV_MEM_SIZE (48U * 1024U)          /*[bytes]*/
+
+/*Set an address for the memory pool instead of allocating it as a normal array. Can be in external SRAM too.*/
+#define LV_MEM_ADR 0     /*0: unused*/
+/*Instead of an address give a memory allocator that will be called to get a memory pool for LVGL. E.g. my_malloc*/
+#if LV_MEM_ADR == 0
+//#define LV_MEM_POOL_INCLUDE your_alloc_library  /* Uncomment if using an external allocator*/
+//#define LV_MEM_POOL_ALLOC   your_alloc          /* Uncomment if using an external allocator*/
+#endif
+
+#else       /*LV_MEM_CUSTOM*/
+#define LV_MEM_CUSTOM_INCLUDE <stdlib.h>   /*Header for the dynamic memory function*/
+#define LV_MEM_CUSTOM_ALLOC   malloc
+#define LV_MEM_CUSTOM_FREE    free
+#define LV_MEM_CUSTOM_REALLOC realloc
+#endif     /*LV_MEM_CUSTOM*/
+
+/*Number of the intermediate memory buffer used during rendering and other internal processing mechanisms.
+ *You will see an error log message if there wasn't enough buffers. */
+#define LV_MEM_BUF_MAX_NUM 10
+
+/*Use the standard `memcpy` and `memset` instead of LVGL's own functions. (Might or might not be faster).*/
+#define LV_MEMCPY_MEMSET_STD 0
+
+/*====================
+   HAL SETTINGS
+ *====================*/
+
+/*Default display refresh period. LVG will redraw changed areas with this period time*/
+#define LV_DISP_DEF_REFR_PERIOD 16      /*[ms]*/
+
+/*Input device read period in milliseconds*/
+#define LV_INDEV_DEF_READ_PERIOD 30     /*[ms]*/
+
+/*Use a custom tick source that tells the elapsed time in milliseconds.
+ *It removes the need to manually update the tick with `lv_tick_inc()`)*/
+#define LV_TICK_CUSTOM 1
+#if LV_TICK_CUSTOM
+#define LV_TICK_CUSTOM_INCLUDE "Arduino.h"         /*Header for the system time function*/
+#define LV_TICK_CUSTOM_SYS_TIME_EXPR (millis())    /*Expression evaluating to current system time in ms*/
+#endif   /*LV_TICK_CUSTOM*/
+
+/*Default Dot Per Inch. Used to initialize default sizes such as widgets sized, style paddings.
+ *(Not so important, you can adjust it to modify default sizes and spaces)*/
+#define LV_DPI_DEF 130     /*[px/inch]*/
+
+/*=======================
+ * FEATURE CONFIGURATION
+ *=======================*/
+
+/*-------------
+ * Drawing
+ *-----------*/
+
+/*Enable complex draw engine.
+ *Required to draw shadow, gradient, rounded corners, circles, arc, skew lines, image transformations or any masks*/
+#define LV_DRAW_COMPLEX 1
+#if LV_DRAW_COMPLEX != 0
+
+/*Allow buffering some shadow calculation.
+*LV_SHADOW_CACHE_SIZE is the max. shadow size to buffer, where shadow size is `shadow_width + radius`
+*Caching has LV_SHADOW_CACHE_SIZE^2 RAM cost*/
+#define LV_SHADOW_CACHE_SIZE 0
+
+/* Set number of maximally cached circle data.
+* The circumference of 1/4 circle are saved for anti-aliasing
+* radius * 4 bytes are used per circle (the most often used radiuses are saved)
+* 0: to disable caching */
+#define LV_CIRCLE_CACHE_SIZE 4
+#endif /*LV_DRAW_COMPLEX*/
+
+/*Default image cache size. Image caching keeps the images opened.
+ *If only the built-in image formats are used there is no real advantage of caching. (I.e. if no new image decoder is added)
+ *With complex image decoders (e.g. PNG or JPG) caching can save the continuous open/decode of images.
+ *However the opened images might consume additional RAM.
+ *0: to disable caching*/
+#define LV_IMG_CACHE_DEF_SIZE   0
+
+/*Number of stops allowed per gradient. Increase this to allow more stops.
+ *This adds (sizeof(lv_color_t) + 1) bytes per additional stop*/
+#define LV_GRADIENT_MAX_STOPS       2
+
+/*Default gradient buffer size.
+ *When LVGL calculates the gradient "maps" it can save them into a cache to avoid calculating them again.
+ *LV_GRAD_CACHE_DEF_SIZE sets the size of this cache in bytes.
+ *If the cache is too small the map will be allocated only while it's required for the drawing.
+ *0 mean no caching.*/
+#define LV_GRAD_CACHE_DEF_SIZE      0
+
+/*Allow dithering the gradients (to achieve visual smooth color gradients on limited color depth display)
+ *LV_DITHER_GRADIENT implies allocating one or two more lines of the object's rendering surface
+ *The increase in memory consumption is (32 bits * object width) plus 24 bits * object width if using error diffusion */
+#define LV_DITHER_GRADIENT      0
+#if LV_DITHER_GRADIENT
+/*Add support for error diffusion dithering.
+ *Error diffusion dithering gets a much better visual result, but implies more CPU consumption and memory when drawing.
+ *The increase in memory consumption is (24 bits * object's width)*/
+#define LV_DITHER_ERROR_DIFFUSION   0
+#endif
+
+/*Maximum buffer size to allocate for rotation.
+ *Only used if software rotation is enabled in the display driver.*/
+#define LV_DISP_ROT_MAX_BUF (10*1024)
+
+/*-------------
+ * GPU
+ *-----------*/
+
+/*Use Arm's 2D acceleration library Arm-2D */
+#define LV_USE_GPU_ARM2D 0
+
+/*Use STM32's DMA2D (aka Chrom Art) GPU*/
+#define LV_USE_GPU_STM32_DMA2D 0
+#if LV_USE_GPU_STM32_DMA2D
+/*Must be defined to include path of CMSIS header of target processor
+e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
+#define LV_GPU_DMA2D_CMSIS_INCLUDE
+#endif
+
+/*Use NXP's PXP GPU iMX RTxxx platforms*/
+#define LV_USE_GPU_NXP_PXP 0
+#if LV_USE_GPU_NXP_PXP
+/*1: Add default bare metal and FreeRTOS interrupt handling routines for PXP (lv_gpu_nxp_pxp_osa.c)
+*   and call lv_gpu_nxp_pxp_init() automatically during lv_init(). Note that symbol SDK_OS_FREE_RTOS
+*   has to be defined in order to use FreeRTOS OSA, otherwise bare-metal implementation is selected.
+*0: lv_gpu_nxp_pxp_init() has to be called manually before lv_init()
+*/
+#define LV_USE_GPU_NXP_PXP_AUTO_INIT 0
+#endif
+
+/*Use NXP's VG-Lite GPU iMX RTxxx platforms*/
+#define LV_USE_GPU_NXP_VG_LITE 0
+
+/*Use SDL renderer API*/
+#define LV_USE_GPU_SDL 0
+#if LV_USE_GPU_SDL
+#define LV_GPU_SDL_INCLUDE_PATH <SDL2/SDL.h>
+/*Texture cache size, 8MB by default*/
+#define LV_GPU_SDL_LRU_SIZE (1024 * 1024 * 8)
+/*Custom blend mode for mask drawing, disable if you need to link with older SDL2 lib*/
+#define LV_GPU_SDL_CUSTOM_BLEND_MODE (SDL_VERSION_ATLEAST(2, 0, 6))
+#endif
+
+/*-------------
+ * Logging
+ *-----------*/
+
+/*Enable the log module*/
+#define LV_USE_LOG 0
+#if LV_USE_LOG
+
+/*How important log should be added:
+*LV_LOG_LEVEL_TRACE       A lot of logs to give detailed information
+*LV_LOG_LEVEL_INFO        Log important events
+*LV_LOG_LEVEL_WARN        Log if something unwanted happened but didn't cause a problem
+*LV_LOG_LEVEL_ERROR       Only critical issue, when the system may fail
+*LV_LOG_LEVEL_USER        Only logs added by the user
+*LV_LOG_LEVEL_NONE        Do not log anything*/
+#define LV_LOG_LEVEL LV_LOG_LEVEL_WARN
+
+/*1: Print the log with 'printf';
+*0: User need to register a callback with `lv_log_register_print_cb()`*/
+#define LV_LOG_PRINTF 1
+
+/*Enable/disable LV_LOG_TRACE in modules that produces a huge number of logs*/
+#define LV_LOG_TRACE_MEM        1
+#define LV_LOG_TRACE_TIMER      1
+#define LV_LOG_TRACE_INDEV      1
+#define LV_LOG_TRACE_DISP_REFR  1
+#define LV_LOG_TRACE_EVENT      1
+#define LV_LOG_TRACE_OBJ_CREATE 1
+#define LV_LOG_TRACE_LAYOUT     1
+#define LV_LOG_TRACE_ANIM       1
+
+#endif  /*LV_USE_LOG*/
+
+/*-------------
+ * Asserts
+ *-----------*/
+
+/*Enable asserts if an operation is failed or an invalid data is found.
+ *If LV_USE_LOG is enabled an error message will be printed on failure*/
+#define LV_USE_ASSERT_NULL          1   /*Check if the parameter is NULL. (Very fast, recommended)*/
+#define LV_USE_ASSERT_MALLOC        1   /*Checks is the memory is successfully allocated or no. (Very fast, recommended)*/
+#define LV_USE_ASSERT_STYLE         0   /*Check if the styles are properly initialized. (Very fast, recommended)*/
+#define LV_USE_ASSERT_MEM_INTEGRITY 0   /*Check the integrity of `lv_mem` after critical operations. (Slow)*/
+#define LV_USE_ASSERT_OBJ           0   /*Check the object's type and existence (e.g. not deleted). (Slow)*/
+
+/*Add a custom handler when assert happens e.g. to restart the MCU*/
+#define LV_ASSERT_HANDLER_INCLUDE <stdint.h>
+#define LV_ASSERT_HANDLER while(1);   /*Halt by default*/
+
+/*-------------
+ * Others
+ *-----------*/
+
+/*1: Show CPU usage and FPS count*/
+#define LV_USE_PERF_MONITOR 0
+#if LV_USE_PERF_MONITOR
+#define LV_USE_PERF_MONITOR_POS LV_ALIGN_BOTTOM_RIGHT
+#endif
+
+/*1: Show the used memory and the memory fragmentation
+ * Requires LV_MEM_CUSTOM = 0*/
+#define LV_USE_MEM_MONITOR 0
+#if LV_USE_MEM_MONITOR
+#define LV_USE_MEM_MONITOR_POS LV_ALIGN_BOTTOM_LEFT
+#endif
+
+/*1: Draw random colored rectangles over the redrawn areas*/
+#define LV_USE_REFR_DEBUG 0
+
+/*Change the built in (v)snprintf functions*/
+#define LV_SPRINTF_CUSTOM 0
+#if LV_SPRINTF_CUSTOM
+#define LV_SPRINTF_INCLUDE <stdio.h>
+#define lv_snprintf  snprintf
+#define lv_vsnprintf vsnprintf
+#else   /*LV_SPRINTF_CUSTOM*/
+#define LV_SPRINTF_USE_FLOAT 0
+#endif  /*LV_SPRINTF_CUSTOM*/
+
+#define LV_USE_USER_DATA 1
+
+/*Garbage Collector settings
+ *Used if lvgl is bound to higher level language and the memory is managed by that language*/
+#define LV_ENABLE_GC 0
+#if LV_ENABLE_GC != 0
+#define LV_GC_INCLUDE "gc.h"                           /*Include Garbage Collector related things*/
+#endif /*LV_ENABLE_GC*/
+
+/*=====================
+ *  COMPILER SETTINGS
+ *====================*/
+
+/*For big endian systems set to 1*/
+#define LV_BIG_ENDIAN_SYSTEM 0
+
+/*Define a custom attribute to `lv_tick_inc` function*/
+#define LV_ATTRIBUTE_TICK_INC
+
+/*Define a custom attribute to `lv_timer_handler` function*/
+#define LV_ATTRIBUTE_TIMER_HANDLER
+
+/*Define a custom attribute to `lv_disp_flush_ready` function*/
+#define LV_ATTRIBUTE_FLUSH_READY
+
+/*Required alignment size for buffers*/
+#define LV_ATTRIBUTE_MEM_ALIGN_SIZE 1
+
+/*Will be added where memories needs to be aligned (with -Os data might not be aligned to boundary by default).
+ * E.g. __attribute__((aligned(4)))*/
+#define LV_ATTRIBUTE_MEM_ALIGN
+
+/*Attribute to mark large constant arrays for example font's bitmaps*/
+#define LV_ATTRIBUTE_LARGE_CONST
+
+/*Compiler prefix for a big array declaration in RAM*/
+#define LV_ATTRIBUTE_LARGE_RAM_ARRAY
+
+/*Place performance critical functions into a faster memory (e.g RAM)*/
+#define LV_ATTRIBUTE_FAST_MEM
+
+/*Prefix variables that are used in GPU accelerated operations, often these need to be placed in RAM sections that are DMA accessible*/
+#define LV_ATTRIBUTE_DMA
+
+/*Export integer constant to binding. This macro is used with constants in the form of LV_<CONST> that
+ *should also appear on LVGL binding API such as Micropython.*/
+#define LV_EXPORT_CONST_INT(int_value) struct _silence_gcc_warning /*The default value just prevents GCC warning*/
+
+/*Extend the default -32k..32k coordinate range to -4M..4M by using int32_t for coordinates instead of int16_t*/
+#define LV_USE_LARGE_COORD 0
+
+/*==================
+ *   FONT USAGE
+ *===================*/
+
+/*Montserrat fonts with ASCII range and some symbols using bpp = 4
+ *https://fonts.google.com/specimen/Montserrat*/
+#define LV_FONT_MONTSERRAT_8  0
+#define LV_FONT_MONTSERRAT_10 0
+#define LV_FONT_MONTSERRAT_12 1
+#define LV_FONT_MONTSERRAT_14 0
+#define LV_FONT_MONTSERRAT_16 0
+#define LV_FONT_MONTSERRAT_18 0
+#define LV_FONT_MONTSERRAT_20 1
+#define LV_FONT_MONTSERRAT_22 0
+#define LV_FONT_MONTSERRAT_24 0
+#define LV_FONT_MONTSERRAT_26 0
+#define LV_FONT_MONTSERRAT_28 0
+#define LV_FONT_MONTSERRAT_30 0
+#define LV_FONT_MONTSERRAT_32 0
+#define LV_FONT_MONTSERRAT_34 0
+#define LV_FONT_MONTSERRAT_36 0
+#define LV_FONT_MONTSERRAT_38 0
+#define LV_FONT_MONTSERRAT_40 0
+#define LV_FONT_MONTSERRAT_42 0
+#define LV_FONT_MONTSERRAT_44 0
+#define LV_FONT_MONTSERRAT_46 0
+#define LV_FONT_MONTSERRAT_48 0
+#define LV_FONT_MONTSERRAT_48 0
+
+/*Demonstrate special features*/
+#define LV_FONT_MONTSERRAT_12_SUBPX      1
+#define LV_FONT_MONTSERRAT_28_COMPRESSED 0  /*bpp = 3*/
+#define LV_FONT_DEJAVU_16_PERSIAN_HEBREW 0  /*Hebrew, Arabic, Persian letters and all their forms*/
+#define LV_FONT_SIMSUN_16_CJK            0  /*1000 most common CJK radicals*/
+
+/*Pixel perfect monospace fonts*/
+#define LV_FONT_UNSCII_8  0
+#define LV_FONT_UNSCII_16 1
+
+/*Optionally declare custom fonts here.
+ *You can use these fonts as default font too and they will be available globally.
+ *E.g. #define LV_FONT_CUSTOM_DECLARE   LV_FONT_DECLARE(my_font_1) LV_FONT_DECLARE(my_font_2)*/
+#define LV_FONT_CUSTOM_DECLARE
+
+/*Always set a default font*/
+#define LV_FONT_DEFAULT &lv_font_montserrat_12
+
+/*Enable handling large font and/or fonts with a lot of characters.
+ *The limit depends on the font size, font face and bpp.
+ *Compiler error will be triggered if a font needs it.*/
+#define LV_FONT_FMT_TXT_LARGE 0
+
+/*Enables/disables support for compressed fonts.*/
+#define LV_USE_FONT_COMPRESSED 0
+
+/*Enable subpixel rendering*/
+#define LV_USE_FONT_SUBPX 0
+#if LV_USE_FONT_SUBPX
+/*Set the pixel order of the display. Physical order of RGB channels. Doesn't matter with "normal" fonts.*/
+#define LV_FONT_SUBPX_BGR 0  /*0: RGB; 1:BGR order*/
+#endif
+
+/*=================
+ *  TEXT SETTINGS
+ *=================*/
+
+/**
+ * Select a character encoding for strings.
+ * Your IDE or editor should have the same character encoding
+ * - LV_TXT_ENC_UTF8
+ * - LV_TXT_ENC_ASCII
+ */
+#define LV_TXT_ENC LV_TXT_ENC_UTF8
+
+/*Can break (wrap) texts on these chars*/
+#define LV_TXT_BREAK_CHARS " ,.;:-_"
+
+/*If a word is at least this long, will break wherever "prettiest"
+ *To disable, set to a value <= 0*/
+#define LV_TXT_LINE_BREAK_LONG_LEN 0
+
+/*Minimum number of characters in a long word to put on a line before a break.
+ *Depends on LV_TXT_LINE_BREAK_LONG_LEN.*/
+#define LV_TXT_LINE_BREAK_LONG_PRE_MIN_LEN 3
+
+/*Minimum number of characters in a long word to put on a line after a break.
+ *Depends on LV_TXT_LINE_BREAK_LONG_LEN.*/
+#define LV_TXT_LINE_BREAK_LONG_POST_MIN_LEN 3
+
+/*The control character to use for signalling text recoloring.*/
+#define LV_TXT_COLOR_CMD "#"
+
+/*Support bidirectional texts. Allows mixing Left-to-Right and Right-to-Left texts.
+ *The direction will be processed according to the Unicode Bidirectional Algorithm:
+ *https://www.w3.org/International/articles/inline-bidi-markup/uba-basics*/
+#define LV_USE_BIDI 0
+#if LV_USE_BIDI
+/*Set the default direction. Supported values:
+*`LV_BASE_DIR_LTR` Left-to-Right
+*`LV_BASE_DIR_RTL` Right-to-Left
+*`LV_BASE_DIR_AUTO` detect texts base direction*/
+#define LV_BIDI_BASE_DIR_DEF LV_BASE_DIR_AUTO
+#endif
+
+/*Enable Arabic/Persian processing
+ *In these languages characters should be replaced with an other form based on their position in the text*/
+#define LV_USE_ARABIC_PERSIAN_CHARS 0
+
+/*==================
+ *  WIDGET USAGE
+ *================*/
+
+/*Documentation of the widgets: https://docs.lvgl.io/latest/en/html/widgets/index.html*/
+
+#define LV_USE_ARC        1
+
+#define LV_USE_ANIMIMG    1
+
+#define LV_USE_BAR        1
+
+#define LV_USE_BTN        1
+
+#define LV_USE_BTNMATRIX  1
+
+#define LV_USE_CANVAS     1
+
+#define LV_USE_CHECKBOX   1
+
+#define LV_USE_DROPDOWN   1   /*Requires: lv_label*/
+
+#define LV_USE_IMG        1   /*Requires: lv_label*/
+
+#define LV_USE_LABEL      1
+#if LV_USE_LABEL
+#define LV_LABEL_TEXT_SELECTION 1 /*Enable selecting text of the label*/
+#define LV_LABEL_LONG_TXT_HINT 1  /*Store some extra info in labels to speed up drawing of very long texts*/
+#endif
+
+#define LV_USE_LINE       1
+
+#define LV_USE_ROLLER     1   /*Requires: lv_label*/
+#if LV_USE_ROLLER
+#define LV_ROLLER_INF_PAGES 7 /*Number of extra "pages" when the roller is infinite*/
+#endif
+
+#define LV_USE_SLIDER     1   /*Requires: lv_bar*/
+
+#define LV_USE_SWITCH     1
+
+#define LV_USE_TEXTAREA   1   /*Requires: lv_label*/
+#if LV_USE_TEXTAREA != 0
+#define LV_TEXTAREA_DEF_PWD_SHOW_TIME 1500    /*ms*/
+#endif
+
+#define LV_USE_TABLE      1
+
+/*==================
+ * EXTRA COMPONENTS
+ *==================*/
+
+/*-----------
+ * Widgets
+ *----------*/
+#define LV_USE_CALENDAR   1
+#if LV_USE_CALENDAR
+#define LV_CALENDAR_WEEK_STARTS_MONDAY 0
+#if LV_CALENDAR_WEEK_STARTS_MONDAY
+#define LV_CALENDAR_DEFAULT_DAY_NAMES {"Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"}
+#else
+#define LV_CALENDAR_DEFAULT_DAY_NAMES {"Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"}
+#endif
+
+#define LV_CALENDAR_DEFAULT_MONTH_NAMES {"January", "February", "March",  "April", "May",  "June", "July", "August", "September", "October", "November", "December"}
+#define LV_USE_CALENDAR_HEADER_ARROW 1
+#define LV_USE_CALENDAR_HEADER_DROPDOWN 1
+#endif  /*LV_USE_CALENDAR*/
+
+#define LV_USE_CHART      1
+
+#define LV_USE_COLORWHEEL 1
+
+#define LV_USE_IMGBTN     1
+
+#define LV_USE_KEYBOARD   1
+
+#define LV_USE_LED        1
+
+#define LV_USE_LIST       1
+
+#define LV_USE_MENU       1
+
+#define LV_USE_METER      1
+
+#define LV_USE_MSGBOX     1
+
+#define LV_USE_SPINBOX    1
+
+#define LV_USE_SPINNER    1
+
+#define LV_USE_TABVIEW    1
+
+#define LV_USE_TILEVIEW   1
+
+#define LV_USE_WIN        1
+
+#define LV_USE_SPAN       1
+#if LV_USE_SPAN
+/*A line text can contain maximum num of span descriptor */
+#define LV_SPAN_SNIPPET_STACK_SIZE 64
+#endif
+
+/*-----------
+ * Themes
+ *----------*/
+
+/*A simple, impressive and very complete theme*/
+#define LV_USE_THEME_DEFAULT 1
+#if LV_USE_THEME_DEFAULT
+
+/*0: Light mode; 1: Dark mode*/
+#define LV_THEME_DEFAULT_DARK 1
+
+/*1: Enable grow on press*/
+#define LV_THEME_DEFAULT_GROW 1
+
+/*Default transition time in [ms]*/
+#define LV_THEME_DEFAULT_TRANSITION_TIME 80
+#endif /*LV_USE_THEME_DEFAULT*/
+
+/*A very simple theme that is a good starting point for a custom theme*/
+#define LV_USE_THEME_BASIC 1
+
+/*A theme designed for monochrome displays*/
+#define LV_USE_THEME_MONO 1
+
+/*-----------
+ * Layouts
+ *----------*/
+
+/*A layout similar to Flexbox in CSS.*/
+#define LV_USE_FLEX 1
+
+/*A layout similar to Grid in CSS.*/
+#define LV_USE_GRID 1
+
+/*---------------------
+ * 3rd party libraries
+ *--------------------*/
+
+/*File system interfaces for common APIs */
+
+/*API for fopen, fread, etc*/
+#define LV_USE_FS_STDIO 0
+#if LV_USE_FS_STDIO
+#define LV_FS_STDIO_LETTER '\0'     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
+#define LV_FS_STDIO_PATH ""         /*Set the working directory. File/directory paths will be appended to it.*/
+#define LV_FS_STDIO_CACHE_SIZE  0   /*>0 to cache this number of bytes in lv_fs_read()*/
+#endif
+
+/*API for open, read, etc*/
+#define LV_USE_FS_POSIX 0
+#if LV_USE_FS_POSIX
+#define LV_FS_POSIX_LETTER '\0'     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
+#define LV_FS_POSIX_PATH ""         /*Set the working directory. File/directory paths will be appended to it.*/
+#define LV_FS_POSIX_CACHE_SIZE  0   /*>0 to cache this number of bytes in lv_fs_read()*/
+#endif
+
+/*API for CreateFile, ReadFile, etc*/
+#define LV_USE_FS_WIN32 0
+#if LV_USE_FS_WIN32
+#define LV_FS_WIN32_LETTER  '\0'    /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
+#define LV_FS_WIN32_PATH ""         /*Set the working directory. File/directory paths will be appended to it.*/
+#define LV_FS_WIN32_CACHE_SIZE 0    /*>0 to cache this number of bytes in lv_fs_read()*/
+#endif
+
+/*API for FATFS (needs to be added separately). Uses f_open, f_read, etc*/
+#define LV_USE_FS_FATFS  0
+#if LV_USE_FS_FATFS
+#define LV_FS_FATFS_LETTER '\0'     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
+#define LV_FS_FATFS_CACHE_SIZE 0    /*>0 to cache this number of bytes in lv_fs_read()*/
+#endif
+
+/*PNG decoder library*/
+#define LV_USE_PNG 0
+
+/*BMP decoder library*/
+#define LV_USE_BMP 0
+
+/* JPG + split JPG decoder library.
+ * Split JPG is a custom format optimized for embedded systems. */
+#define LV_USE_SJPG 0
+
+/*GIF decoder library*/
+#define LV_USE_GIF 1
+
+/*QR code library*/
+#define LV_USE_QRCODE 0
+
+/*FreeType library*/
+#define LV_USE_FREETYPE 0
+#if LV_USE_FREETYPE
+/*Memory used by FreeType to cache characters [bytes] (-1: no caching)*/
+#define LV_FREETYPE_CACHE_SIZE (16 * 1024)
+#if LV_FREETYPE_CACHE_SIZE >= 0
+/* 1: bitmap cache use the sbit cache, 0:bitmap cache use the image cache. */
+/* sbit cache:it is much more memory efficient for small bitmaps(font size < 256) */
+/* if font size >= 256, must be configured as image cache */
+#define LV_FREETYPE_SBIT_CACHE 0
+/* Maximum number of opened FT_Face/FT_Size objects managed by this cache instance. */
+/* (0:use system defaults) */
+#define LV_FREETYPE_CACHE_FT_FACES 0
+#define LV_FREETYPE_CACHE_FT_SIZES 0
+#endif
+#endif
+
+/*Rlottie library*/
+#define LV_USE_RLOTTIE 0
+
+/*FFmpeg library for image decoding and playing videos
+ *Supports all major image formats so do not enable other image decoder with it*/
+#define LV_USE_FFMPEG  0
+#if LV_USE_FFMPEG
+/*Dump input information to stderr*/
+#define LV_FFMPEG_DUMP_FORMAT 0
+#endif
+
+/*-----------
+ * Others
+ *----------*/
+
+/*1: Enable API to take snapshot for object*/
+#define LV_USE_SNAPSHOT 0
+
+/*1: Enable Monkey test*/
+#define LV_USE_MONKEY   0
+
+/*1: Enable grid navigation*/
+#define LV_USE_GRIDNAV  0
+
+/*1: Enable lv_obj fragment*/
+#define LV_USE_FRAGMENT 0
+
+/*1: Support using images as font in label or span widgets */
+#define LV_USE_IMGFONT 0
+
+/*1: Enable a published subscriber based messaging system */
+#define LV_USE_MSG 0
+
+/*==================
+* EXAMPLES
+*==================*/
+
+/*Enable the examples to be built with the library*/
+#define LV_BUILD_EXAMPLES 0
+
+/*===================
+ * DEMO USAGE
+ ====================*/
+
+/*Show some widget. It might be required to increase `LV_MEM_SIZE` */
+#define LV_USE_DEMO_WIDGETS        0
+#if LV_USE_DEMO_WIDGETS
+#define LV_DEMO_WIDGETS_SLIDESHOW  0
+#endif
+
+/*Demonstrate the usage of encoder and keyboard*/
+#define LV_USE_DEMO_KEYPAD_AND_ENCODER     0
+
+/*Benchmark your system*/
+#define LV_USE_DEMO_BENCHMARK   0
+
+/*Stress test for LVGL*/
+#define LV_USE_DEMO_STRESS      0
+
+/*Music player demo*/
+#define LV_USE_DEMO_MUSIC       0
+#if LV_USE_DEMO_MUSIC
+# define LV_DEMO_MUSIC_SQUARE       0
+# define LV_DEMO_MUSIC_LANDSCAPE    0
+# define LV_DEMO_MUSIC_ROUND        0
+# define LV_DEMO_MUSIC_LARGE        0
+# define LV_DEMO_MUSIC_AUTO_PLAY    0
+#endif
+
+/*--END OF LV_CONF_H--*/
+
+#endif /*LV_CONF_H*/
+
+#endif /*End of "Content enable"*/

--- a/variants/heltec_wifi_lora_32_V4/platformio.ini
+++ b/variants/heltec_wifi_lora_32_V4/platformio.ini
@@ -1,0 +1,20 @@
+[env:heltec_wifi_lora_32_V4]
+extends = esp32
+board = heltec_wifi_lora_32_V3
+upload_command = pio pkg exec -p "tool-esptoolpy" -- esptool -b 921600 write_flash 0x0000 ${platformio.build_dir}/${this.__env__}/bootloader.bin 0xE000 otadata.bin 0x8000 ${platformio.build_dir}/${this.__env__}/partitions.bin 0x10000 safeboot-s3.bin 0xC0000 ${platformio.build_dir}/${this.__env__}/firmware.bin
+
+lib_ignore = Adafruit TCA8418, epdiy, es7210, ESP32-audioI2S, GxEPD2, lvgl, SensorLib, TFT_eSPI, TinyGSM
+
+lib_deps =
+	${libs.lib_deps}
+	${esp32libs.lib_deps}
+build_flags =
+	${esp32.build_flags}
+	${common.build_flags}
+	-DARDUINO_USB_MODE=1
+	-DARDUINO_USB_CDC_ON_BOOT=1
+	-D BOARD_HELTEC_V4="heltec_v4"
+	-D P_LORA_PA_POWER=7
+	-D P_LORA_PA_EN=2
+	-D P_LORA_PA_TX_EN=46
+	-I variants/${this.__env__}

--- a/variants/heltec_wifi_lora_32_V4/platformio.ini
+++ b/variants/heltec_wifi_lora_32_V4/platformio.ini
@@ -14,6 +14,8 @@ build_flags =
 	-DARDUINO_USB_MODE=1
 	-DARDUINO_USB_CDC_ON_BOOT=1
 	-D BOARD_HELTEC_V4="heltec_v4"
+	; PA Control - only available on 868/915MHz version, remove for 433MHz
+	-D HELTEC_V4_HAS_PA=1
 	-D P_LORA_PA_POWER=7
 	-D P_LORA_PA_EN=2
 	-D P_LORA_PA_TX_EN=46


### PR DESCRIPTION
## Summary

- Fixed incorrect battery voltage reading on Heltec WiFi LoRa 32 V2 — was reading wrong ADC pin (GPIO 34) with wrong attenuation and a 24.80x multiplier producing garbage values
- Added dedicated `BOARD_HELTEC` code path using GPIO 37 with `analogReadMilliVolts()` and the correct 3.2:1 voltage divider ratio (220K/100K)
- Verified on hardware: reads ~3.76V / 44% on a partially charged LiPo (previously showed ~1.25V / 0%)

## Test plan

- [x] Builds successfully for `heltec_wifi_lora_32_V2` target
- [x] Flashed and verified on Heltec V2 hardware — battery voltage and percentage now report correctly via serial `--info` command and BLE

🤖 Generated with [Claude Code](https://claude.com/claude-code)