### PR TITLE
Port LoRa message loss fixes to nRF52/RAK4630

### DIFF
--- a/nRF-lora-doku.md
+++ b/nRF-lora-doku.md
@@ -1,0 +1,89 @@
+# nRF52/RAK4630: LoRa Nachrichtenverlust-Fixes
+
+Port der ESP32-Fixes aus PR #710 und PR #714 auf die nRF52/RAK4630-Plattform.
+
+## Hintergrund
+
+PR #710 und #714 haben 12+ Bugs behoben, die ~50% bidirektionalen Nachrichtenverlust auf ESP32 (Heltec V3) verursachten. Die meisten Fixes befinden sich im gemeinsamen Code (`lora_functions.cpp`, `loop_functions.cpp/h`, `udp_functions.cpp`) und wirken bereits auf beiden Plattformen.
+
+Was fehlte, waren die **plattformspezifischen Main-Loop-Verbesserungen** aus `esp32_main.cpp`, die hier fuer `nrf52_main.cpp` angepasst wurden.
+
+## Architekturunterschied ESP32 vs. nRF52
+
+- **ESP32**: Nutzt RadioLib mit Interrupt-Flags und Main-Loop-Polling
+- **nRF52**: Nutzt die RAK SX126x-Bibliothek mit direkten Callbacks aus dem Radio-IRQ
+
+Daher koennen nicht alle ESP32-Fixes 1:1 uebernommen werden — sie muessen an das RAK-Callback-Modell angepasst werden.
+
+## Bereits im Shared-Code vorhandene Fixes
+
+Diese Fixes aus PR #710/#714 sind bereits fuer nRF52 aktiv:
+
+| Bug | Beschreibung | Datei |
+|-----|-------------|-------|
+| BUG #3 | OnHeaderDetect setzt cmd_counter/tx_waiting nicht mehr zurueck | `lora_functions.cpp` |
+| BUG #4 | cmd_counter von 7 auf 3 reduziert | `lora_functions.cpp` |
+| BUG #5 | Retransmit-Schwelle angepasst | `lora_functions.cpp` |
+| BUG #6 | ACK msg_id Fix | `lora_functions.cpp` |
+| BUG #8 | DM-ACK loescht Ringpuffer | `loop_functions.cpp` |
+| BUG #9-12 | Ringpuffer-Deadlock-Fixes | `lora_functions.cpp` |
+| PR #714 BUG-01 | Retransmit-Mechanismus (Slot-Erhaltung, Full-Range-Scan, ACK-Slot-Freigabe) | `lora_functions.cpp` |
+| PR #714 BUG-02 | RING_OVERFLOW mit Puffernamen | `loop_functions.cpp/h` |
+
+## nRF52-spezifische Aenderungen
+
+### 1. Radio.Rx() an den Anfang von OnRxDone verschoben (BUG #2 Aequivalent)
+
+**Datei:** `src/lora_functions.cpp`
+
+**Problem:** `Radio.Rx(RX_TIMEOUT_VALUE)` wurde am Ende von `OnRxDone()` aufgerufen, nach ~800 Zeilen Paketverarbeitung. Das erzeugt ein RX-Blindfenster in dem eingehende Pakete verloren gehen.
+
+**Fix:** `Radio.Rx()` wird jetzt am Anfang von `OnRxDone()` aufgerufen (nach Sicherheitskopie des Payloads). Ein `#if defined BOARD_RAK4630` Guard stellt sicher, dass ESP32 nicht betroffen ist.
+
+**Warum Payload-Kopie:** Der `payload`-Zeiger kann auf den internen Radiopuffer zeigen, der durch `Radio.Rx()` ueberschrieben wird. Ein statischer Puffer (`rxPayloadCopy`) sichert die Daten vor dem Radio-Neustart.
+
+### 2. RING_STATUS periodischer Debug-Report
+
+**Datei:** `src/nrf52/nrf52_main.cpp`
+
+Alle 30 Sekunden wird (bei aktivem `bLORADEBUG`) ein Statusbericht des Ringpuffers ausgegeben: Anzahl wartender, wiederholender und abgeschlossener Eintraege sowie die aktuelle Queue-Laenge.
+
+### 3. Timeout-Handler mit is_receiving-Guard (BUG #1 Aequivalent)
+
+**Datei:** `src/nrf52/nrf52_main.cpp`
+
+**Problem:** Der bisherige Timeout-Handler setzte den Timer blind zurueck, was zu einer Race-Condition fuehren konnte: Header erkannt (`is_receiving=true`) aber Timeout feuert und unterbricht den laufenden Empfang.
+
+**Fix:** Wenn `is_receiving` aktiv ist, wird der Timer verlaengert statt zurueckgesetzt. Zusaetzlich wird bei tatsaechlichem Timeout `Radio.Rx()` neu gestartet als Sicherheitsmassnahme.
+
+### 4. TX_GATE_ENTER Debug-Ausgabe
+
+**Datei:** `src/nrf52/nrf52_main.cpp`
+
+Debug-Ausgabe vor `doTX()` zeigt Queue-Laenge, `cmd_counter` und `tx_waiting` Status.
+
+**Hinweis:** Anders als beim ESP32-Fix werden `cmd_counter` und `tx_waiting` hier NICHT zurueckgesetzt. nRF52 ruft `doTX()` bei jeder Loop-Iteration auf, daher funktioniert der CAD-Delay-Mechanismus bereits korrekt. Ausserdem wuerde das nRF52-spezifische `cmd_counter=50` fuer die Ethernet-DHCP-Pause kaputt gehen.
+
+## Geaenderte Dateien
+
+| Datei | Aenderung |
+|-------|-----------|
+| `src/lora_functions.cpp` | `Radio.Rx()` von Ende an Anfang von `OnRxDone()` verschoben |
+| `src/nrf52/nrf52_main.cpp` | RING_STATUS, Timeout-Handler, TX-Debug hinzugefuegt |
+| `nRF-lora-doku.md` | Diese Dokumentation |
+
+## Verifikation
+
+1. **Build RAK4631:** Kompilieren — keine Compile-Fehler
+2. **Build ESP32:** Fuer Heltec V3 kompilieren — keine Regression (Guards)
+3. **Serial-Debug** (`bLORADEBUG` aktivieren):
+   - `RX_RESTART_EARLY` bei jedem empfangenen Paket
+   - `RING_STATUS` alle 30s
+   - `RX_TIMEOUT_FIRE` / `RX_RESTART` bei Timeout-Events
+   - `TX_GATE_ENTER` vor Sendungen
+4. **Feldtest:** 2+ Node Mesh mit RAK4631, bidirektionale Nachrichtenzustellung pruefen
+
+## Referenzen
+
+- PR #710: Erste Runde der LoRa-Fixes (BUG #1-#12)
+- PR #714: Retransmit-Mechanismus-Reparatur und RING_OVERFLOW-Fix

