### PR TITLE
Add Ethernet support for T-ETH-ELITE and refactor network handling

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -21,6 +21,7 @@ default_envs =
 	E22_XML-DevKitC
 	E22_1268_S3-DevKitC-1-N16R8
 	E22_1262_S3-DevKitC-1-N16R8
+	T-ETH-ELITE_1262
 	ttgo-lora32-v21
 	ttgo_tbeam_SX1268
 	heltec_wifi_lora_32_V2

--- a/src/command_functions.cpp
+++ b/src/command_functions.cpp
@@ -2883,6 +2883,34 @@ void commandAction(char *umsg_text, bool ble)
         return;
     }
     else
+    // --- network or wifi mode ---
+    if(commandCheck(msg_text+2, (char*)"netmode wifi") == 0)
+    {
+        meshcom_settings.node_netmode = 0;
+
+        Serial.println("[CMD] netmode -> WiFi");
+
+        save_settings();
+
+        rebootAuto = millis() + 2000;
+
+        bReturn = true;
+    }
+    else
+    if(commandCheck(msg_text+2, (char*)"netmode eth") == 0)
+    {
+        meshcom_settings.node_netmode = 1;
+
+        Serial.println("[CMD] netmode -> Ethernet");
+        //Serial.printf("node_netmode=%d\n", meshcom_settings.node_netmode); // solo per debug
+
+        save_settings();
+
+        rebootAuto = millis() + 2000;
+
+        bReturn = true;
+    } 
+    else
     if(commandCheck(msg_text+2, (char*)"wifiap on") == 0)
     {
         bWIFIAP=true;

--- a/src/esp32/esp32_eth.cpp
+++ b/src/esp32/esp32_eth.cpp
@@ -1,0 +1,159 @@
+#include "esp32_eth.h"
+#include "esp32_flash.h"
+#include <configuration.h>
+
+void EspETH::initethDHCP()
+{
+    Serial.println("[ETH] init");
+
+    ETH.begin(
+        ETH_PHY_W5500,
+        1,
+        ETH_CS_PIN,
+        ETH_INT_PIN,
+        ETH_RST_PIN,
+        SPI3_HOST,
+        ETH_SCLK_PIN,
+        ETH_MISO_PIN,
+        ETH_MOSI_PIN
+    );
+
+    delay(1000);
+
+    Serial.println(ETH.linkUp() ? "[ETH] LINK UP" : "[ETH] LINK DOWN");
+
+    IPAddress cfg_ip;
+    cfg_ip.fromString(meshcom_settings.node_ownip);
+
+    // -----------------------------
+    // STATIC CONFIGURATION
+    // -----------------------------
+    if(cfg_ip != IPAddress(0,0,0,0))
+    {
+        IPAddress gw;
+        IPAddress mask;
+        IPAddress dns;
+
+        gw.fromString(meshcom_settings.node_owngw);
+        mask.fromString(meshcom_settings.node_ownms);
+        dns.fromString(meshcom_settings.node_owndns);
+
+        ETH.config(cfg_ip, gw, mask, dns);
+
+        Serial.print("[ETH] STATIC IP: ");
+        Serial.println(cfg_ip);
+
+        snprintf(meshcom_settings.node_ip, sizeof(meshcom_settings.node_ip), "%s", meshcom_settings.node_ownip);
+        snprintf(meshcom_settings.node_gw, sizeof(meshcom_settings.node_gw), "%s", meshcom_settings.node_owngw);
+        snprintf(meshcom_settings.node_dns, sizeof(meshcom_settings.node_dns), "%s", meshcom_settings.node_owndns);
+        snprintf(meshcom_settings.node_subnet, sizeof(meshcom_settings.node_subnet), "%s", meshcom_settings.node_ownms);
+
+        meshcom_settings.node_hasIPaddress = true;
+        Serial.printf("[ETH] node_hasIPaddress=%d\n", meshcom_settings.node_hasIPaddress);
+    }
+    else
+    {
+        // -----------------------------
+        // DHCP MODE
+        // -----------------------------
+        Serial.println("[ETH] DHCP mode");
+
+        IPAddress ip;
+
+        for(int i=0;i<50;i++)
+        {
+            ip = ETH.localIP();
+
+            if(ip[0] != 0)
+                break;
+
+            delay(200);
+        }
+
+        if(ip[0] != 0)
+        {
+            Serial.print("[ETH] DHCP IP: ");
+            Serial.println(ip);
+
+            meshcom_settings.node_hasIPaddress = true;
+
+            snprintf(meshcom_settings.node_ip, sizeof(meshcom_settings.node_ip),
+                "%i.%i.%i.%i", ip[0], ip[1], ip[2], ip[3]);
+
+            IPAddress gw = ETH.gatewayIP();
+            IPAddress dns = ETH.dnsIP();
+            IPAddress mask = ETH.subnetMask();
+
+            snprintf(meshcom_settings.node_gw, sizeof(meshcom_settings.node_gw),
+                "%i.%i.%i.%i", gw[0], gw[1], gw[2], gw[3]);
+
+            snprintf(meshcom_settings.node_dns, sizeof(meshcom_settings.node_dns),
+                "%i.%i.%i.%i", dns[0], dns[1], dns[2], dns[3]);
+
+            snprintf(meshcom_settings.node_subnet, sizeof(meshcom_settings.node_subnet),
+                "%i.%i.%i.%i", mask[0], mask[1], mask[2], mask[3]);
+        }
+        else
+        {
+            Serial.println("[ETH] DHCP failed -> fallback 192.168.4.1");
+
+            IPAddress ip(192,168,4,1);
+            IPAddress gw(192,168,4,1);
+            IPAddress mask(255,255,255,0);
+
+            ETH.config(ip, gw, mask);
+
+            meshcom_settings.node_hasIPaddress = true;
+        }
+    }
+
+    Udp.begin(EXTERN_PORT);
+}
+
+void EspETH::initethfixIP()
+{
+    Serial.println("[ETH] init FIX-IP");
+
+    ETH.begin();
+
+    delay(2000);
+
+    IPAddress ip = ETH.localIP();
+
+    if(ip[0] != 0)
+    {
+        Serial.print("[ETH] IP: ");
+        Serial.println(ip);
+        meshcom_settings.node_hasIPaddress = true;
+    }
+    else
+    {
+        Serial.println("[ETH] IP error");
+        meshcom_settings.node_hasIPaddress = true;
+    }
+
+    Udp.begin(EXTERN_PORT);
+}
+
+bool EspETH::sendUDP(uint8_t *buffer, uint16_t rx_buf_size)
+{
+    Udp.beginPacket(udp_dest_addr, EXTERN_PORT);
+
+    for(int i=0;i<rx_buf_size;i++)
+    {
+        Udp.write(buffer[i]);
+    }
+
+    return Udp.endPacket();
+}
+
+int EspETH::checkUDP()
+{
+    int packetSize = Udp.parsePacket();
+
+    if(packetSize <= 0)
+        return -1;
+
+    return 0;
+}
+

--- a/src/esp32/esp32_eth.h
+++ b/src/esp32/esp32_eth.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <Arduino.h>
+#include <configuration.h>
+#include <ETHClass2.h>
+#include <EthernetUdp.h>
+
+class EspETH {
+
+public:
+
+    void initethDHCP();
+    void initethfixIP();
+
+    bool sendUDP(uint8_t *buffer, uint16_t rx_buf_size);
+    int checkUDP();
+
+    // Ethernet IP state is managed by meshcom_settings.node_hasIPaddress
+    bool hasETHHardware = true;
+
+    IPAddress udp_dest_addr;
+
+private:
+
+    ETHClass2 ETH;
+    EthernetUDP Udp;
+
+};
+

--- a/src/esp32/esp32_flash.cpp
+++ b/src/esp32/esp32_flash.cpp
@@ -223,6 +223,9 @@ void init_flash(void)
     strVar = preferences.getString("node_owndns");
     snprintf(meshcom_settings.node_owndns, sizeof(meshcom_settings.node_owndns), "%s", strVar.c_str());
 
+    // Network Mode wifi/eth
+    meshcom_settings.node_netmode = preferences.getUChar("node_netmode", 0);
+
     preferences.end();
 }
 
@@ -441,6 +444,8 @@ void save_settings(void)
     strVar = meshcom_settings.node_owndns;
     preferences.putString("node_owndns", strVar); 
 
+    // Network Mode wifi/eth
+    preferences.putUChar("node_netmode", meshcom_settings.node_netmode);
 
     preferences.end();
 

--- a/src/esp32/esp32_flash.h
+++ b/src/esp32/esp32_flash.h
@@ -192,6 +192,8 @@ struct s_meshcom_settings
 	bool node_kbl_sync = true;
 	bool node_wifion = true;
 	#endif
