### PR TITLE
fix: strcpy/strcat Buffer-Overflow Hardening

### DIFF
--- a/src/command_functions.cpp
+++ b/src/command_functions.cpp
@@ -100,7 +100,8 @@ int casecmp(const char *s1, const char *s2)
 int commandCheck(char *msg, char *command)
 {
     char vmsg[100];
-    strcpy(vmsg, msg);
+    strncpy(vmsg, msg, sizeof(vmsg) - 1);
+    vmsg[sizeof(vmsg) - 1] = '\0';
     vmsg[strlen(command)] = 0x00;
 
     if(casecmp(vmsg, command) == 0)

--- a/src/esp32/esp32_main.cpp
+++ b/src/esp32/esp32_main.cpp
@@ -829,8 +829,10 @@ void esp32setup()
     // Umstellung auf langes WIFI Passwort
     if(strlen(meshcom_settings.node_ossid) > 0 && (strlen(meshcom_settings.node_ssid) == 0 || strcmp(meshcom_settings.node_ssid, "none") == 0))
     {
-        strcpy(meshcom_settings.node_ssid, meshcom_settings.node_ossid);
-        strcpy(meshcom_settings.node_pwd, meshcom_settings.node_opwd);
+        strncpy(meshcom_settings.node_ssid, meshcom_settings.node_ossid, sizeof(meshcom_settings.node_ssid) - 1);
+        meshcom_settings.node_ssid[sizeof(meshcom_settings.node_ssid) - 1] = '\0';
+        strncpy(meshcom_settings.node_pwd, meshcom_settings.node_opwd, sizeof(meshcom_settings.node_pwd) - 1);
+        meshcom_settings.node_pwd[sizeof(meshcom_settings.node_pwd) - 1] = '\0';
 
         memset(meshcom_settings.node_ossid, 0x00, sizeof(meshcom_settings.node_ossid));
         memset(meshcom_settings.node_opwd, 0x00, sizeof(meshcom_settings.node_opwd));
@@ -3412,7 +3414,8 @@ void checkSerialCommand(void)
             if(strText.endsWith("\n") || strText.endsWith("\r"))
             {
                 strText.trim();
-                strcpy(msg_text, strText.c_str());
+                strncpy(msg_text, strText.c_str(), sizeof(msg_text) - 1);
+                msg_text[sizeof(msg_text) - 1] = '\0';
 
                 int inext=0;
                 char msg_buffer[600];

--- a/src/loop_functions.cpp
+++ b/src/loop_functions.cpp
@@ -1552,8 +1552,10 @@ void sendDisplayText(struct aprsMessage &aprsmsg, int16_t rssi, int8_t snr)
 
         TDeck_pro_lora_disp(strPath, strAscii);
 
-        strcpy(pageLastTextLong1[pagePointer], msg_text);
-        strcpy(pageLastTextLong2[pagePointer], strAscii.c_str());
+        strncpy(pageLastTextLong1[pagePointer], msg_text, sizeof(pageLastTextLong1[pagePointer]) - 1);
+        pageLastTextLong1[pagePointer][sizeof(pageLastTextLong1[pagePointer]) - 1] = '\0';
+        strncpy(pageLastTextLong2[pagePointer], strAscii.c_str(), sizeof(pageLastTextLong2[pagePointer]) - 1);
+        pageLastTextLong2[pagePointer][sizeof(pageLastTextLong2[pagePointer]) - 1] = '\0';
 
         bSetDisplay = false;
 
@@ -1596,8 +1598,10 @@ void sendDisplayText(struct aprsMessage &aprsmsg, int16_t rssi, int8_t snr)
 
     e290_display.println(strAscii);
 
-    strcpy(pageLastTextLong1[pagePointer], msg_text);
-    strcpy(pageLastTextLong2[pagePointer], strAscii.c_str());
+    strncpy(pageLastTextLong1[pagePointer], msg_text, sizeof(pageLastTextLong1[pagePointer]) - 1);
+    pageLastTextLong1[pagePointer][sizeof(pageLastTextLong1[pagePointer]) - 1] = '\0';
+    strncpy(pageLastTextLong2[pagePointer], strAscii.c_str(), sizeof(pageLastTextLong2[pagePointer]) - 1);
+    pageLastTextLong2[pagePointer][sizeof(pageLastTextLong2[pagePointer]) - 1] = '\0';
 
     e290_display.update();
 
@@ -1631,8 +1635,10 @@ void sendDisplayText(struct aprsMessage &aprsmsg, int16_t rssi, int8_t snr)
 
     strAscii = utf8ascii(aprsmsg.msg_payload);
 
-    strcpy(pageLastTextLong1[pagePointer], strPath.c_str());
-    strcpy(pageLastTextLong2[pagePointer], strAscii.c_str());
+    strncpy(pageLastTextLong1[pagePointer], strPath.c_str(), sizeof(pageLastTextLong1[pagePointer]) - 1);
+    pageLastTextLong1[pagePointer][sizeof(pageLastTextLong1[pagePointer]) - 1] = '\0';
+    strncpy(pageLastTextLong2[pagePointer], strAscii.c_str(), sizeof(pageLastTextLong2[pagePointer]) - 1);
+    pageLastTextLong2[pagePointer][sizeof(pageLastTextLong2[pagePointer]) - 1] = '\0';
 
     displayTFT(strPath, strAscii);
 
@@ -1715,7 +1721,7 @@ void sendDisplayText(struct aprsMessage &aprsmsg, int16_t rssi, int8_t snr)
     iwords=99;
 
     memset(line_text, 0x00, 21);
-    strcat(line_text, words[0]);
+    strncat(line_text, words[0], sizeof(line_text) - strlen(line_text) - 1);
 
     bool bEnd=false;
 
@@ -1749,13 +1755,13 @@ void sendDisplayText(struct aprsMessage &aprsmsg, int16_t rssi, int8_t snr)
 
             bClear=false;
 
-            strcat(line_text, words[itxt]);
+            strncat(line_text, words[itxt], sizeof(line_text) - strlen(line_text) - 1);
 
         }
         else
         {
-            strcat(line_text, " ");
-            strcat(line_text, words[itxt]);
+            strncat(line_text, " ", sizeof(line_text) - strlen(line_text) - 1);
+            strncat(line_text, words[itxt], sizeof(line_text) - strlen(line_text) - 1);
         }
     }
 

--- a/src/nrf52/nrf52_main.cpp
+++ b/src/nrf52/nrf52_main.cpp
@@ -515,8 +515,10 @@ void nrf52setup()
     // Umstekllung auf langes WIFI Passwort
     if(strlen(meshcom_settings.node_ossid) > 4 && strlen(meshcom_settings.node_ssid) < 5)
     {
-        strcpy(meshcom_settings.node_ssid, meshcom_settings.node_ossid);
-        strcpy(meshcom_settings.node_pwd, meshcom_settings.node_opwd);
+        strncpy(meshcom_settings.node_ssid, meshcom_settings.node_ossid, sizeof(meshcom_settings.node_ssid) - 1);
+        meshcom_settings.node_ssid[sizeof(meshcom_settings.node_ssid) - 1] = '\0';
+        strncpy(meshcom_settings.node_pwd, meshcom_settings.node_opwd, sizeof(meshcom_settings.node_pwd) - 1);
+        meshcom_settings.node_pwd[sizeof(meshcom_settings.node_pwd) - 1] = '\0';
 
         memset(meshcom_settings.node_ossid, 0x00, sizeof(meshcom_settings.node_ossid));
         memset(meshcom_settings.node_opwd, 0x00, sizeof(meshcom_settings.node_opwd));
@@ -2149,7 +2151,8 @@ void checkSerialCommand(void)
             if(strText.endsWith("\n") || strText.endsWith("\r"))
             {
                 strText.trim();
-                strcpy(msg_text, strText.c_str());
+                strncpy(msg_text, strText.c_str(), sizeof(msg_text) - 1);
+                msg_text[sizeof(msg_text) - 1] = '\0';
 
                 int inext = 0;
                 char msg_buffer[600];


### PR DESCRIPTION
## Zusammenfassung

Alle unsicheren `strcpy()` und `strcat()` Aufrufe durch groessenbegrenzte Varianten (`strncpy`/`strncat`) ersetzt.

## Geaenderte Dateien

- `src/command_functions.cpp` — 1 Stelle
- `src/esp32/esp32_main.cpp` — 2 Stellen
- `src/nrf52/nrf52_main.cpp` — 2 Stellen
- `src/loop_functions.cpp` — 9 Stellen

## Befunde im Detail

### HOCH — echtes Overflow-Risiko

| Datei | Zeile | Problem |
|-------|-------|---------|
| `command_functions.cpp` | `commandCheck()` | `strcpy(vmsg[100], msg)` — `msg` Parameter ist unbegrenzt, kann 100-Byte Buffer ueberschreiben |
| `esp32/esp32_main.cpp` | SSID-Migration | `strcpy(node_ssid[33], node_ossid[40])` — 40 Bytes werden in 33-Byte Buffer kopiert = 7 Byte Overflow in angrenzende Struct-Felder |
| `nrf52/nrf52_main.cpp` | SSID-Migration | identisch, beide Plattformen betroffen |

### MITTEL — theoretischer Overflow bei langen Payloads

| Datei | Zeile | Problem |
|-------|-------|---------|
| `loop_functions.cpp` | Display-Text | `strcpy(pageLastTextLong1[25], ...)` — Source kann laenger als 25 Bytes sein (APRS Path + Callsign) |
| `loop_functions.cpp` | Display-Text | `strcpy(pageLastTextLong2[200], ...)` — `utf8ascii()` Output theoretisch unbegrenzt |
| `loop_functions.cpp` | Wortumbruch | `strcat(line_text[21], ...)` — erster Concat ohne Bounds-Check, Schleife kann 21-Byte Buffer ueberschreiben |
| `esp32/esp32_main.cpp` | Serial-Input | `strcpy(msg_text[600], strText.c_str())` — Serial-Input ohne Laengenpruefung |
| `nrf52/nrf52_main.cpp` | Serial-Input | identisch |

### NICHT GEAENDERT (bereits sicher)

- `SDWrapper/sd_wrapper.cpp` — Buffer-Groesse wird exakt aus Source-Laenge berechnet
- `web_functions.cpp` — Source explizit auf 150 Zeichen begrenzt vor strcpy
- `onebutton_functions.cpp` — Source und Destination haben identische Groesse
- `Displays/BaseDisplay/SD.cpp` — Literal-String ".bmp"

## Loesung

Jede unsichere Stelle wurde durch das Pattern ersetzt:
```c
strncpy(dest, src, sizeof(dest) - 1);
dest[sizeof(dest) - 1] = '\0';
```

Fuer `strcat` analog:
```c
strncat(dest, src, sizeof(dest) - strlen(dest) - 1);
```

## Testplan

- [ ] Build fuer ESP32 Targets (Heltec V3, E22, T-Beam, T-Deck)
- [ ] Build fuer NRF52 Target (RAK4631)
- [ ] Serielle Kommandos funktionieren weiterhin
- [ ] Display-Textanzeige korrekt (E290, Tracker, T-Deck Pro)
- [ ] WiFi-SSID-Migration bei Firmware-Update


🤖 Generated with [Claude Code](https://claude.com/claude-code)