### PR TITLE
Dependency-Update: RadioLib 7.6.0, NimBLE-Arduino 2.3.8

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -103,8 +103,8 @@ monitor_speed = 115200
 [esp32libs]
 lib_deps = 
 	WiFi
-	jgromes/RadioLib@7.1.2
-	h2zero/NimBLE-Arduino@2.2.3
+	jgromes/RadioLib@7.6.0
+	h2zero/NimBLE-Arduino@2.3.8
 	plerup/EspSoftwareSerial@^8.2.0
 	marian-craciunescu/ESP32Ping @ ^1.7
 

--- a/src/configuration_global.h
+++ b/src/configuration_global.h
@@ -1,7 +1,7 @@
 #define SOURCE_VERSION "4.35"
 #define SOURCE_VERSION_SUB "n"
 
-#define FLASH_VERSION 20260103
+#define FLASH_VERSION 20260304
 
 //Hardware Types
 #define TLORA_V2 1


### PR DESCRIPTION
## Zusammenfassung

Aktualisierung der beiden kritischen Kern-Dependencies **RadioLib** und **NimBLE-Arduino** auf die jeweils aktuelle stabile Version. Alle 4 Standard-Targets (Heltec V3, E22, T-Beam, T-Beam Supreme) kompilieren fehlerfrei.

## Dependency-Audit: Ist-Zustand aller Module

Vor dieser Änderung wurde ein vollständiges Audit aller Abhängigkeiten durchgeführt. Hier die Übersicht:

### Kern-Dependencies (LoRa / BLE / Plattform)

| Bibliothek | Bisherige Version | Aktuelle Version | Status |
|---|---|---|---|
| **RadioLib** | 7.1.2 | **7.6.0** | **4 Minor-Versionen zurück** |
| **NimBLE-Arduino** | 2.2.3 | **2.3.8** | **1 Minor + 8 Patches zurück** |
| espressif32 (Plattform) | ^6.12.0 | 6.13.0 | wird automatisch aufgelöst |
| SX126x-Arduino (nRF52) | ^2.0.30 | 2.0.32 | wird automatisch aufgelöst |

### Web / OTA Dependencies (nur Safeboot)

| Bibliothek | Bisherige Version | Aktuelle Version | Status |
|---|---|---|---|
| AsyncTCP | 3.2.14 | 3.3.2 | gepinnt, Breaking Changes → zurückgestellt |
| ESPAsyncWebServer | 3.3.23 | 3.6.0 | gepinnt, Breaking Changes → zurückgestellt |

### Display / Sensor / Utility-Bibliotheken

| Bibliothek | Bisherige Version | Aktuelle Version | Status |
|---|---|---|---|
| U8g2 | ^2.36.5 | 2.36.17 | wird automatisch aufgelöst |
| ArduinoJson | ^7.4.2 | 7.4.3 | wird automatisch aufgelöst (Security-Fix) |
| TinyGPSPlus | ^1.1.0 | 1.1.0 | aktuell |
| BMx280MI | ^1.2.3 | 1.2.3 | aktuell |
| Adafruit BME680 | ^2.0.5 | 2.0.6 | wird automatisch aufgelöst |
| Adafruit BMP3XX | 2.1.6 | 2.1.6 | aktuell |
| RTClib | ^2.1.4 | 2.1.4 | aktuell |
| OneButton | ^2.6.1 | 2.6.2 | wird automatisch aufgelöst |
| EspSoftwareSerial | ^8.2.0 | 8.2.0 | aktuell |
| SparkFun u-blox GNSS | GitHub HEAD | 2.2.28 | aktuell |

## Durchgeführte Änderungen

### 1. RadioLib: 7.1.2 → 7.6.0

**Datei:** `platformio.ini`, Zeile 106

**Gründe für das Update:**
- **Timing-Overflow-Fixes** (7.6.0): Integer-Überläufe in Timing-Funktionen wurden durch korrektes Type-Casting behoben. Das betrifft direkt die TX/RX-Zuverlässigkeit bei LoRa, dem Kern von MeshCom.
- **`calculateTimeOnAir()`-Methode** (7.3.0): Ermöglicht präzise Time-on-Air-Berechnung für Duty-Cycle-Management und Kanalauslastung.
- **LoRa Coding Rate 4/4 Support** (7.3.0): Erweiterte Konfigurationsmöglichkeiten.
- **HAL-Verbesserungen**: Pull-up/Pull-down Pin-Konfiguration konfigurierbar, diverse Plattform-Fixes.

**Risikobewertung:** GERING
- LoRaWAN-Breaking-Changes sind irrelevant, da MeshCom LoRaWAN explizit ausschließt (`-DRADIOLIB_EXCLUDE_LORAWAN=1`).
- Die entfernte Methode `getDataRate()` wird im ESP32-Code nicht verwendet.
- MeshCom nutzt ausschließlich LoRa P2P, das keine Breaking Changes hat.

### 2. NimBLE-Arduino: 2.2.3 → 2.3.8

**Datei:** `platformio.ini`, Zeile 107

**Gründe für das Update:**
- **ESP32 Init-Crash-Fix** (2.3.8): Behebt Abstürze bei der Initialisierung mit Arduino Core 3.3.7+ — wichtig für zukünftige Plattform-Upgrades.
- **Deinit-Crashes und Memory-Leaks** (2.3.8): Speicherlecks auf neueren ESP32-Varianten behoben.
- **Reduzierter IRAM-Verbrauch** (2.3.0): Wertvoll auf RAM-beschränkten ESP32-Modulen.
- **ESP32-C6/H2/C2-Support** (2.3.0): Ermöglicht zukünftige Hardware-Targets.
- **Max-Connections-Fix** (2.3.2): Verbindungen >4 wurden nicht korrekt angewendet.

**Risikobewertung:** GERING
- „Secure Connections standardmäßig deaktiviert" (2.3.2) — MeshCom ruft `setSecurityAuth()` explizit auf, daher keine Auswirkung.
- Custom GAP Handler Signaturänderung — wird in MeshCom nicht verwendet.

### 3. FLASH_VERSION aktualisiert

**Datei:** `src/configuration_global.h`, Zeile 4
- `FLASH_VERSION` von `20260103` auf `20260304` aktualisiert (heutiges Datum).

## Build-Ergebnisse

Alle 4 Standard-Targets kompilieren fehlerfrei:

| Target | RAM | Flash | Binary |
|---|---|---|---|
| Heltec V3 | 34.7% | 41.3% | 1,3 MB |
| E22 | 22.4% | 44.9% | 1,5 MB |
| T-Beam | 9.1% | 46.4% | 1,5 MB |
| T-Beam Supreme | 34.8% | 41.7% | 1,4 MB |

## Testplan

- [ ] LoRa TX/RX Funktionstest auf Hardware (P2P-Kommunikation zwischen Nodes)
- [ ] BLE-Verbindung mit MeshCom-App testen
- [ ] Langzeittest auf Stabilität (Memory-Leaks, Timing)