--- a/src/lora_functions.cpp
+++ b/src/lora_functions.cpp
@@ -102,6 +102,20 @@ void OnRxDone(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr)
     // Debug I: OnRxDone timing — capture start time
     unsigned long _onrxdone_start = millis();
 
+#if defined BOARD_RAK4630
+    // FIX BUG #2 (nRF52): RX sofort neu starten um Blindfenster zu minimieren.
+    // Sicherheitskopie: Payload koennte auf internen Radiopuffer zeigen,
+    // der durch Radio.Rx() ueberschrieben wird.
+    static uint8_t rxPayloadCopy[UDP_TX_BUF_SIZE];
+    uint16_t rxSize = (size <= UDP_TX_BUF_SIZE) ? size : UDP_TX_BUF_SIZE;
+    memcpy(rxPayloadCopy, payload, rxSize);
+    payload = rxPayloadCopy;
+    size = rxSize;
+    Radio.Rx(RX_TIMEOUT_VALUE);
+    if(bLORADEBUG)
+        Serial.printf("[MC-DBG] RX_RESTART_EARLY src=OnRxDone\n");
+#endif
+
     // only for Test T5_EPAPER
     //bDisplayInfo=true;
 
@@ -911,10 +925,8 @@ void OnRxDone(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr)
         }
     }
 
-    #if defined BOARD_RAK4630
-        Radio.Rx(RX_TIMEOUT_VALUE);
-    #endif
-
+    // Note: Radio.Rx() for RAK4630 is now called at the beginning of OnRxDone
+    // to minimize the RX blind window (BUG #2 fix).
 
     // Debug I: ONRXDONE_TIME — measure processing duration
     if(bLORADEBUG)

--- a/src/nrf52/nrf52_main.cpp
+++ b/src/nrf52/nrf52_main.cpp
@@ -1030,29 +1030,60 @@ extern bool btimeClient;
         }
     }
 
