### PR TITLE
Fix LoRa message loss: RX blind windows, ring buffer overflow, retransmit bugs

### DIFF
--- a/src/esp32/esp32_main.cpp
+++ b/src/esp32/esp32_main.cpp
@@ -1572,38 +1572,58 @@ void esp32loop()
             // Timeout RECEIVE_TIMEOUT
             if((iReceiveTimeOutTime + RECEIVE_TIMEOUT) < millis())
             {
-                iReceiveTimeOutTime=0;
+                // Debug A: RX_TIMEOUT_FIRE
+                if(bLORADEBUG)
+                    Serial.printf("[MC-DBG] RX_TIMEOUT_FIRE ts=%lu last_event=%lu delta=%lu\n",
+                        millis(), iReceiveTimeOutTime, millis() - iReceiveTimeOutTime);
 
-                // clear Receive Interrupt
-                bEnableInterruptReceive = false; //KBC 0801
-                radio.clearPacketReceivedAction(); // KBC 0801
-
-                // clear Transmit Interrupt
-                bEnableInterruptTransmit = false; // KBC 0801
-                radio.clearPacketSentAction();  //KBC 0801
-
-                // set Receive Interupt
-                bEnableInterruptReceive = true; //KBC 0801
-                radio.setPacketReceivedAction(setFlagReceive); //KBC 0801
-
-                int state = radio.startReceive();
-                if (state == RADIOLIB_ERR_NONE)
+                // FIX BUG #1: Do not reset radio if a received packet is pending
+                if(receiveFlag)
                 {
+                    // A packet arrived just before timeout — let the receiveFlag
+                    // handler process it. Just reset the timer.
+                    iReceiveTimeOutTime = millis();
+
                     if(bLORADEBUG)
                     {
                         Serial.print(getTimeString());
-                        Serial.println(" [LoRa]...Receive Timeout, startReceive again with sucess");
+                        Serial.println(F(" [MC-DBG] RX_TIMEOUT skipped: receiveFlag pending"));
                     }
                 }
                 else
                 {
+                    iReceiveTimeOutTime=0;
+
+                    // FIX BUG #1: Call startReceive FIRST, then re-wire interrupts.
+                    // Disable interrupt gating while we reconfigure
+                    bEnableInterruptReceive = false;
+                    bEnableInterruptTransmit = false;
+
+                    int state = radio.startReceive();
+
+                    // Now re-wire the interrupt callback
+                    radio.clearPacketReceivedAction();
+                    radio.clearPacketSentAction();
+                    radio.setPacketReceivedAction(setFlagReceive);
+
+                    bEnableInterruptReceive = true;
+
+                    // Debug B: RX_RESTART after timeout
+                    if(bLORADEBUG)
+                        Serial.printf("[MC-DBG] RX_RESTART src=timeout state=%d\n", state);
+
                     if(bLORADEBUG)
                     {
                         Serial.print(getTimeString());
-                        Serial.print(" [LoRa]...Receive Timeout, startReceive again with error = ");
-                        Serial.println(state);
+                        if (state == RADIOLIB_ERR_NONE)
+                            Serial.println(F(" [LoRa]...Receive Timeout, startReceive again with sucess"));
+                        else
+                        {
+                            Serial.print(F(" [LoRa]...Receive Timeout, startReceive again with error = "));
+                            Serial.println(state);
+                        }
                     }
-                }        
+                }
             }
         }
         
@@ -1612,6 +1632,10 @@ void esp32loop()
             // check ongoing reception
             if(receiveFlag)
             {
+                // Debug C: RX_FLAG_PROCESS
+                if(bLORADEBUG)
+                    Serial.printf("[MC-DBG] RX_FLAG_PROCESS ts=%lu\n", millis());
+
                 // reset flags first
                 bEnableInterruptReceive = false;
                 receiveFlag = false;
@@ -1621,19 +1645,11 @@ void esp32loop()
 
                 checkRX(bRadio);
 
-                // clear Receive Interrupt
-                bEnableInterruptReceive = false; // KBC 0801
-                radio.clearPacketReceivedAction(); // KBC 0801
-
-                // clear Transmit Interrupt
-                bEnableInterruptTransmit = false; // KBC 0801
-                radio.clearPacketSentAction();  //KBC 0801
-
-                // set Receive Interupt
-                bEnableInterruptReceive = true; //KBC 0801
-                radio.setPacketReceivedAction(setFlagReceive); //KBC 0801
-
+                // FIX BUG #2: checkRX() now restarts RX internally.
+                // Remove redundant interrupt rewiring that would double-reconfigure.
+                // Only reset the timeout timers here.
                 inoReceiveTimeOutTime=millis();
+                iReceiveTimeOutTime = millis();
             }
             else
             if(transmittedFlag)
@@ -1643,6 +1659,10 @@ void esp32loop()
                 bEnableInterruptReceive = false;
 
                 transmittedFlag = false;
