### PR TITLE
Fix: max_hop bei UDP-zu-LoRa Gateway-Relay dekrementieren

### DIFF
--- a/src/udp_functions.cpp
+++ b/src/udp_functions.cpp
@@ -179,6 +179,18 @@ void getMeshComUDPpacket(unsigned char inc_udp_buffer[UDP_TX_BUF_SIZE], int pack
 
           bool bUDPtoLoraSend = true;
 
+          // Hop limit: treat UDP-to-LoRa relay same as LoRa mesh relay
+          if(aprsmsg.max_hop == 0)
+          {
+            if(bDisplayInfo)
+              Serial.printf("[UDP] DROP max_hop=0 msg_id=%08X src=%s\n", aprsmsg.msg_id, source_call);
+            bUDPtoLoraSend = false;
+          }
+          else
+          {
+            aprsmsg.max_hop--;
+          }
+
           if(msg_type_b == 0x21)
           {
             sendDisplayPosition(aprsmsg, 99, 0);


### PR DESCRIPTION
## Zusammenfassung

Der `max_hop`-Zähler wird beim LoRa-Mesh-Relay korrekt dekrementiert (`lora_functions.cpp:919-925`), aber **nicht** wenn ein Gateway eine Nachricht über UDP empfängt und ins LoRa-Mesh einspeist (`udp_functions.cpp`, `getMeshComUDPpacket()`).

Dadurch kann eine Nachricht beliebig viele Gateways durchlaufen und sogar Schleifen bilden.

## Beobachtung

Eine WX-Beacon-Nachricht (msg_id `691182BC`) von DG1GMY-23 wurde mit **7 Relay-Stationen** im Pfad empfangen, obwohl `max_hop_text = 4`:

```
Via: DB0AU-12, DB0HOB-12, DL3MBG-12, OE2XZR-12, DD7MH-11, DB0HOB-12, DB0ED-99
```

DB0HOB-12 erscheint **zweimal** — eine Schleife im Gateway-Netzwerk.

## Ursache

In `udp_functions.cpp` (`getMeshComUDPpacket()`) wird das vom Server empfangene Paket per `decodeAPRS()` dekodiert und direkt in den LoRa-TX-Ringbuffer geschrieben, **ohne `max_hop` zu prüfen oder zu dekrementieren**.

Die Hop-Begrenzung greift damit nur innerhalb eines einzelnen LoRa-Mesh-Segments zwischen zwei Gateways, nicht über das gesamte Netzwerk.

## Änderung

**`src/udp_functions.cpp`** — In `getMeshComUDPpacket()`, nach `decodeAPRS()` und vor der LoRa-Weiterleitung:

- Prüfe `max_hop == 0` → Nachricht nicht ins LoRa-Mesh einspeisen
- Sonst `max_hop--` → identisches Verhalten wie beim LoRa-Relay in `lora_functions.cpp`

Dies ist ein minimaler, gezielter Fix (12 Zeilen) analog zur bestehenden Relay-Logik.

## Referenz

- Issue: #741