+
+	uint8_t node_netmode = 0;   // 0 = WiFi, 1 = Ethernet
 };
 
 extern s_meshcom_settings meshcom_settings;

--- a/src/esp32/esp32_main.cpp
+++ b/src/esp32/esp32_main.cpp
@@ -14,6 +14,11 @@
 #include <SPI.h>
 #include <WiFi.h>
 
+#ifdef BOARD_T_ETH_ELITE
+#include "esp32_eth.h"
+SPIClass ethSPI(FSPI);
+#endif
+
 #include "esp32_gps.h"
 #include "esp32_flash.h"
 
@@ -144,6 +149,11 @@ bool bHeyFirst = true;
 bool bTeleFirst = true;
 
 bool bAllStarted = true;
+
+#ifdef BOARD_T_ETH_ELITE
+EspETH neth;
+bool bETHERNET = false;
+#endif
 
 String strTime;
 String strDate;
@@ -945,9 +955,9 @@ void esp32setup()
     #endif
 
 
-    #if defined (BOARD_TRACKER)
-        SPI.begin(RADIO_SCLK_PIN, RADIO_MISO_PIN, RADIO_MOSI_PIN);
-    #endif
+#if defined (BOARD_TRACKER)
+    SPI.begin(RADIO_SCLK_PIN, RADIO_MISO_PIN, RADIO_MOSI_PIN);
+#endif
 
     #if defined(BOARD_T5_EPAPER)
     // extra source
@@ -956,6 +966,10 @@ void esp32setup()
     #elif defined(BOARD_E220)
         Serial.print(F(" Initializing ... "));
         int state = radio.begin(434.0F, 125.0F, 9, 7, SYNC_WORD_SX127x, 10, LORA_PREAMBLE_LENGTH, /*float tcxoVoltage = 0*/ 1.6F, /*bool useRegulatorLDO = false*/ false);
+    #elif defined(BOARD_T_ETH_ELITE)
+    Serial.print(F(" Initializing ... "));
+    int state = radio.begin(433.175F);
+    radio.setDio2AsRfSwitch(true);
     #else
         Serial.print(F(" Initializing ... "));
         int state = radio.begin(433.175F);
@@ -1366,7 +1380,7 @@ void esp32setup()
     {
         bAllStarted=false;
 
-        if(!startWIFI())
+        if(!startNetwork())
         {
             Serial.println("[WIFI]...no connection");
             #if defined(BOARD_T_DECK) || defined(BOARD_T_DECK_PLUS)
@@ -1920,7 +1934,7 @@ void esp32loop()
                 if(bWEBSERVER)
                     stopWebserver();
 
-                startWIFI();
+                startNetwork();
 
                 ifalseping = 5;
                 
@@ -1935,7 +1949,7 @@ void esp32loop()
         }
     }
 
-    if(meshcom_settings.node_hasIPaddress)
+    if(meshcom_settings.node_netmode == 0 && meshcom_settings.node_hasIPaddress)
     {
         currentWiFiMillis = millis();
 
@@ -2666,7 +2680,7 @@ void esp32loop()
                         if(bWEBSERVER)
                             stopWebserver();
 
-                        startWIFI();
+                        startNetwork();
                     }
                     else
                     {
@@ -2699,6 +2713,13 @@ void esp32loop()
 
         if(bEXTUDP)
         {
+        #ifdef BOARD_T_ETH_ELITE
+            if(meshcom_settings.node_hasIPaddress == false)
+            {
+                neth.initethDHCP();
+            }
+        #endif
+
             startExternUDP();
         }
     }

--- a/src/extudp_functions.cpp
+++ b/src/extudp_functions.cpp
@@ -4,9 +4,15 @@
 #include <loop_functions.h>
 #include <debugconf.h>
 #include "ArduinoJson.h"
+#include <SPI.h>
 
-// WIFI
-#ifdef ESP32
+// WIFI and Ethernet
+#ifdef BOARD_T_ETH_ELITE
+  #include <ETHClass2.h>
+  #include <EthernetUdp.h>
+
+  ETHClass2 ETH;
+#elif defined(ESP32)
   #include <WiFi.h>
   #include <WiFiClient.h>
 #else
@@ -21,12 +27,15 @@ String s_extern_node_ip = "";
 String strExtOutput;
 String str_ip;
 
-#ifdef ESP32
+#ifdef BOARD_T_ETH_ELITE
+  IPAddress extern_node_ip;
+  EthernetUDP UdpExtern;
+#elif defined(ESP32)
   IPAddress extern_node_ip = IPAddress(0,0,0,0);
   WiFiUDP UdpExtern;
 #else
-  EthernetUDP UdpExtern;
   IPAddress extern_node_ip;
+  EthernetUDP UdpExtern;
 #endif
 
 unsigned char incomingExtPacket[UDP_TX_BUF_SIZE];  // buffer for incoming packets