+
+                // Debug G: TX_DONE
+                if(bLORADEBUG)
+                    Serial.printf("[MC-DBG] TX_DONE state=%d ts=%lu\n", transmissionState, millis());
 
                 if (transmissionState == RADIOLIB_ERR_NONE)
                 {
@@ -1693,6 +1713,10 @@ void esp32loop()
 
                 int state = radio.startReceive();
 
+                // Debug H: RX_RESTARTED after TX
+                if(bLORADEBUG)
+                    Serial.printf("[MC-DBG] RX_RESTARTED src=after_tx state=%d\n", state);
+
                 if (state != RADIOLIB_ERR_NONE)
                 {
                     if(bLORADEBUG)
@@ -1701,7 +1725,7 @@ void esp32loop()
                         Serial.print(F("failed, code "));
                         Serial.println(state);
                     }
-                }        
+                }
 
                 inoReceiveTimeOutTime=millis();
 
@@ -1717,6 +1741,12 @@ void esp32loop()
             // do not print anything, it just spams the console
             if (iWrite != iRead)
             {
+                // Debug E: TX_GATE_ENTER
+                if(bLORADEBUG)
+                    Serial.printf("[MC-DBG] TX_GATE_ENTER qlen=%d cmd_ctr=%d tx_wait=%d\n",
+                        (iWrite >= iRead) ? (iWrite - iRead) : (MAX_RING - iRead + iWrite),
+                        cmd_counter, tx_waiting);
+
                 // save transmission state between loops
                 cmd_counter=0;
                 tx_waiting=true;
@@ -1736,6 +1766,11 @@ void esp32loop()
                 if(doTX())
                 {
                     //KBC 0801 bEnableInterruptTransmit = true;
+
+                    // Debug F: TX_START
+                    if(bLORADEBUG)
+                        Serial.printf("[MC-DBG] TX_START qlen=%d\n",
+                            (iWrite >= iRead) ? (iWrite - iRead) : (MAX_RING - iRead + iWrite));
                 }
                 else
                 {
@@ -2748,6 +2783,28 @@ int checkRX(bool bRadio)
 
     if (state == RADIOLIB_ERR_LORA_HEADER_DAMAGED || state == RADIOLIB_ERR_NONE)
     {
+        // FIX BUG #2: Save RSSI/SNR/FreqError BEFORE restarting RX.
+        // These read from SX1262 hardware registers via SPI and would be
+        // invalidated once startReceive() transitions the radio to standby+RX.
+        int16_t saved_rssi = (int16_t)radio.getRSSI();
+        int8_t  saved_snr  = (int8_t)radio.getSNR();
+        float   saved_ferr = radio.getFrequencyError();
+
+        // FIX BUG #2: Restart RX immediately after reading FIFO, BEFORE processing.
+        // The packet data is already in our local payload buffer.
+        // The radio can now listen for the next packet while we process this one.
+        {
+            radio.clearPacketReceivedAction();
+            radio.clearPacketSentAction();
+            bEnableInterruptReceive = true;
+            radio.setPacketReceivedAction(setFlagReceive);
+            int rxstate = radio.startReceive();
+
+            // Debug D: RX_RESTARTED after readData
+            if(bLORADEBUG)
+                Serial.printf("[MC-DBG] RX_RESTARTED src=after_readData state=%d\n", rxstate);
+        }
+
         if(bLORADEBUG)
         {
             // packet was successfully received
@@ -2755,25 +2812,34 @@ int checkRX(bool bRadio)
 
             // print RSSI (Received Signal Strength Indicator)
             Serial.print(F("RSSI:\t\t"));
-            Serial.print(radio.getRSSI());
+            Serial.print(saved_rssi);
             Serial.print(F(" dBm / "));
 
             // print SNR (Signal-to-Noise Ratio)
             Serial.print(F("SNR:\t\t"));
-            Serial.print(radio.getSNR());
+            Serial.print(saved_snr);
             Serial.print(F(" dB / "));
 
             // print frequency error
             Serial.print(F("Frequency error:\t"));
-            Serial.print(radio.getFrequencyError());
+            Serial.print(saved_ferr);
             Serial.println(F(" Hz"));
         }
 
-        OnRxDone(payload, (uint16_t)ibytes, (int16_t)radio.getRSSI(), (int8_t)radio.getSNR());
+        OnRxDone(payload, (uint16_t)ibytes, saved_rssi, saved_snr);
     }
     else
     if (state == RADIOLIB_ERR_CRC_MISMATCH)
     {
+        // FIX BUG #2: Also restart RX after CRC error
+        {
+            radio.clearPacketReceivedAction();
+            radio.clearPacketSentAction();
+            bEnableInterruptReceive = true;
+            radio.setPacketReceivedAction(setFlagReceive);
+            radio.startReceive();
+        }
+
         // packet was received, but is malformed
         if(bLORADEBUG)
             Serial.println(F("[LoRa]...CRC error!"));

--- a/src/esp32/esp32_main.cpp
+++ b/src/esp32/esp32_main.cpp
@@ -2842,7 +2842,11 @@ int checkRX(bool bRadio)
 
         // packet was received, but is malformed
         if(bLORADEBUG)
-            Serial.println(F("[LoRa]...CRC error!"));
+        {
+            Serial.printf("[MC-DBG] CRC_ERROR rssi=%.1f snr=%.1f freq_err=%.1f size=%d ts=%lu\n",
+                radio.getRSSI(), radio.getSNR(), radio.getFrequencyError(),
+                (int)ibytes, millis());
+        }
     }
     else
     {

--- a/src/esp32/esp32_main.cpp
+++ b/src/esp32/esp32_main.cpp
@@ -1567,6 +1567,26 @@ void esp32loop()
             }
         }
 
+        // FIX: Periodic ring buffer utilization report (every 30s)
+        {
+            static unsigned long ring_status_timer = 0;
+            if(bLORADEBUG && (millis() - ring_status_timer) > 30000)
+            {
+                ring_status_timer = millis();
+                int pending = 0, retrying = 0, done = 0;
+                for(int i = 0; i < MAX_RING; i++)
+                {
+                    if(ringBuffer[i][0] == 0) continue;
+                    if(ringBuffer[i][1] == 0xFF) done++;
+                    else if(ringBuffer[i][1] == 0x00) pending++;
+                    else retrying++;
+                }
+                int queued = (iWrite >= iRead) ? (iWrite - iRead) : (MAX_RING - iRead + iWrite);
+                Serial.printf("[MC-DBG] RING_STATUS queued=%d pending=%d retrying=%d done=%d iW=%d iR=%d\n",
+                    queued, pending, retrying, done, iWrite, iRead);
+            }
+        }
+
         if(iReceiveTimeOutTime > 0)
         {
             // Timeout RECEIVE_TIMEOUT

--- a/src/loop_functions.cpp
+++ b/src/loop_functions.cpp
@@ -3753,9 +3753,12 @@ void addRingPointer(int &pWrite, int &pRead, int iMAX)
         if(pRead == pWrite)
         {
             pRead = pWrite+1;
-            
+
             if (pRead >= iMAX) // if the buffer is full we start at index 0 -> take care of overwriting!
                 pRead = 0;
+
+            // Debug M: RING_OVERFLOW — NOT gated by bLORADEBUG, always visible
+            Serial.println(F("[MC-DBG] RING_OVERFLOW"));
         }
     }
 

--- a/src/loop_functions.cpp
+++ b/src/loop_functions.cpp
@@ -249,6 +249,9 @@ int iWrite=0;
 int iRead=0;
 int iRetransmit=-1;
 
+// FIX: Per-slot retry counter for retransmit cap
+uint8_t retryCount[MAX_RING] = {0};
+
 // RINGBUFFER for incomming LoRa RX msg_id
 uint8_t ringBufferLoraRX[MAX_RING][5] = {0};
 uint8_t loraWrite = 0;   // counter for ringbuffer
@@ -2362,6 +2365,7 @@ void sendMessage(char *msg_text, int len)
         Serial.printf("einfügen retid:%i status:%02X lng;%02X msg-id: %c-%08X\n", iWrite, ringBuffer[iWrite][1], ringBuffer[iWrite][0], ringBuffer[iWrite][2], ring_msg_id);
     }
 