+    // Periodischer Ringpuffer-Auslastungsbericht (alle 30s)
+    {
+        static unsigned long ring_status_timer = 0;
+        if(bLORADEBUG && (millis() - ring_status_timer) > 30000)
+        {
+            ring_status_timer = millis();
+            int pending = 0, retrying = 0, done = 0;
+            for(int i = 0; i < MAX_RING; i++)
+            {
+                if(ringBuffer[i][0] == 0) continue;
+                if(ringBuffer[i][1] == 0xFF) done++;
+                else if(ringBuffer[i][1] == 0x00) pending++;
+                else retrying++;
+            }
+            int queued = (iWrite >= iRead) ? (iWrite - iRead) : (MAX_RING - iRead + iWrite);
+            Serial.printf("[MC-DBG] RING_STATUS queued=%d pending=%d retrying=%d done=%d iW=%d iR=%d\n",
+                queued, pending, retrying, done, iWrite, iRead);
+        }
+    }
+
     if(iReceiveTimeOutTime > 0)
     {
-        // Timeout RECEIVE_TIMEOUT
         if((iReceiveTimeOutTime + RECEIVE_TIMEOUT) < millis())
         {
-            iReceiveTimeOutTime=0;
-
-            // LoRa preamble was detected
             if(bLORADEBUG)
+                Serial.printf("[MC-DBG] RX_TIMEOUT_FIRE ts=%lu last_event=%lu delta=%lu\n",
+                    millis(), iReceiveTimeOutTime, millis() - iReceiveTimeOutTime);
+
+            // BUG #1 Aequivalent: Wenn Header erkannt, ist Empfang moeglicherweise
+            // noch aktiv. Timer verlaengern statt zuruecksetzen.
+            if(is_receiving)
             {
-                Serial.printf("[SX12xx] Receive Timeout, starting receiving again ... \n");
+                iReceiveTimeOutTime = millis();
+                if(bLORADEBUG)
+                    Serial.printf("[MC-DBG] RX_TIMEOUT skipped: is_receiving=true\n");
+            }
+            else
+            {
+                iReceiveTimeOutTime = 0;
+                Radio.Rx(RX_TIMEOUT_VALUE);
+                if(bLORADEBUG)
+                    Serial.printf("[MC-DBG] RX_RESTART src=timeout\n");
             }
         }
     }
 
     if(iReceiveTimeOutTime == 0 && is_receiving == false && tx_is_active == false)
     {
-        // channel is free
-        // nothing was detected
-        // do not print anything, it just spams the console
         if (iWrite != iRead)
         {
-            // save transmission state between loops
+            if(bLORADEBUG)
+                Serial.printf("[MC-DBG] TX_GATE_ENTER qlen=%d cmd_ctr=%d tx_wait=%d\n",
+                    (iWrite >= iRead) ? (iWrite - iRead) : (MAX_RING - iRead + iWrite),
+                    cmd_counter, tx_waiting);
             doTX();
         }
     }


### PR DESCRIPTION
## Summary

- Port ESP32 main-loop improvements from PR #710 and #714 to the nRF52/RAK4630 platform
- Move `Radio.Rx()` to beginning of `OnRxDone()` to eliminate RX blind window during packet processing (BUG #2 equivalent)
- Add `is_receiving` guard to timeout handler to prevent race condition with active reception (BUG #1 equivalent)
- Add periodic RING_STATUS debug report and TX_GATE_ENTER debug output for diagnostics

All nRF52-specific changes are guarded with `#if defined BOARD_RAK4630` — no ESP32 regression.

### Architecture note

ESP32 uses RadioLib (interrupt flags, main-loop polling), nRF52 uses the RAK SX126x library (direct callbacks from radio IRQ). The ESP32 fixes were adapted to fit the RAK callback model rather than copied 1:1.

### Changed files

| File | Change |
|------|--------|
| `src/lora_functions.cpp` | `Radio.Rx()` moved from end to beginning of `OnRxDone()` with payload safety copy |
| `src/nrf52/nrf52_main.cpp` | RING_STATUS report, timeout handler with `is_receiving` guard, TX debug output |
| `nRF-lora-doku.md` | German documentation of all fixes |

## Test plan

- [ ] Build for RAK4631 target — no compile errors
- [ ] Build for Heltec V3 (ESP32) — no regression
- [ ] Enable `bLORADEBUG`, verify `[MC-DBG]` messages on RAK device: `RX_RESTART_EARLY`, `RING_STATUS`, `RX_TIMEOUT_FIRE`, `TX_GATE_ENTER`
- [ ] Field test: 2+ node mesh with RAK4631, verify bidirectional message delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)