@@ -35,6 +44,24 @@ int packetExtSize=0;
 // Extern JSON UDP
 void startExternUDP()
 {
+  #ifdef BOARD_T_ETH_ELITE
+    static bool ethStarted = false;
+
+   if(!ethStarted)
+   {
+      Serial.println("[ETH] starting ETHClass2");
+
+      ETH.begin();
+
+      delay(2000);
+
+      Serial.print("[ETH] IP: ");
+      Serial.println(ETH.localIP());
+
+      ethStarted = true;
+    }
+  #endif
+
   #ifdef ESP32
     if(bWIFIAP)
       return;
@@ -46,7 +73,9 @@ void startExternUDP()
   if(hasExternIPaddress)
     return;
 
-  #ifdef ESP32
+  #ifdef BOARD_T_ETH_ELITE
+  extern_node_ip = ETH.localIP();
+  #elif defined(ESP32)
     extern_node_ip = WiFi.localIP();
   #else
     extern_node_ip = Ethernet.localIP();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,7 +25,7 @@
 
 void setup()
 {
-  #if defined(BOARD_T5_EPAPER)
+    #if defined(BOARD_T5_EPAPER)
     if (psramInit()) {
         Serial.println("\nThe PSRAM is correctly initialized");
     } else {
@@ -33,9 +33,11 @@ void setup()
     }
   #endif
 
-  #if !defined(BOARD_T_ECHO) && !defined(BOARD_T_DECK) && !defined(BOARD_T_DECK_PLUS) && !defined(BOARD_T5_EPAPER) && !defined(BOARD_T_DECK_PRO)
-    SPI.begin();
-  #endif
+#if defined(BOARD_T_ETH_ELITE)
+  SPI.begin(SCK, MISO, MOSI, SX126x_CS);
+#elif !defined(BOARD_T_ECHO) && !defined(BOARD_T_DECK) && !defined(BOARD_T_DECK_PLUS) && !defined(BOARD_T5_EPAPER) && !defined(BOARD_T_DECK_PRO)
+  SPI.begin();
+#endif
 
   #if defined(BOARD_RAK4630)
     nrf52setup();

--- a/src/nrf52/nrf52_main.cpp
+++ b/src/nrf52/nrf52_main.cpp
@@ -1667,7 +1667,7 @@ if (isPhoneReady == 1)
                 stopWebserver();
 
                 if(!meshcom_settings.node_hasIPaddress)
-                    startWIFI();
+                    startNetwork();
             #endif
 
             if(bWEBSERVER)

--- a/src/t-deck/event_functions.cpp
+++ b/src/t-deck/event_functions.cpp
@@ -278,7 +278,7 @@ void btn_event_handler_setup_btn(lv_event_t * e)
             commandAction((char*)"--webserver on", false);
 
             // attempt to start WiFi immediately
-            startWIFI();
+            startNetwork();
         }
         else
         {

--- a/src/udp_functions.cpp
+++ b/src/udp_functions.cpp
@@ -14,6 +14,12 @@
 #include <lora_setchip.h>
 #include <configuration.h>
 #include "ArduinoJson.h"
+#include "web_functions/web_functions.h"
+
+#ifdef BOARD_T_ETH_ELITE
+#include "esp32/esp32_eth.h"
+extern EspETH neth;
+#endif
 
 String grc_ids;
 
@@ -44,8 +50,6 @@ String s_node_hostip = "";
 
 String strSource_call;
 
-bool hasIPaddress = false;
-
 extern bool hasExternIPaddress;
 
 WiFiUDP Udp;
@@ -72,10 +76,15 @@ void getMeshComUDP()
   if(bWIFIAP)
     return;
 
-  meshcom_settings.node_hasIPaddress = hasIPaddress;
-  
-  if(!hasIPaddress)
-    return;
+  // WiFi mode: sync runtime flag from WiFi state
+  // Ethernet mode: node_hasIPaddress is managed by esp32_eth.cpp
+  if(meshcom_settings.node_netmode == 0)
+  {
+      meshcom_settings.node_hasIPaddress = meshcom_settings.node_hasIPaddress;
+
+      if(!meshcom_settings.node_hasIPaddress)
+          return;
+  }
 
   ifalseping = 5;
 
@@ -391,7 +400,7 @@ void sendMeshComUDP()
     if(bWIFIAP)
       return;
 
-    if(!hasIPaddress)
+    if(!meshcom_settings.node_hasIPaddress)
       return;
 
     if(udpWrite != udpRead)
@@ -414,10 +423,14 @@ void sendMeshComUDP()
                 if (err_cnt_udp_tx >= MAX_ERR_UDP_TX)
                 {
                     // avoid TX and UDP
-                    hasIPaddress = false;
-                    meshcom_settings.node_hasIPaddress = hasIPaddress;
-                    //cmd_counter = 50;
+                    meshcom_settings.node_hasIPaddress = false;
 
+                    // WiFi mode: propagate WiFi state
+                    // Ethernet mode: node_hasIPaddress handled by esp32_eth.cpp
+                    if(meshcom_settings.node_netmode == 0)
+                        meshcom_settings.node_hasIPaddress = meshcom_settings.node_hasIPaddress;
+                    
+                    //cmd_counter = 50;
                     if(bDisplayCont)
                       Serial.println("[ERROR]...resetMeshComUDP");
 
@@ -462,8 +475,22 @@ void sendMeshComUDP()
 }
 
 
-bool startWIFI()
+  bool startNetwork()
 {
+  #if defined(HAS_ETHERNET)
+
+      if(meshcom_settings.node_netmode == 1)
+      {
+          Serial.println("[NET] Ethernet mode");
+
+          if(!meshcom_settings.node_hasIPaddress)
+              neth.initethDHCP();
+
+          return meshcom_settings.node_hasIPaddress;
+      }
+
+  #endif
+
   #if defined(BOARD_T_DECK) || defined(BOARD_T_DECK_PLUS)
   {
     if (!meshcom_settings.node_wifion)
@@ -476,10 +503,10 @@ bool startWIFI()
   }
   #endif
 
-  if(hasIPaddress)
+  if(meshcom_settings.node_netmode == 0 && meshcom_settings.node_hasIPaddress)
   {
     if (bDEBUG)
-        Serial.println("[WIFI]...hasIPaddress=true");
+        Serial.println("[WIFI]...meshcom_settings.node_hasIPaddress=true");
 
     return false;
   }
@@ -492,7 +519,7 @@ bool startWIFI()
     WiFi.disconnect(true, true);
     delay(500);
 
-    hasIPaddress=false;
+    meshcom_settings.node_hasIPaddress=false;
 
     WiFi.mode(WIFI_AP);
     WiFi.softAP(meshcom_settings.node_call);
@@ -526,7 +553,7 @@ bool startWIFI()
   WiFi.disconnect(true, true);
 	delay(500);
 
-  hasIPaddress=false;
+  meshcom_settings.node_hasIPaddress=false;
 
   // Scan for AP with best RSSI
 	int nrAps = WiFi.scanNetworks();
@@ -642,7 +669,7 @@ bool checkWifiPing()
   if(bWIFIAP)
     return true;
 
-  if(hasIPaddress)
+  if(meshcom_settings.node_hasIPaddress)
   {
     if(!Ping.ping(meshcom_settings.node_gw))
     {
@@ -656,9 +683,12 @@ bool checkWifiPing()
 
         WiFi.disconnect(true, true);
 
-        hasIPaddress=false;
+        meshcom_settings.node_hasIPaddress=false;
 
-        meshcom_settings.node_hasIPaddress = hasIPaddress;
+        // WiFi mode: propagate WiFi state
+        // Ethernet mode: node_hasIPaddress handled by esp32_eth.cpp
+        if(meshcom_settings.node_netmode == 0)
+            meshcom_settings.node_hasIPaddress = meshcom_settings.node_hasIPaddress;
       }
 
       return false;
@@ -688,7 +718,7 @@ String udpUpdateTimeClient()
 
       WiFi.disconnect(true, true);
 
-      hasIPaddress=false;
+      meshcom_settings.node_hasIPaddress=false;
       
       return "none";
     }
@@ -793,20 +823,20 @@ void startMeshComUDP()
 
     if(strcmp(s_node_ip.c_str(), "0.0.0.0") == 0)
     {
-      hasIPaddress=false;
+      meshcom_settings.node_hasIPaddress=false;
       Serial.printf("[WIFI]..not connected for UDP port %d\n",  LOCAL_PORT);
     }
     else
     {
-      hasIPaddress=true;
+      meshcom_settings.node_hasIPaddress=true;
       ifalseping=5;
 
       Serial.printf("[WIFI]...now listening at IP %s, UDP port %d\n",  s_node_ip.c_str(), LOCAL_PORT);
     }
 
-    meshcom_settings.node_hasIPaddress = hasIPaddress;
+    meshcom_settings.node_hasIPaddress = meshcom_settings.node_hasIPaddress;
 
-    if(hasIPaddress)
+    if(meshcom_settings.node_hasIPaddress)
     {
       ifalseping = 5;
 
@@ -871,7 +901,7 @@ void startMeshComUDP()
     Serial.print("[WIFIAP]...node_ip ");
     Serial.println(node_ip);
   
-    hasIPaddress=true;
+    meshcom_settings.node_hasIPaddress=true;
     ifalseping=5;
   }
 
@@ -880,19 +910,19 @@ void startMeshComUDP()
 
 void sendMeshComHeartbeat()
 {
-    if(!hasIPaddress)
+    if(!meshcom_settings.node_hasIPaddress)
     {
       waitRestartUDP--;
 
       if(waitRestartUDP > 0)
         return;
 
-      if(!startWIFI())
+      if(!startNetwork())
         return;
 
       startMeshComUDP();
 
-      if(!hasIPaddress)
+      if(!meshcom_settings.node_hasIPaddress)
       {
         waitRestartUDPCounter++;
 
@@ -919,7 +949,7 @@ void resetMeshComUDP()
 
   WiFi.disconnect(true, true);
 
-  hasIPaddress=false;
+  meshcom_settings.node_hasIPaddress=false;
 
   if(bGATEWAY || bWEBSERVER)
   {
@@ -1000,7 +1030,7 @@ void addNodeData(uint8_t msg_buffer[UDP_TX_BUF_SIZE], uint16_t size, int16_t rss
 {
   #ifdef ESP32
   
-  if(!hasIPaddress)
+  if(!meshcom_settings.node_hasIPaddress)
     return;
     
   #endif

--- a/src/udp_functions.h
+++ b/src/udp_functions.h
@@ -5,7 +5,7 @@
 #include <loop_functions_extern.h>
 
 // WIFI functions
-bool startWIFI();
+bool startNetwork();
 bool doWiFiConnect();
 String udpUpdateTimeClient();
 String udpGetTimeClient();

--- a/src/web_functions/web_functions.cpp
+++ b/src/web_functions/web_functions.cpp
@@ -56,24 +56,33 @@ void startWebserver()
 {
     if (bweb_server_running)
         return;
+    #ifdef HAS_ETHERNET
+    if (meshcom_settings.node_netmode == 0)
+    {
+        if (strlen(meshcom_settings.node_ip) < 7 && !bWIFIAP)
+        {
+            return;
+        }
+    }
+    #else
     if (strlen(meshcom_settings.node_ip) < 7 && !bWIFIAP)
     {
-        /*
-        if(bDEBUG)
-        {
-            Serial.print("[WEB]...no ip set :");
-            Serial.println(meshcom_settings.node_ip);
-        }
-         */
         return;
     }
+    #endif
 
 #ifdef ESP32
     // Check if WiFi is actually connected or AP is active before trying to start MDNS
     bool is_connected = (WiFi.status() == WL_CONNECTED);
     bool is_ap_active = (WiFi.getMode() == WIFI_MODE_AP) || (WiFi.getMode() == WIFI_MODE_APSTA);
 
-    if (!is_connected && !is_ap_active)
+    #ifdef HAS_ETHERNET
+    bool ethernet_mode = (meshcom_settings.node_netmode == 1);
+    #else
+    bool ethernet_mode = false;
+    #endif
+
+    if (!is_connected && !is_ap_active && !ethernet_mode)
     {
         return;
     }
@@ -133,17 +142,20 @@ void loopWebserver()
     if (!bweb_server_running)
         return;
 
+    #ifdef HAS_ETHERNET
+    if (meshcom_settings.node_netmode == 0)
+    {
+        if (strlen(meshcom_settings.node_ip) < 7)
+        {
+            return;
+        }
+    }
+    #else
     if (strlen(meshcom_settings.node_ip) < 7)
     {
-        /*
-        if(bDEBUG)
-        {
-            Serial.print("[WEBLOOP]...no ip set :");
-            Serial.println(meshcom_settings.node_ip);
-        }
-        */
         return;
     }
+    #endif
 
     web_client = web_server.available(); // Create a client connection.
 
@@ -1033,6 +1045,7 @@ void sub_page_setup()
     _create_setup_textinput_element("extudp", "ext. UDP IP", String(meshcom_settings.node_extern), "192.168.100.100", "extudpip", 50, false, false); // create Textinput-Element including Label and Button
 
     web_client.println("</div><div class=\"grid grid2\">");
+    _create_setup_switch_element("netmode", "Ethernet Mode", "switch between WiFi and Ethernet", meshcom_settings.node_netmode == 1);
     _create_setup_switch_element("extudp", "ext UDP", "enable ext. UDP", bEXTUDP); // create Switch-Element inclucing Label and Description
     _create_setup_switch_element("gateway", "Gateway", "enable gateway", bGATEWAY);   // create Switch-Element inclucing Label and Description
 
@@ -1408,34 +1421,40 @@ void sub_page_info()
     web_client.printf("<tr><td>Spreading Factor (SF)</td><td>%i</td></tr>\n", getSF());
     web_client.printf("<tr><td>Coding Rate (CR)</td><td>%i</td></tr>\n", getCR());
     web_client.printf("<tr><td>TX Power</td><td>%i dBm (%.2f mW)</td></tr>\n", getPower(), 1000 * powf(10, ((float)getPower() - 30) / 10));
+    web_client.printf("<tr><td>Netmode</td><td>%s</td></tr>\n", (meshcom_settings.node_netmode == 1 ? "Ethernet" : "WiFi"));
 
-#ifndef BOARD_RAK4630
-    if (bWIFIAP)
-        web_client.printf("<tr><td>WiFi SSID</td><td>%s</td></tr>\n", cBLEName);
-    else
-        web_client.printf("<tr><td>WiFi SSID</td><td>%s</td></tr>\n", meshcom_settings.node_ssid);
-    web_client.printf("<tr><td>WiFi AP</td><td>%s</td></tr>\n", (bWIFIAP ? "yes" : "no"));
+    #ifndef BOARD_RAK4630
+    if(meshcom_settings.node_netmode == 0)
+    {
+        if (bWIFIAP)
+            web_client.printf("<tr><td>WiFi SSID</td><td>%s</td></tr>\n", cBLEName);
+        else
+            web_client.printf("<tr><td>WiFi SSID</td><td>%s</td></tr>\n", meshcom_settings.node_ssid);
 
-    web_client.printf("<tr><td>WiFi RSSI</td><td>%i</td></tr>\n", WiFi.RSSI()); 
-    web_client.printf("<tr><td>WiFi POWER SET</td><td>%i dBm\n</td></tr>\n", WiFi.getTxPower()/4);
-#endif
+        web_client.printf("<tr><td>WiFi AP</td><td>%s</td></tr>\n", (bWIFIAP ? "yes" : "no"));
+        web_client.printf("<tr><td>WiFi RSSI</td><td>%i</td></tr>\n", WiFi.RSSI()); 
+        web_client.printf("<tr><td>WiFi POWER SET</td><td>%i dBm\n</td></tr>\n", WiFi.getTxPower()/4);
+    }
+    #endif
 
     // wenn WIFI unterbrochen wird
     // if(meshcom_settings.node_hasIPaddress && strcmp(meshcom_settings.node_ip, "0.0.0.0") == 0)
     //    meshcom_settings.node_hasIPaddress = false;
-    // web_client.printf("<tr><td><b>hasIpAddress</b></td><td>%s</td></tr>\n", (meshcom_settings.node_hasIPaddress?"yes":"no"));
-
+    //    web_client.printf("<tr><td><b>hasIpAddress</b></td><td>%s</td></tr>\n", (meshcom_settings.node_hasIPaddress?"yes":"no"));
+    
     web_client.printf("<tr><td>hasIpAddress</td><td>%s</td></tr>\n", (meshcom_settings.node_hasIPaddress ? "yes" : "no"));
 
     if (meshcom_settings.node_hasIPaddress)
     {
         web_client.printf("<tr><td>IP address</td><td>%s</td></tr>\n", meshcom_settings.node_ip);
+        web_client.printf("<tr><td>SUB-MASK</td><td>%s</td></tr>\n", meshcom_settings.node_subnet);
+
         if (!bWIFIAP)
         {
             web_client.printf("<tr><td>GW address</td><td>%s</td></tr>\n", meshcom_settings.node_gw);
             web_client.printf("<tr><td>DNS address</td><td>%s</td></tr>\n", meshcom_settings.node_dns);
         }
-        web_client.printf("<tr><td>SUB-MASK</td><td>%s</td></tr>\n", meshcom_settings.node_subnet);
+    
     }
 
     if (bINA226ON)

--- a/src/web_functions/web_setup.cpp
+++ b/src/web_functions/web_setup.cpp
@@ -35,6 +35,22 @@ void webSetup_setParam(setupStruct *setupData){
         return;
     } else
 
+    if(setupData->paramName.equals("netmode")) {
+
+        if(setupData->paramValue.equals("on")) {
+            snprintf(message_text, sizeof(message_text), "--netmode eth");
+        } else {
+            snprintf(message_text, sizeof(message_text), "--netmode wifi");
+        }
+
+        commandAction(message_text, bPhoneReady);
+
+        setupData->returnCode = WS_RETURNCODE_OKAY;
+        setupData->returnValue = meshcom_settings.node_netmode == 1 ? "eth" : "wifi";
+        return;
+
+    } else
+
     if(setupData->paramName.equals("setcall")) {        
         snprintf(message_text, sizeof(message_text), "--setcall %s", setupData->paramValue.c_str());                   // set command string
         commandAction(message_text, bPhoneReady);                                                                      // try to execute the command

--- a/variants/T-ETH-ELITE_1262/configuration.h
+++ b/variants/T-ETH-ELITE_1262/configuration.h
@@ -1,0 +1,93 @@
+/*
+definitions for LILYGO T-ETH-Elite S3 + SX1262 shield
+*/
+
+#pragma once
+
+#include <Arduino.h>
+#include <configuration_global.h>
+
+#define HAS_ETHERNET
+
+// Manteniamo compatibilità MeshCom
+#define MODUL_HARDWARE ESP32_S3_EBYTE_E22
+
+// Frequenze
+#define RF_FREQUENCY 433.175000
+#define LORA_APRS_FREQUENCY 433.775000
+#define BOARD_COUNTRY 8
+
+// GPS
+#define ENABLE_GPS
+#define GPS_RESET_MODE 1
+#define GPS_L76K
+
+// Radio
+#define SX126x_V3
+#define SX1262_E22
+
+#define CURRENT_LIMIT 140
+#define TX_POWER_MAX 22
+#define TX_POWER_MIN 2
+#define LORA_PREAMBLE_LENGTH DEFAULT_PREAMPLE_LENGTH
+#define WAIT_TX 5
+#define TX_OUTPUT_POWER 22
+#define LORA_CR 6
+#define LORA_BANDWIDTH 125
+#define LORA_SF 11
+
+// GPIO
+#define ANALOG_PIN 7
+#define ANALOG_REFRESH_INTERVAL 30
+
+#define BATTERY_PIN 2
+#define ADC_MULTIPLIER 1
+
+#define BUTTON_PIN 0
+#define BUTTON_EXT -1
+
+#define LED_PIXEL 0
+#define LED_PIN 38
+#define BOARD_LED 1
+
+#define OneWire_GPIO -1
+
+#define GPS_TX_PIN 42
+#define GPS_RX_PIN 39
+
+// I2C
+#define I2C_SDA 17
+#define I2C_SCL 18
+
+// SPI radio
+#define SCK 10
+#define MISO 9
+#define MOSI 11
+#define SS 40
+
+// =========================
+// Ethernet W5500 (T-ETH-ELITE)
+#define ETH_CS_PIN    45
+#define ETH_INT_PIN   14
+#define ETH_RST_PIN   16
+#define ETH_SCLK_PIN  48
+#define ETH_MISO_PIN  47
+#define ETH_MOSI_PIN  21
+
+// E22 compatibility
+#define E22_RXEN -1
+#define E22_TXEN -1
+
+#define E22_DIO1 8
+#define E22_BUSY 16
+#define E22_NRST 46
+
+#define E22_SCK SCK
+#define E22_NSS SS
+#define LORA_RST E22_NRST
+
+// SX126x mapping
+#define SX126x_CS    E22_NSS
+#define SX126x_IRQ   E22_DIO1
+#define SX126x_RST   E22_NRST
+#define SX126x_GPIO  E22_BUSY

--- a/variants/T-ETH-ELITE_1262/lv_conf.h
+++ b/variants/T-ETH-ELITE_1262/lv_conf.h
@@ -1,0 +1,713 @@
+/**
+ * @file lv_conf.h
+ * Configuration file for v8.3.0-dev
+ */
+
+/*
+ * Copy this file as `lv_conf.h`
+ * 1. simply next to the `lvgl` folder
+ * 2. or any other places and
+ *    - define `LV_CONF_INCLUDE_SIMPLE`
+ *    - add the path as include path
+ */
+
+/* clang-format off */
+#if 1 /*Set it to "1" to enable content*/
+
+#ifndef LV_CONF_H
+#define LV_CONF_H
+
+#include <stdint.h>
+
+/*====================
+   COLOR SETTINGS
+ *====================*/
+
+/*Color depth: 1 (1 byte per pixel), 8 (RGB332), 16 (RGB565), 32 (ARGB8888)*/
+#define LV_COLOR_DEPTH 16
+
+/*Swap the 2 bytes of RGB565 color. Useful if the display has an 8-bit interface (e.g. SPI)*/
+#define LV_COLOR_16_SWAP 1
+
+/*Enable more complex drawing routines to manage screens transparency.
+ *Can be used if the UI is above another layer, e.g. an OSD menu or video player.
+ *Requires `LV_COLOR_DEPTH = 32` colors and the screen's `bg_opa` should be set to non LV_OPA_COVER value*/
+#define LV_COLOR_SCREEN_TRANSP 0
+
+/* Adjust color mix functions rounding. GPUs might calculate color mix (blending) differently.
+ * 0: round down, 64: round up from x.75, 128: round up from half, 192: round up from x.25, 254: round up */
+#define LV_COLOR_MIX_ROUND_OFS (LV_COLOR_DEPTH == 32 ? 0: 128)
+
+/*Images pixels with this color will not be drawn if they are chroma keyed)*/
+#define LV_COLOR_CHROMA_KEY lv_color_hex(0x00ff00)         /*pure green*/
+
+/*=========================
+   MEMORY SETTINGS
+ *=========================*/
+
+/*1: use custom malloc/free, 0: use the built-in `lv_mem_alloc()` and `lv_mem_free()`*/
+#define LV_MEM_CUSTOM 1
+#if LV_MEM_CUSTOM == 0
+/*Size of the memory available for `lv_mem_alloc()` in bytes (>= 2kB)*/
+#define LV_MEM_SIZE (48U * 1024U)          /*[bytes]*/
+
+/*Set an address for the memory pool instead of allocating it as a normal array. Can be in external SRAM too.*/
+#define LV_MEM_ADR 0     /*0: unused*/
+/*Instead of an address give a memory allocator that will be called to get a memory pool for LVGL. E.g. my_malloc*/
+#if LV_MEM_ADR == 0
+//#define LV_MEM_POOL_INCLUDE your_alloc_library  /* Uncomment if using an external allocator*/
+//#define LV_MEM_POOL_ALLOC   your_alloc          /* Uncomment if using an external allocator*/
+#endif
+
+#else       /*LV_MEM_CUSTOM*/
+#define LV_MEM_CUSTOM_INCLUDE <stdlib.h>   /*Header for the dynamic memory function*/
+#define LV_MEM_CUSTOM_ALLOC   malloc
+#define LV_MEM_CUSTOM_FREE    free
+#define LV_MEM_CUSTOM_REALLOC realloc
+#endif     /*LV_MEM_CUSTOM*/
+
+/*Number of the intermediate memory buffer used during rendering and other internal processing mechanisms.
+ *You will see an error log message if there wasn't enough buffers. */
+#define LV_MEM_BUF_MAX_NUM 10
+
+/*Use the standard `memcpy` and `memset` instead of LVGL's own functions. (Might or might not be faster).*/
+#define LV_MEMCPY_MEMSET_STD 0
+
+/*====================
+   HAL SETTINGS
+ *====================*/
+
+/*Default display refresh period. LVG will redraw changed areas with this period time*/
+#define LV_DISP_DEF_REFR_PERIOD 16      /*[ms]*/
+
+/*Input device read period in milliseconds*/
+#define LV_INDEV_DEF_READ_PERIOD 30     /*[ms]*/
+
+/*Use a custom tick source that tells the elapsed time in milliseconds.
+ *It removes the need to manually update the tick with `lv_tick_inc()`)*/
+#define LV_TICK_CUSTOM 1
+#if LV_TICK_CUSTOM
+#define LV_TICK_CUSTOM_INCLUDE "Arduino.h"         /*Header for the system time function*/
+#define LV_TICK_CUSTOM_SYS_TIME_EXPR (millis())    /*Expression evaluating to current system time in ms*/
+#endif   /*LV_TICK_CUSTOM*/
+
+/*Default Dot Per Inch. Used to initialize default sizes such as widgets sized, style paddings.
+ *(Not so important, you can adjust it to modify default sizes and spaces)*/
+#define LV_DPI_DEF 130     /*[px/inch]*/
+
+/*=======================
+ * FEATURE CONFIGURATION
+ *=======================*/
+
+/*-------------
+ * Drawing
+ *-----------*/
+
+/*Enable complex draw engine.
+ *Required to draw shadow, gradient, rounded corners, circles, arc, skew lines, image transformations or any masks*/
+#define LV_DRAW_COMPLEX 1
+#if LV_DRAW_COMPLEX != 0
+
+/*Allow buffering some shadow calculation.
+*LV_SHADOW_CACHE_SIZE is the max. shadow size to buffer, where shadow size is `shadow_width + radius`
+*Caching has LV_SHADOW_CACHE_SIZE^2 RAM cost*/
+#define LV_SHADOW_CACHE_SIZE 0
+
+/* Set number of maximally cached circle data.
+* The circumference of 1/4 circle are saved for anti-aliasing
+* radius * 4 bytes are used per circle (the most often used radiuses are saved)
+* 0: to disable caching */
+#define LV_CIRCLE_CACHE_SIZE 4
+#endif /*LV_DRAW_COMPLEX*/
+
+/*Default image cache size. Image caching keeps the images opened.
+ *If only the built-in image formats are used there is no real advantage of caching. (I.e. if no new image decoder is added)
+ *With complex image decoders (e.g. PNG or JPG) caching can save the continuous open/decode of images.
+ *However the opened images might consume additional RAM.
+ *0: to disable caching*/
+#define LV_IMG_CACHE_DEF_SIZE   0
+
+/*Number of stops allowed per gradient. Increase this to allow more stops.
+ *This adds (sizeof(lv_color_t) + 1) bytes per additional stop*/
+#define LV_GRADIENT_MAX_STOPS       2
+
+/*Default gradient buffer size.
+ *When LVGL calculates the gradient "maps" it can save them into a cache to avoid calculating them again.
+ *LV_GRAD_CACHE_DEF_SIZE sets the size of this cache in bytes.
+ *If the cache is too small the map will be allocated only while it's required for the drawing.
+ *0 mean no caching.*/
+#define LV_GRAD_CACHE_DEF_SIZE      0
+
+/*Allow dithering the gradients (to achieve visual smooth color gradients on limited color depth display)
+ *LV_DITHER_GRADIENT implies allocating one or two more lines of the object's rendering surface
+ *The increase in memory consumption is (32 bits * object width) plus 24 bits * object width if using error diffusion */
+#define LV_DITHER_GRADIENT      0
+#if LV_DITHER_GRADIENT
+/*Add support for error diffusion dithering.
+ *Error diffusion dithering gets a much better visual result, but implies more CPU consumption and memory when drawing.
+ *The increase in memory consumption is (24 bits * object's width)*/
+#define LV_DITHER_ERROR_DIFFUSION   0
+#endif
+
+/*Maximum buffer size to allocate for rotation.
+ *Only used if software rotation is enabled in the display driver.*/
+#define LV_DISP_ROT_MAX_BUF (10*1024)
+
+/*-------------
+ * GPU
+ *-----------*/
+
+/*Use Arm's 2D acceleration library Arm-2D */
+#define LV_USE_GPU_ARM2D 0
+
+/*Use STM32's DMA2D (aka Chrom Art) GPU*/
+#define LV_USE_GPU_STM32_DMA2D 0
+#if LV_USE_GPU_STM32_DMA2D
+/*Must be defined to include path of CMSIS header of target processor
+e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
+#define LV_GPU_DMA2D_CMSIS_INCLUDE
+#endif
+
+/*Use NXP's PXP GPU iMX RTxxx platforms*/
+#define LV_USE_GPU_NXP_PXP 0
+#if LV_USE_GPU_NXP_PXP
+/*1: Add default bare metal and FreeRTOS interrupt handling routines for PXP (lv_gpu_nxp_pxp_osa.c)
+*   and call lv_gpu_nxp_pxp_init() automatically during lv_init(). Note that symbol SDK_OS_FREE_RTOS
+*   has to be defined in order to use FreeRTOS OSA, otherwise bare-metal implementation is selected.
+*0: lv_gpu_nxp_pxp_init() has to be called manually before lv_init()
+*/
+#define LV_USE_GPU_NXP_PXP_AUTO_INIT 0
+#endif
+
+/*Use NXP's VG-Lite GPU iMX RTxxx platforms*/
+#define LV_USE_GPU_NXP_VG_LITE 0
+
+/*Use SDL renderer API*/
+#define LV_USE_GPU_SDL 0
+#if LV_USE_GPU_SDL
+#define LV_GPU_SDL_INCLUDE_PATH <SDL2/SDL.h>
+/*Texture cache size, 8MB by default*/
+#define LV_GPU_SDL_LRU_SIZE (1024 * 1024 * 8)
+/*Custom blend mode for mask drawing, disable if you need to link with older SDL2 lib*/
+#define LV_GPU_SDL_CUSTOM_BLEND_MODE (SDL_VERSION_ATLEAST(2, 0, 6))
+#endif
+
+/*-------------
+ * Logging
+ *-----------*/
+
+/*Enable the log module*/
+#define LV_USE_LOG 0
+#if LV_USE_LOG
+
+/*How important log should be added:
+*LV_LOG_LEVEL_TRACE       A lot of logs to give detailed information
+*LV_LOG_LEVEL_INFO        Log important events
+*LV_LOG_LEVEL_WARN        Log if something unwanted happened but didn't cause a problem
+*LV_LOG_LEVEL_ERROR       Only critical issue, when the system may fail
+*LV_LOG_LEVEL_USER        Only logs added by the user
+*LV_LOG_LEVEL_NONE        Do not log anything*/
+#define LV_LOG_LEVEL LV_LOG_LEVEL_WARN
+
+/*1: Print the log with 'printf';
+*0: User need to register a callback with `lv_log_register_print_cb()`*/
+#define LV_LOG_PRINTF 1
+
+/*Enable/disable LV_LOG_TRACE in modules that produces a huge number of logs*/
+#define LV_LOG_TRACE_MEM        1
+#define LV_LOG_TRACE_TIMER      1
+#define LV_LOG_TRACE_INDEV      1
+#define LV_LOG_TRACE_DISP_REFR  1
+#define LV_LOG_TRACE_EVENT      1
+#define LV_LOG_TRACE_OBJ_CREATE 1
+#define LV_LOG_TRACE_LAYOUT     1
+#define LV_LOG_TRACE_ANIM       1
+
+#endif  /*LV_USE_LOG*/
+
+/*-------------
+ * Asserts
+ *-----------*/
+
+/*Enable asserts if an operation is failed or an invalid data is found.
+ *If LV_USE_LOG is enabled an error message will be printed on failure*/
+#define LV_USE_ASSERT_NULL          1   /*Check if the parameter is NULL. (Very fast, recommended)*/
+#define LV_USE_ASSERT_MALLOC        1   /*Checks is the memory is successfully allocated or no. (Very fast, recommended)*/
+#define LV_USE_ASSERT_STYLE         0   /*Check if the styles are properly initialized. (Very fast, recommended)*/
+#define LV_USE_ASSERT_MEM_INTEGRITY 0   /*Check the integrity of `lv_mem` after critical operations. (Slow)*/
+#define LV_USE_ASSERT_OBJ           0   /*Check the object's type and existence (e.g. not deleted). (Slow)*/
+
+/*Add a custom handler when assert happens e.g. to restart the MCU*/
+#define LV_ASSERT_HANDLER_INCLUDE <stdint.h>
+#define LV_ASSERT_HANDLER while(1);   /*Halt by default*/
+
+/*-------------
+ * Others
+ *-----------*/
+
+/*1: Show CPU usage and FPS count*/
+#define LV_USE_PERF_MONITOR 0
+#if LV_USE_PERF_MONITOR
+#define LV_USE_PERF_MONITOR_POS LV_ALIGN_BOTTOM_RIGHT
+#endif
+
+/*1: Show the used memory and the memory fragmentation
+ * Requires LV_MEM_CUSTOM = 0*/
+#define LV_USE_MEM_MONITOR 0
+#if LV_USE_MEM_MONITOR
+#define LV_USE_MEM_MONITOR_POS LV_ALIGN_BOTTOM_LEFT
+#endif
+
+/*1: Draw random colored rectangles over the redrawn areas*/
+#define LV_USE_REFR_DEBUG 0
+
+/*Change the built in (v)snprintf functions*/
+#define LV_SPRINTF_CUSTOM 0
+#if LV_SPRINTF_CUSTOM
+#define LV_SPRINTF_INCLUDE <stdio.h>
+#define lv_snprintf  snprintf
+#define lv_vsnprintf vsnprintf
+#else   /*LV_SPRINTF_CUSTOM*/
+#define LV_SPRINTF_USE_FLOAT 0
+#endif  /*LV_SPRINTF_CUSTOM*/
+
+#define LV_USE_USER_DATA 1
+
+/*Garbage Collector settings
+ *Used if lvgl is bound to higher level language and the memory is managed by that language*/
+#define LV_ENABLE_GC 0
+#if LV_ENABLE_GC != 0
+#define LV_GC_INCLUDE "gc.h"                           /*Include Garbage Collector related things*/
+#endif /*LV_ENABLE_GC*/
+
+/*=====================
+ *  COMPILER SETTINGS
+ *====================*/
+
+/*For big endian systems set to 1*/
+#define LV_BIG_ENDIAN_SYSTEM 0
+
+/*Define a custom attribute to `lv_tick_inc` function*/
+#define LV_ATTRIBUTE_TICK_INC
+
+/*Define a custom attribute to `lv_timer_handler` function*/
+#define LV_ATTRIBUTE_TIMER_HANDLER
+
+/*Define a custom attribute to `lv_disp_flush_ready` function*/
+#define LV_ATTRIBUTE_FLUSH_READY
+
+/*Required alignment size for buffers*/
+#define LV_ATTRIBUTE_MEM_ALIGN_SIZE 1
+
+/*Will be added where memories needs to be aligned (with -Os data might not be aligned to boundary by default).
+ * E.g. __attribute__((aligned(4)))*/
+#define LV_ATTRIBUTE_MEM_ALIGN
+
+/*Attribute to mark large constant arrays for example font's bitmaps*/
+#define LV_ATTRIBUTE_LARGE_CONST
+
+/*Compiler prefix for a big array declaration in RAM*/
+#define LV_ATTRIBUTE_LARGE_RAM_ARRAY
+
+/*Place performance critical functions into a faster memory (e.g RAM)*/
+#define LV_ATTRIBUTE_FAST_MEM
+
+/*Prefix variables that are used in GPU accelerated operations, often these need to be placed in RAM sections that are DMA accessible*/
+#define LV_ATTRIBUTE_DMA
+
+/*Export integer constant to binding. This macro is used with constants in the form of LV_<CONST> that
+ *should also appear on LVGL binding API such as Micropython.*/
+#define LV_EXPORT_CONST_INT(int_value) struct _silence_gcc_warning /*The default value just prevents GCC warning*/
+
+/*Extend the default -32k..32k coordinate range to -4M..4M by using int32_t for coordinates instead of int16_t*/
+#define LV_USE_LARGE_COORD 0
+
+/*==================
+ *   FONT USAGE
+ *===================*/
+
+/*Montserrat fonts with ASCII range and some symbols using bpp = 4
+ *https://fonts.google.com/specimen/Montserrat*/
+#define LV_FONT_MONTSERRAT_8  0
+#define LV_FONT_MONTSERRAT_10 0
+#define LV_FONT_MONTSERRAT_12 1
+#define LV_FONT_MONTSERRAT_14 0
+#define LV_FONT_MONTSERRAT_16 0
+#define LV_FONT_MONTSERRAT_18 0
+#define LV_FONT_MONTSERRAT_20 1
+#define LV_FONT_MONTSERRAT_22 0
+#define LV_FONT_MONTSERRAT_24 0
+#define LV_FONT_MONTSERRAT_26 0
+#define LV_FONT_MONTSERRAT_28 0
+#define LV_FONT_MONTSERRAT_30 0
+#define LV_FONT_MONTSERRAT_32 0
+#define LV_FONT_MONTSERRAT_34 0
+#define LV_FONT_MONTSERRAT_36 0
+#define LV_FONT_MONTSERRAT_38 0
+#define LV_FONT_MONTSERRAT_40 0
+#define LV_FONT_MONTSERRAT_42 0
+#define LV_FONT_MONTSERRAT_44 0
+#define LV_FONT_MONTSERRAT_46 0
+#define LV_FONT_MONTSERRAT_48 0
+#define LV_FONT_MONTSERRAT_48 0
+
+/*Demonstrate special features*/
+#define LV_FONT_MONTSERRAT_12_SUBPX      1
+#define LV_FONT_MONTSERRAT_28_COMPRESSED 0  /*bpp = 3*/
+#define LV_FONT_DEJAVU_16_PERSIAN_HEBREW 0  /*Hebrew, Arabic, Persian letters and all their forms*/
+#define LV_FONT_SIMSUN_16_CJK            0  /*1000 most common CJK radicals*/
+
+/*Pixel perfect monospace fonts*/
+#define LV_FONT_UNSCII_8  0
+#define LV_FONT_UNSCII_16 1
+
+/*Optionally declare custom fonts here.
+ *You can use these fonts as default font too and they will be available globally.
+ *E.g. #define LV_FONT_CUSTOM_DECLARE   LV_FONT_DECLARE(my_font_1) LV_FONT_DECLARE(my_font_2)*/
+#define LV_FONT_CUSTOM_DECLARE
+
+/*Always set a default font*/
+#define LV_FONT_DEFAULT &lv_font_montserrat_12
+
+/*Enable handling large font and/or fonts with a lot of characters.
+ *The limit depends on the font size, font face and bpp.
+ *Compiler error will be triggered if a font needs it.*/
+#define LV_FONT_FMT_TXT_LARGE 0
+
+/*Enables/disables support for compressed fonts.*/
+#define LV_USE_FONT_COMPRESSED 0
+
+/*Enable subpixel rendering*/
+#define LV_USE_FONT_SUBPX 0
+#if LV_USE_FONT_SUBPX
+/*Set the pixel order of the display. Physical order of RGB channels. Doesn't matter with "normal" fonts.*/
+#define LV_FONT_SUBPX_BGR 0  /*0: RGB; 1:BGR order*/
+#endif
+
+/*=================
+ *  TEXT SETTINGS
+ *=================*/
+
+/**
+ * Select a character encoding for strings.
+ * Your IDE or editor should have the same character encoding
+ * - LV_TXT_ENC_UTF8
+ * - LV_TXT_ENC_ASCII
+ */
+#define LV_TXT_ENC LV_TXT_ENC_UTF8
+
+/*Can break (wrap) texts on these chars*/
+#define LV_TXT_BREAK_CHARS " ,.;:-_"
+
+/*If a word is at least this long, will break wherever "prettiest"
+ *To disable, set to a value <= 0*/
+#define LV_TXT_LINE_BREAK_LONG_LEN 0
+
+/*Minimum number of characters in a long word to put on a line before a break.
+ *Depends on LV_TXT_LINE_BREAK_LONG_LEN.*/
+#define LV_TXT_LINE_BREAK_LONG_PRE_MIN_LEN 3
+
+/*Minimum number of characters in a long word to put on a line after a break.
+ *Depends on LV_TXT_LINE_BREAK_LONG_LEN.*/
+#define LV_TXT_LINE_BREAK_LONG_POST_MIN_LEN 3
+
+/*The control character to use for signalling text recoloring.*/
+#define LV_TXT_COLOR_CMD "#"
+
+/*Support bidirectional texts. Allows mixing Left-to-Right and Right-to-Left texts.
+ *The direction will be processed according to the Unicode Bidirectional Algorithm:
+ *https://www.w3.org/International/articles/inline-bidi-markup/uba-basics*/
+#define LV_USE_BIDI 0
+#if LV_USE_BIDI
+/*Set the default direction. Supported values:
+*`LV_BASE_DIR_LTR` Left-to-Right
+*`LV_BASE_DIR_RTL` Right-to-Left
+*`LV_BASE_DIR_AUTO` detect texts base direction*/
+#define LV_BIDI_BASE_DIR_DEF LV_BASE_DIR_AUTO
+#endif
+
+/*Enable Arabic/Persian processing
+ *In these languages characters should be replaced with an other form based on their position in the text*/
+#define LV_USE_ARABIC_PERSIAN_CHARS 0
+
+/*==================
+ *  WIDGET USAGE
+ *================*/
+
+/*Documentation of the widgets: https://docs.lvgl.io/latest/en/html/widgets/index.html*/
+
+#define LV_USE_ARC        1
+
+#define LV_USE_ANIMIMG    1
+
+#define LV_USE_BAR        1
+
+#define LV_USE_BTN        1
+
+#define LV_USE_BTNMATRIX  1
+
+#define LV_USE_CANVAS     1
+
+#define LV_USE_CHECKBOX   1
+
+#define LV_USE_DROPDOWN   1   /*Requires: lv_label*/
+
+#define LV_USE_IMG        1   /*Requires: lv_label*/
+
+#define LV_USE_LABEL      1
+#if LV_USE_LABEL
+#define LV_LABEL_TEXT_SELECTION 1 /*Enable selecting text of the label*/
+#define LV_LABEL_LONG_TXT_HINT 1  /*Store some extra info in labels to speed up drawing of very long texts*/
+#endif
+
+#define LV_USE_LINE       1
+
+#define LV_USE_ROLLER     1   /*Requires: lv_label*/
+#if LV_USE_ROLLER
+#define LV_ROLLER_INF_PAGES 7 /*Number of extra "pages" when the roller is infinite*/
+#endif
+
+#define LV_USE_SLIDER     1   /*Requires: lv_bar*/
+
+#define LV_USE_SWITCH     1
+
+#define LV_USE_TEXTAREA   1   /*Requires: lv_label*/
+#if LV_USE_TEXTAREA != 0
+#define LV_TEXTAREA_DEF_PWD_SHOW_TIME 1500    /*ms*/
+#endif
+
+#define LV_USE_TABLE      1
+
+/*==================
+ * EXTRA COMPONENTS
+ *==================*/
+
+/*-----------
+ * Widgets
+ *----------*/
+#define LV_USE_CALENDAR   1
+#if LV_USE_CALENDAR
+#define LV_CALENDAR_WEEK_STARTS_MONDAY 0
+#if LV_CALENDAR_WEEK_STARTS_MONDAY
+#define LV_CALENDAR_DEFAULT_DAY_NAMES {"Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"}
+#else
+#define LV_CALENDAR_DEFAULT_DAY_NAMES {"Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"}
+#endif
+
+#define LV_CALENDAR_DEFAULT_MONTH_NAMES {"January", "February", "March",  "April", "May",  "June", "July", "August", "September", "October", "November", "December"}
+#define LV_USE_CALENDAR_HEADER_ARROW 1
+#define LV_USE_CALENDAR_HEADER_DROPDOWN 1
+#endif  /*LV_USE_CALENDAR*/
+
+#define LV_USE_CHART      1
+
+#define LV_USE_COLORWHEEL 1
+
+#define LV_USE_IMGBTN     1
+
+#define LV_USE_KEYBOARD   1
+
+#define LV_USE_LED        1
+
+#define LV_USE_LIST       1
+
+#define LV_USE_MENU       1
+
+#define LV_USE_METER      1
+
+#define LV_USE_MSGBOX     1
+
+#define LV_USE_SPINBOX    1
+
+#define LV_USE_SPINNER    1
+
+#define LV_USE_TABVIEW    1
+
+#define LV_USE_TILEVIEW   1
+
+#define LV_USE_WIN        1
+
+#define LV_USE_SPAN       1
+#if LV_USE_SPAN
+/*A line text can contain maximum num of span descriptor */
+#define LV_SPAN_SNIPPET_STACK_SIZE 64
+#endif
+
+/*-----------
+ * Themes
+ *----------*/
+
+/*A simple, impressive and very complete theme*/
+#define LV_USE_THEME_DEFAULT 1
+#if LV_USE_THEME_DEFAULT
+
+/*0: Light mode; 1: Dark mode*/
+#define LV_THEME_DEFAULT_DARK 1
+
+/*1: Enable grow on press*/
+#define LV_THEME_DEFAULT_GROW 1
+
+/*Default transition time in [ms]*/
+#define LV_THEME_DEFAULT_TRANSITION_TIME 80
+#endif /*LV_USE_THEME_DEFAULT*/
+
+/*A very simple theme that is a good starting point for a custom theme*/
+#define LV_USE_THEME_BASIC 1
+
+/*A theme designed for monochrome displays*/
+#define LV_USE_THEME_MONO 1
+
+/*-----------
+ * Layouts
+ *----------*/
+
+/*A layout similar to Flexbox in CSS.*/
+#define LV_USE_FLEX 1
+
+/*A layout similar to Grid in CSS.*/
+#define LV_USE_GRID 1
+
+/*---------------------
+ * 3rd party libraries
+ *--------------------*/
+
+/*File system interfaces for common APIs */
+
+/*API for fopen, fread, etc*/
+#define LV_USE_FS_STDIO 0
+#if LV_USE_FS_STDIO
+#define LV_FS_STDIO_LETTER '\0'     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
+#define LV_FS_STDIO_PATH ""         /*Set the working directory. File/directory paths will be appended to it.*/
+#define LV_FS_STDIO_CACHE_SIZE  0   /*>0 to cache this number of bytes in lv_fs_read()*/
+#endif
+
+/*API for open, read, etc*/
+#define LV_USE_FS_POSIX 0
+#if LV_USE_FS_POSIX
+#define LV_FS_POSIX_LETTER '\0'     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
+#define LV_FS_POSIX_PATH ""         /*Set the working directory. File/directory paths will be appended to it.*/
+#define LV_FS_POSIX_CACHE_SIZE  0   /*>0 to cache this number of bytes in lv_fs_read()*/
+#endif
+
+/*API for CreateFile, ReadFile, etc*/
+#define LV_USE_FS_WIN32 0
+#if LV_USE_FS_WIN32
+#define LV_FS_WIN32_LETTER  '\0'    /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
+#define LV_FS_WIN32_PATH ""         /*Set the working directory. File/directory paths will be appended to it.*/
+#define LV_FS_WIN32_CACHE_SIZE 0    /*>0 to cache this number of bytes in lv_fs_read()*/
+#endif
+
+/*API for FATFS (needs to be added separately). Uses f_open, f_read, etc*/
+#define LV_USE_FS_FATFS  0
+#if LV_USE_FS_FATFS
+#define LV_FS_FATFS_LETTER '\0'     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
+#define LV_FS_FATFS_CACHE_SIZE 0    /*>0 to cache this number of bytes in lv_fs_read()*/
+#endif
+
+/*PNG decoder library*/
+#define LV_USE_PNG 0
+
+/*BMP decoder library*/
+#define LV_USE_BMP 0
+
+/* JPG + split JPG decoder library.
+ * Split JPG is a custom format optimized for embedded systems. */
+#define LV_USE_SJPG 0
+
+/*GIF decoder library*/
+#define LV_USE_GIF 1
+
+/*QR code library*/
+#define LV_USE_QRCODE 0
+
+/*FreeType library*/
+#define LV_USE_FREETYPE 0
+#if LV_USE_FREETYPE
+/*Memory used by FreeType to cache characters [bytes] (-1: no caching)*/
+#define LV_FREETYPE_CACHE_SIZE (16 * 1024)
+#if LV_FREETYPE_CACHE_SIZE >= 0
+/* 1: bitmap cache use the sbit cache, 0:bitmap cache use the image cache. */
+/* sbit cache:it is much more memory efficient for small bitmaps(font size < 256) */
+/* if font size >= 256, must be configured as image cache */
+#define LV_FREETYPE_SBIT_CACHE 0
+/* Maximum number of opened FT_Face/FT_Size objects managed by this cache instance. */
+/* (0:use system defaults) */
+#define LV_FREETYPE_CACHE_FT_FACES 0
+#define LV_FREETYPE_CACHE_FT_SIZES 0
+#endif
+#endif
+
+/*Rlottie library*/
+#define LV_USE_RLOTTIE 0
+
+/*FFmpeg library for image decoding and playing videos
+ *Supports all major image formats so do not enable other image decoder with it*/
+#define LV_USE_FFMPEG  0
+#if LV_USE_FFMPEG
+/*Dump input information to stderr*/
+#define LV_FFMPEG_DUMP_FORMAT 0
+#endif
+
+/*-----------
+ * Others
+ *----------*/
+
+/*1: Enable API to take snapshot for object*/
+#define LV_USE_SNAPSHOT 0
+
+/*1: Enable Monkey test*/
+#define LV_USE_MONKEY   0
+
+/*1: Enable grid navigation*/
+#define LV_USE_GRIDNAV  0
+
+/*1: Enable lv_obj fragment*/
+#define LV_USE_FRAGMENT 0
+
+/*1: Support using images as font in label or span widgets */
+#define LV_USE_IMGFONT 0
+
+/*1: Enable a published subscriber based messaging system */
+#define LV_USE_MSG 0
+
+/*==================
+* EXAMPLES
+*==================*/
+
+/*Enable the examples to be built with the library*/
+#define LV_BUILD_EXAMPLES 0
+
+/*===================
+ * DEMO USAGE
+ ====================*/
+
+/*Show some widget. It might be required to increase `LV_MEM_SIZE` */
+#define LV_USE_DEMO_WIDGETS        0
+#if LV_USE_DEMO_WIDGETS
+#define LV_DEMO_WIDGETS_SLIDESHOW  0
+#endif
+
+/*Demonstrate the usage of encoder and keyboard*/
+#define LV_USE_DEMO_KEYPAD_AND_ENCODER     0
+
+/*Benchmark your system*/
+#define LV_USE_DEMO_BENCHMARK   0
+
+/*Stress test for LVGL*/
+#define LV_USE_DEMO_STRESS      0
+
+/*Music player demo*/
+#define LV_USE_DEMO_MUSIC       0
+#if LV_USE_DEMO_MUSIC
+# define LV_DEMO_MUSIC_SQUARE       0
+# define LV_DEMO_MUSIC_LANDSCAPE    0
+# define LV_DEMO_MUSIC_ROUND        0
+# define LV_DEMO_MUSIC_LARGE        0
+# define LV_DEMO_MUSIC_AUTO_PLAY    0
+#endif
+
+/*--END OF LV_CONF_H--*/
+
+#endif /*LV_CONF_H*/
+
+#endif /*End of "Content enable"*/

--- a/variants/T-ETH-ELITE_1262/platformio.ini
+++ b/variants/T-ETH-ELITE_1262/platformio.ini
@@ -1,0 +1,34 @@
+[env:T-ETH-ELITE_1262]
+extends = esp32
+board = esp32-s3-devkitc-1-n16r8
+board_build.partitions = partitions-4MB-safeboot.csv
+
+upload_protocol = custom
+upload_command = python3 ~/.platformio/packages/tool-esptoolpy/esptool.py -b 921600 write_flash 0x0000 ${platformio.build_dir}/${this.__env__}/bootloader.bin 0xE000 otadata.bin 0x8000 ${platformio.build_dir}/${this.__env__}/partitions.bin 0x10000 safeboot-s3.bin 0xC0000 ${platformio.build_dir}/${this.__env__}/firmware.bin
+
+monitor_speed = 115200
+board_upload.flash_size = 16MB
+board_upload.maximum_size = 16777216
+monitor_filters = esp32_exception_decoder
+
+lib_ignore = Adafruit TCA8418, epdiy, es7210, ESP32-audioI2S, GxEPD2, lvgl, TFT_eSPI, TinyGSM
+
+lib_extra_dirs = lib
+
+lib_deps =
+    ${libs.lib_deps}
+    ${esp32libs.lib_deps}
+    adafruit/Adafruit NeoPixel@^1.12.5
+    https://github.com/meshtastic/ETHClass2/archive/v1.0.0.zip
+	arduino-libraries/Ethernet@^2.0.2
+
+build_flags =
+    ${esp32.build_flags}
+    ${common.build_flags}
+    ${common.usb_flags}
+    -D MONITOR_SPEED=${upload_settings.monitor_speed}
+    -D BOARD_T_ETH_ELITE="esp32-s3-devkitc-1-n16r8"
+    -D BOARD_E22
+    -I variants/${this.__env__}
+    -DCORE_DEBUG_LEVEL=0
+    -Wno-unused-parameter


### PR DESCRIPTION
Add Ethernet support for LilyGO T-ETH-ELITE (ESP32-S3 + W5500).

Main changes:
- Added new board variant T-ETH-ELITE_1262
- Added esp32_eth driver
- Added network mode switch (WiFi / Ethernet)
- Web UI control for network mode
- Persist network mode using node_netmode
- Refactored startWIFI() → startNetwork()
- Unified network state using meshcom_settings.node_hasIPaddress

Tested on real hardware:
- Static IP
- DHCP
- WiFi/Ethernet switching
- Persistence across reboot