+    retryCount[iWrite] = 0;
     addRingPointer(iWrite, iRead, MAX_RING);
 
     /*
@@ -2369,7 +2373,7 @@ void sendMessage(char *msg_text, int len)
     if(iWrite >= MAX_RING)
         iWrite=0;
     */
-    
+
     if(bGATEWAY && meshcom_settings.node_hasIPaddress)
     {
 	    // UDP out

--- a/src/loop_functions.cpp
+++ b/src/loop_functions.cpp
@@ -2349,7 +2349,7 @@ void sendMessage(char *msg_text, int len)
     
     if (ringBuffer[iWrite][2] == 0x3A) // only Messages
     {
-        if(aprsmsg.msg_payload.startsWith("{") > 0)
+        if(aprsmsg.msg_payload.startsWith("{CET}") || aprsmsg.msg_payload.startsWith("{MCP}") || aprsmsg.msg_payload.startsWith("{SET}"))
             ringBuffer[iWrite][1] = 0xFF; // retransmission Status ...0xFF no retransmission on {CET} & Co.
         else
             ringBuffer[iWrite][1] = 0x00; // retransmission Status ...0xFF no retransmission

--- a/src/loop_functions_extern.h
+++ b/src/loop_functions_extern.h
@@ -160,6 +160,7 @@ extern unsigned char ringBuffer[MAX_RING][UDP_TX_BUF_SIZE+5];
 extern int iWrite;
 extern int iRead;
 extern int iRetransmit;
+extern uint8_t retryCount[MAX_RING];
 
 extern unsigned char ringbufferRAWLoraRX[MAX_LOG][UDP_TX_BUF_SIZE+5];
 extern int RAWLoRaWrite;

--- a/src/lora_functions.cpp
+++ b/src/lora_functions.cpp
@@ -652,7 +652,12 @@ void OnRxDone(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr)
                                                 print_buff[4]=(msg_counter >> 24) & 0xFF;
                                                 print_buff[5]=0x80;      // server & max hop
                                                 print_buff[5] = print_buff[5] | meshcom_settings.max_hop_text;
-                                                print_buff[10]=0x01;     // switch ack GW / Node currently fixed to 0x00 
+                                                // FIX BUG #6: Include original msg_id so sender can match ACK and stop retransmitting
+                                                print_buff[6]=aprsmsg.msg_id & 0xFF;
+                                                print_buff[7]=(aprsmsg.msg_id >> 8) & 0xFF;
+                                                print_buff[8]=(aprsmsg.msg_id >> 16) & 0xFF;
+                                                print_buff[9]=(aprsmsg.msg_id >> 24) & 0xFF;
+                                                print_buff[10]=0x01;     // switch ack GW / Node currently fixed to 0x00
                                                 print_buff[11]=0x00;     // msg always 0x00 at the end
                                                 
                                                 ringBuffer[iWrite][0]=12;

--- a/src/lora_functions.cpp
+++ b/src/lora_functions.cpp
@@ -1137,7 +1137,7 @@ bool doTX()
 // unsigned char ringBuffer[MAX_RING][UDP_TX_BUF_SIZE] = {0};
 
 // Maximum retransmit attempts per message
-#define MAX_RETRANSMIT 3
+#define MAX_RETRANSMIT 5
 
 bool updateRetransmissionStatus()
 {
@@ -1155,11 +1155,9 @@ bool updateRetransmissionStatus()
         {
             ringBuffer[ircheck][1]++;
 
-            // Retransmit threshold with exponential backoff:
-            //   Retry 1: 0x10 (15 ticks x 2s = 30s)
-            //   Retry 2: 0x20 (31 ticks x 2s = 62s)
-            //   Retry 3: 0x30 (47 ticks x 2s = 94s)
-            uint8_t threshold = 0x10 * (retryCount[ircheck] + 1);
+            // Fixed-interval retransmit: 30s per retry (15 ticks × 2s)
+            //   Retry 1-5: each waits 30s → total max 150s (2.5 min)
+            uint8_t threshold = 0x10;
 
             if(ringBuffer[ircheck][1] == threshold)
             {

--- a/src/lora_functions.cpp
+++ b/src/lora_functions.cpp
@@ -498,6 +498,30 @@ void OnRxDone(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr)
                                     if(iackcheck >= 0)
                                     {
                                         own_msg_id[iackcheck][4] = 0x02;   // 02...ACK
+
+                                        // BUG #8 fix: clear ringBuffer entry to stop retransmission
+                                        for(int ircheck=0; ircheck<MAX_RING; ircheck++)
+                                        {
+                                            if(ringBuffer[ircheck][0] > 0 && ringBuffer[ircheck][1] != 0xFF)
+                                            {
+                                                unsigned int ring_msg_id =
+                                                    (ringBuffer[ircheck][6]<<24) |
+                                                    (ringBuffer[ircheck][5]<<16) |
+                                                    (ringBuffer[ircheck][4]<<8)  |
+                                                     ringBuffer[ircheck][3];
+
+                                                if(ring_msg_id == msg_counter)
+                                                {
+                                                    ringBuffer[ircheck][1] = 0xFF;
+                                                    retryCount[ircheck] = 0;
+
+                                                    if(bDisplayRetx)
+                                                    {
+                                                        Serial.printf("\n[RETX] DM-ACK for retid:%i stop retransmit msg-id:%08X\n", ircheck, ring_msg_id);
+                                                    }
+                                                }
+                                            }
+                                        }
                                     }
 
                                     addBLEOutBuffer(print_buff, 7);

--- a/src/lora_functions.cpp
+++ b/src/lora_functions.cpp
@@ -99,6 +99,9 @@ bool bNewLine = false;
 
 void OnRxDone(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr)
 {
+    // Debug I: OnRxDone timing — capture start time
+    unsigned long _onrxdone_start = millis();
+
     // only for Test T5_EPAPER
     //bDisplayInfo=true;
 
@@ -874,6 +877,10 @@ void OnRxDone(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr)
     #endif
 
 
+    // Debug I: ONRXDONE_TIME — measure processing duration
+    if(bLORADEBUG)
+        Serial.printf("[MC-DBG] ONRXDONE_TIME ms=%lu\n", millis() - _onrxdone_start);
+
     if(bLORADEBUG)
         Serial.println("OnRxDone");
 
@@ -944,10 +951,11 @@ bool doTX()
     // next TX new TX-DELAY
     if(cmd_counter > 0)
     {
+        // Debug J: CAD_WAIT
+        if(bLORADEBUG)
+            Serial.printf("[MC-DBG] CAD_WAIT remaining=%d\n", cmd_counter);
+
         cmd_counter--;
-        
-        //if(bLORADEBUG)
-        //Serial.printf("cmd_counter > 0:%i \n", cmd_counter);
 
         return false;
     }
@@ -1092,6 +1100,11 @@ bool doTX()
                         #ifdef BOARD_HELTEC_V4
                         enablePATransmit();
                         #endif
+
+                        // Debug K: RADIO_TX
+                        if(bLORADEBUG)
+                            Serial.printf("[MC-DBG] RADIO_TX len=%d\n", sendlng);
+
                         transmissionState = radio.startTransmit(lora_tx_buffer, sendlng);
                         #endif
                         bLED_RED = true;
@@ -1255,12 +1268,12 @@ void OnPreambleDetect(void)
  */
 void OnHeaderDetect(void)
 {
-    // Suche nach freiem Kanal unterbrechen
-    tx_waiting=false;
-    cmd_counter=0;
-
+    // FIX BUG #3: Only block TX during active reception.
+    // Do NOT reset cmd_counter or tx_waiting.
+    // The CAD wait will resume after this packet is processed.
     is_receiving = true;
-    
+
+    // Debug L: HDR_DETECT with state context
     if(bLORADEBUG)
-        Serial.println("OnHeaderDetect");
+        Serial.printf("[MC-DBG] HDR_DETECT tx_wait=%d cmd_ctr=%d\n", tx_waiting, cmd_counter);
 }

--- a/src/lora_functions.cpp
+++ b/src/lora_functions.cpp
@@ -167,6 +167,7 @@ void OnRxDone(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr)
                     ringBuffer[iWrite][1]=0xFF; // retransmission Status ...0xFF no retransmission
                     memcpy(ringBuffer[iWrite]+2, print_buff, 12);
 
+                    retryCount[iWrite] = 0;
                     addRingPointer(iWrite, iRead, MAX_RING);
                     /*
                     iWrite++;
@@ -203,6 +204,7 @@ void OnRxDone(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr)
                 if(memcmp(ringBuffer[ircheck]+3, RcvBuffer+1, 4) == 0)
                 {
                     ringBuffer[ircheck][1] = 0xFF; // no retransmission
+                    retryCount[ircheck] = 0; // clear retry counter
 
                     if(bDisplayRetx)
                     {
@@ -819,22 +821,19 @@ void OnRxDone(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr)
 
                                 ringBuffer[iWrite][0]=size;
                                 memcpy(ringBuffer[iWrite]+2, RcvBuffer, size);
-                                if (ringBuffer[iWrite][2] == 0x3A) // only Messages
-                                {
-                                    if(aprsmsg.msg_payload.startsWith("{") > 0)
-                                        ringBuffer[iWrite][1] = 0xFF; // retransmission Status ...0xFF no retransmission on {CET} & Co.
-                                    else
-                                        ringBuffer[iWrite][1] = 0x00; // retransmission Status ...0xFF no retransmission
-                                }
-                                else
-                                    ringBuffer[iWrite][1] = 0xFF; // retransmission Status ...0xFF no retransmission on {CET} & Co.
 
-                                if(bDisplayRetx)
+                                // FIX: Relay messages are fire-and-forget.
+                                // Only the ORIGINATING node should retransmit.
+                                ringBuffer[iWrite][1] = 0xFF; // no retransmission for ANY relay message
+
+                                if(bLORADEBUG)
                                 {
-                                    unsigned int ring_msg_id = (ringBuffer[iWrite][6]<<24) | (ringBuffer[iWrite][5]<<16) | (ringBuffer[iWrite][4]<<8) | ringBuffer[iWrite][3];
-                                    Serial.printf("einfügen retid:%i status:%02X lng;%02X msg-id: %c-%08X\n", iWrite, ringBuffer[iWrite][1], ringBuffer[iWrite][0], ringBuffer[iWrite][2], ring_msg_id);
+                                    unsigned int relay_msg_id = (ringBuffer[iWrite][6]<<24) | (ringBuffer[iWrite][5]<<16) | (ringBuffer[iWrite][4]<<8) | ringBuffer[iWrite][3];
+                                    Serial.printf("[MC-DBG] RELAY_QUEUED msg_id=%08X type=%02X len=%d\n",
+                                        relay_msg_id, ringBuffer[iWrite][2], size);
                                 }
 
+                                retryCount[iWrite] = 0;
                                 addRingPointer(iWrite, iRead, MAX_RING);
 
                                 /*
@@ -973,16 +972,8 @@ bool doTX()
         if(ringBuffer[iRead][1] == 0x00) // mark open to send
             ringBuffer[iRead][1] = 0x01; // mark as sent
 
-        if(ringBuffer[iRead][1] == 0x7F)
-        {
-            if(bDisplayRetx)
-            {
-                unsigned int ring_msg_id = (ringBuffer[iRead][6]<<24) | (ringBuffer[iRead][5]<<16) | (ringBuffer[iRead][4]<<8) | ringBuffer[iRead][3];
-                Serial.printf("resend   retid:%i status:%02X lng;%02X msg-id: %c-%08X\n", iRead, ringBuffer[iRead][1], ringBuffer[iRead][0], ringBuffer[iRead][2], ring_msg_id);
-            }
-
-            ringBuffer[iRead][1] = 0xFF; // mark as resent
-        }
+        // FIX: 0x7F handling removed. Retransmit copies now use status 0x01
+        // and re-enter the normal timer cycle with retryCount tracking.
 
         iRead++;
         if (iRead >= MAX_RING)
@@ -1140,15 +1131,14 @@ bool doTX()
 // based on:
 // unsigned char ringBuffer[MAX_RING][UDP_TX_BUF_SIZE] = {0};
 
+// Maximum retransmit attempts per message
+#define MAX_RETRANSMIT 3
+
 bool updateRetransmissionStatus()
 {
-//    Serial.println("update retransmit");
-
     for(int ircheck=0; ircheck < MAX_RING; ircheck++)
     {
-        // Status == ringBuffer[ircheck][1]
-        //   0x00 not yet sent
-        //   0xFF no retransmission
+        // Non-text messages: force no-retransmit
         if(ringBuffer[ircheck][2] != 0x3A)
         {
             ringBuffer[ircheck][1] = 0xFF;
@@ -1160,22 +1150,44 @@ bool updateRetransmissionStatus()
         {
             ringBuffer[ircheck][1]++;
 
-            // stoppen da kein Empfang über längere Zeit
-            if(ringBuffer[ircheck][1] == 0x10)    // FIX BUG #5: 15 x 2sec = 30sec retransmit (was 0x20 = 62sec)
+            // Retransmit threshold with exponential backoff:
+            //   Retry 1: 0x10 (15 ticks x 2s = 30s)
+            //   Retry 2: 0x20 (31 ticks x 2s = 62s)
+            //   Retry 3: 0x30 (47 ticks x 2s = 94s)
+            uint8_t threshold = 0x10 * (retryCount[ircheck] + 1);
+
+            if(ringBuffer[ircheck][1] == threshold)
             {
-                // Debug: RETRANSMIT
+                // Check retry cap
+                if(retryCount[ircheck] >= MAX_RETRANSMIT)
+                {
+                    // Give up — max retries exhausted
+                    ringBuffer[ircheck][1] = 0xFF;
+
+                    if(bLORADEBUG)
+                    {
+                        unsigned int ring_msg_id = (ringBuffer[ircheck][6]<<24) | (ringBuffer[ircheck][5]<<16) | (ringBuffer[ircheck][4]<<8) | ringBuffer[ircheck][3];
+                        Serial.printf("[MC-DBG] RETRANSMIT_GIVEUP retries=%d msg_id=%08X\n",
+                            retryCount[ircheck], ring_msg_id);
+                    }
+
+                    continue;
+                }
+
                 if(bLORADEBUG)
                 {
                     unsigned int ring_msg_id = (ringBuffer[ircheck][6]<<24) | (ringBuffer[ircheck][5]<<16) | (ringBuffer[ircheck][4]<<8) | ringBuffer[ircheck][3];
-                    Serial.printf("[MC-DBG] RETRANSMIT after_sec=%d msg_id=%08X\n",
-                        (ringBuffer[ircheck][1] - 1) * 2, ring_msg_id);
+                    Serial.printf("[MC-DBG] RETRANSMIT retry=%d after_sec=%d msg_id=%08X\n",
+                        retryCount[ircheck] + 1, (ringBuffer[ircheck][1] - 1) * 2, ring_msg_id);
                 }
+
                 int ring_msg_lng = ringBuffer[ircheck][0];
 
                 if(bDisplayRetx)
                 {
                     unsigned int ring_msg_id = (ringBuffer[ircheck][6]<<24) | (ringBuffer[ircheck][5]<<16) | (ringBuffer[ircheck][4]<<8) | ringBuffer[ircheck][3];
-                    Serial.printf("Retransmit retid:%i status:%02X lng;%02X msg-id: %c-%08X\n", ircheck, ringBuffer[ircheck][1], ringBuffer[ircheck][0], ringBuffer[ircheck][2], ring_msg_id);
+                    Serial.printf("\n[RETX] Retransmit retid:%i status:%02X lng;%02X msg-id: %c-%08X retry:%d\n",
+                        ircheck, ringBuffer[ircheck][1], ringBuffer[ircheck][0], ringBuffer[ircheck][2], ring_msg_id, retryCount[ircheck] + 1);
 
                     for(int iq=0;iq<ring_msg_lng+2;iq++)
                     {
@@ -1185,26 +1197,21 @@ bool updateRetransmissionStatus()
                     Serial.println("");
                 }
 
-                // origimalmeldung markieren
+                // Mark original as done
                 ringBuffer[ircheck][1] = 0xFF;
 
-                // Neuen Eintrag im Ringbuffer zur Wiederholung anlegen
+                // Copy message to new slot at iWrite
                 memcpy(ringBuffer[iWrite], ringBuffer[ircheck], size + 2);
 
-                // KB hier das retransmitt
-                if (ringBuffer[iWrite][2] == 0x3A) // only Messages
-                    ringBuffer[iWrite][1] = 0x7F; // retransmission Status ...0x7F retransmission
+                if (ringBuffer[iWrite][2] == 0x3A) // text messages
+                    ringBuffer[iWrite][1] = 0x01;  // start timer immediately
                 else
-                    ringBuffer[iWrite][1] = 0xFF; // retransmission Status ...0xFF no retransmission
-                
-                
-                addRingPointer(iWrite, iRead, MAX_RING);
+                    ringBuffer[iWrite][1] = 0xFF;
 
-                /*
-                iWrite++;
-                if (iWrite >= MAX_RING) // if the buffer is full we start at index 0 -> take care of overwriting!
-                    iWrite = 0;
-                */
+                // Transfer and increment retry count
+                retryCount[iWrite] = retryCount[ircheck] + 1;
+
+                addRingPointer(iWrite, iRead, MAX_RING);
 
                 return true;
             }

--- a/src/lora_functions.cpp
+++ b/src/lora_functions.cpp
@@ -1072,13 +1072,10 @@ bool doTX()
                     }
                     else
                     {
-                        //vor jeden senden 7 aufeinander folgende CAD abwarten
+                        //vor jeden senden CAD abwarten
                         //if(aprsmsg.msg_payload.indexOf(":ack") > 0)
                         {
-                            cmd_counter=7;
-                            
-                            //if(bLORADEBUG)
-                            //    Serial.printf("cmd_counter = 7:%i \n", cmd_counter);
+                            cmd_counter=3;    // FIX BUG #4: Reduced from 7 — blind delay, not real CAD
 
                             iRead=save_read;
                             ringBuffer[iRead][1] = save_ring_status;
@@ -1164,8 +1161,15 @@ bool updateRetransmissionStatus()
             ringBuffer[ircheck][1]++;
 
             // stoppen da kein Empfang über längere Zeit
-            if(ringBuffer[ircheck][1] == 0x20)    // 32 x 10sec = 320sec (5min 20sec) Wartezeit
+            if(ringBuffer[ircheck][1] == 0x10)    // FIX BUG #5: 15 x 2sec = 30sec retransmit (was 0x20 = 62sec)
             {
+                // Debug: RETRANSMIT
+                if(bLORADEBUG)
+                {
+                    unsigned int ring_msg_id = (ringBuffer[ircheck][6]<<24) | (ringBuffer[ircheck][5]<<16) | (ringBuffer[ircheck][4]<<8) | ringBuffer[ircheck][3];
+                    Serial.printf("[MC-DBG] RETRANSMIT after_sec=%d msg_id=%08X\n",
+                        (ringBuffer[ircheck][1] - 1) * 2, ring_msg_id);
+                }
                 int ring_msg_lng = ringBuffer[ircheck][0];
 
                 if(bDisplayRetx)

--- a/src/lora_functions.cpp
+++ b/src/lora_functions.cpp
@@ -1008,6 +1008,11 @@ bool doTX()
         if (iRead >= MAX_RING)
             iRead = 0;
 
+        // NOTE: Slot clearing (Bug 1 fix) is deferred until after the transmit
+        // decision. Two rollback paths (CAD wait, APRS chip-switch failure)
+        // restore iRead to save_read and retry the same slot on the next call.
+        // Clearing here would destroy the slot data before those paths execute.
+
         // we can now tx the message
         if (TX_ENABLE == 1)
         {
@@ -1068,6 +1073,11 @@ bool doTX()
                 }
 
                 bSetLoRaAPRS = true;
+
+                // FIX Bug 4: Clear consumed slot only after successful transmit
+                ringBuffer[save_read][0] = 0;
+                ringBuffer[save_read][1] = 0xFF;
+                retryCount[save_read] = 0;
 
                 return true;
             }
@@ -1141,6 +1151,11 @@ bool doTX()
                         }
                     }
 
+                    // FIX Bug 4: Clear consumed slot only after successful transmit
+                    ringBuffer[save_read][0] = 0;
+                    ringBuffer[save_read][1] = 0xFF;
+                    retryCount[save_read] = 0;
+
                     return true;
                 }
             }
@@ -1149,6 +1164,14 @@ bool doTX()
         {
             DEBUG_MSG("RADIO", "TX DISABLED");
         }
+
+        // FIX Bug 4: Clear consumed slot on non-rollback drop paths
+        // (TX disabled, or msg_type_b_lora == 0x00 decode failure).
+        // The slot is consumed (iRead advanced) but will never be sent,
+        // so clear it to prevent deadlock accumulation.
+        ringBuffer[save_read][0] = 0;
+        ringBuffer[save_read][1] = 0xFF;
+        retryCount[save_read] = 0;
     }
 
     //#endif
@@ -1161,12 +1184,19 @@ bool doTX()
 // unsigned char ringBuffer[MAX_RING][UDP_TX_BUF_SIZE] = {0};
 
 // Maximum retransmit attempts per message
-#define MAX_RETRANSMIT 5
+#define MAX_RETRANSMIT 3
 
 bool updateRetransmissionStatus()
 {
-    for(int ircheck=0; ircheck < MAX_RING; ircheck++)
+    // FIX: Only scan slots in the active iRead→iWrite range.
+    // Consumed slots behind iRead are cleared by doTX() (Bug 1 fix),
+    // but this defense-in-depth prevents ghost retransmits from stale data.
+    int count = (iWrite >= iRead) ? (iWrite - iRead) : (MAX_RING - iRead + iWrite);
+
+    for(int q = 0; q < count; q++)
     {
+        int ircheck = (iRead + q) % MAX_RING;
+
         // Non-text messages: force no-retransmit
         if(ringBuffer[ircheck][2] != 0x3A)
         {
@@ -1179,9 +1209,9 @@ bool updateRetransmissionStatus()
         {
             ringBuffer[ircheck][1]++;
 
-            // Fixed-interval retransmit: 30s per retry (15 ticks × 2s)
-            //   Retry 1-5: each waits 30s → total max 150s (2.5 min)
-            uint8_t threshold = 0x10;
+            // Fixed-interval retransmit: 40s per retry (20 ticks × 2s)
+            //   Retry 1-3: each waits 40s → total max 120s (2 min)
+            uint8_t threshold = 0x15;
 
             if(ringBuffer[ircheck][1] == threshold)
             {

--- a/src/udp_functions.cpp
+++ b/src/udp_functions.cpp
@@ -329,6 +329,7 @@ void getMeshComUDPpacket(unsigned char inc_udp_buffer[UDP_TX_BUF_SIZE], int pack
               ringBuffer[iWrite][1] = 0xFF; // retransmission Status ...0xFF no retransmission
             memcpy(ringBuffer[iWrite] + 2, convBuffer, size);
 
+            retryCount[iWrite] = 0;
             addRingPointer(iWrite, iRead, MAX_RING);
 
             /*


### PR DESCRIPTION
## Summary

This PR fixes 12 bugs in the LoRa radio state machine and ring buffer management that together caused **~50% bidirectional message loss** on busy MeshCom channels (observed on Heltec V3, firmware 4.35k).

### Bugs fixed

- **BUG #1-3**: RX blind windows — `RECEIVE_TIMEOUT` discards pending packets, `checkRX()` delays RX restart by ~780 lines of processing, `OnHeaderDetect()` resets TX counters on every preamble causing TX starvation
- **BUG #4-5**: TX backoff too long (`cmd_counter` 7→3), retransmit threshold too slow (62s→30s)
- **BUG #6**: Non-gateway ACK missing original `msg_id` — sender can't match ACK, retransmits until timeout
- **BUG #8**: DM text-ACK (`:ack`) doesn't clear ring buffer entry, causing retransmit despite successful delivery
- **BUG #9-12**: Ring buffer deadlock — done-slot accumulation, scan range exceeding active slots, premature slot clearing before CAD-wait rollback

### Key changes

- Relay messages marked fire-and-forget (`0xFF`) — only originating node retransmits
- Retry tracking with `retryCount[]` array (3 retries, 40s interval, 120s max)
- Removed `0x7F` retransmit-copy mechanism that flooded the 30-slot ring buffer
- CRC error diagnostics with RSSI/SNR/freq_err for collision diagnosis
- 13 `[MC-DBG]` debug messages for radio state visibility

### Files changed

- `src/esp32/esp32_main.cpp` — RX restart reordering, debug messages, ring buffer status
- `src/lora_functions.cpp` — retransmit logic, relay fire-and-forget, ACK msg_id fix, deadlock fix
- `src/loop_functions.cpp` — startsWith edge case, RX flag handling
- `src/loop_functions_extern.h` — `retryCount[]` declaration
- `src/udp_functions.cpp` — retryCount init for UDP-originated messages

## Test plan

- [ ] Verify bidirectional message delivery on a 2+ node MeshCom network
- [ ] Confirm relay nodes forward once without retransmitting
- [ ] Check that DM ACKs properly stop retransmission
- [ ] Monitor `[MC-DBG]` output for RING_OVERFLOW (should be 0)
- [ ] Verify no regression on gateway ACK behavior

Tested on Heltec WiFi LoRa 32 V3 with 3-node mesh (2 nodes + 1 gateway).