### PR TITLE
fix: RAK4630 CAD-Deadlock und SPI-Race behoben

### DIFF
--- a/src/loop_functions_extern.h
+++ b/src/loop_functions_extern.h
@@ -195,6 +195,9 @@ extern std::atomic<bool> tx_is_active;   // flag to store we are transmitting  a
 extern int cad_attempt;
 extern unsigned long csma_timeout;
 extern int rx_irq_defer_count;
+extern volatile bool cad_in_progress;
+extern volatile bool cad_done_flag;
+extern volatile bool cad_double_check;
 
 // Channel utilization tracking (10s window)
 extern std::atomic<unsigned long> ch_util_rx_start;

--- a/src/lora_functions.cpp
+++ b/src/lora_functions.cpp
@@ -290,6 +290,14 @@ void OnRxDone(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr)
     payload = rxPayloadCopy[rxBufIndex];
     size = rxSize;
     Radio.Rx(RX_TIMEOUT_VALUE);
+    // CAD aborted by RX — reset so main loop doesn't deadlock
+    if(cad_in_progress) {
+        cad_in_progress = false;
+        cad_done_flag = false;
+        cad_double_check = false;
+        if(bLORADEBUG)
+            Serial.printf("[MC-DBG] CAD_ABORT_BY_RX\n");
+    }
     if(bLORADEBUG)
         Serial.printf("[MC-DBG] RX_RESTART_EARLY src=OnRxDone\n");
     #endif
@@ -1092,6 +1100,11 @@ void OnRxTimeout(void)
 {
     #if defined BOARD_RAK4630
         Radio.Rx(RX_TIMEOUT_VALUE);
+        if(cad_in_progress) {
+            cad_in_progress = false;
+            cad_done_flag = false;
+            cad_double_check = false;
+        }
     #endif
 
     if(bLORADEBUG)
@@ -1113,6 +1126,11 @@ void OnRxError(void)
 {
     #if defined BOARD_RAK4630
         Radio.Rx(RX_TIMEOUT_VALUE);
+        if(cad_in_progress) {
+            cad_in_progress = false;
+            cad_done_flag = false;
+            cad_double_check = false;
+        }
     #endif
 
     if(bLORADEBUG)
@@ -1267,7 +1285,9 @@ bool doTX()
                 if(millis() > track_to_meshcom_timer + 1000 * 60 * 5)
                 {
                     #if defined BOARD_RAK4630
+                        taskENTER_CRITICAL();
                         Radio.Send(lora_tx_buffer, sendlng);
+                        taskEXIT_CRITICAL();
                     #else
                         #ifndef BOARD_T5_EPAPER
                         #ifdef RADIO_CTRL
@@ -1296,7 +1316,9 @@ bool doTX()
                 // you can transmit C-string or Arduino string up to
                 // 256 characters long
                 #if defined BOARD_RAK4630
+                    taskENTER_CRITICAL();
                     Radio.Send(lora_tx_buffer, sendlng);
+                    taskEXIT_CRITICAL();
                 #else
                     #ifndef BOARD_T5_EPAPER
                     #ifdef RADIO_CTRL
@@ -1350,7 +1372,9 @@ bool doTX()
                     // you can transmit C-string or Arduino string up to
                     // 256 characters long
                     #if defined BOARD_RAK4630
+                        taskENTER_CRITICAL();
                         Radio.Send(lora_tx_buffer, sendlng);
+                        taskEXIT_CRITICAL();
                     #else
                         #ifndef BOARD_T5_EPAPER
                         #ifdef RADIO_CTRL

--- a/src/nrf52/nrf52_main.cpp
+++ b/src/nrf52/nrf52_main.cpp
@@ -179,8 +179,8 @@ unsigned long iReceiveTimeOutTime = 0;
 // CSMA/CA async CAD state
 volatile bool cad_done_flag = false;
 volatile bool cad_channel_busy = false;
-bool cad_in_progress = false;
-bool cad_double_check = false;
+volatile bool cad_in_progress = false;
+volatile bool cad_double_check = false;
 unsigned long cad_start_time = 0;
 
 bool g_meshcom_initialized;
@@ -1144,7 +1144,9 @@ extern bool btimeClient;
                     Serial.printf("[MC-DBG] RX_IRQ_STALE forced restart after %d deferrals\n", rx_irq_defer_count);
                 rx_irq_defer_count = 0;
                 iReceiveTimeOutTime = 0;
+                taskENTER_CRITICAL();
                 Radio.Rx(RX_TIMEOUT_VALUE);
+                taskEXIT_CRITICAL();
                 if(bLORADEBUG)
                 {
                     Serial.printf("[MC-SM] IDLE -> RX_LISTEN rc=0\n");
@@ -1173,8 +1175,10 @@ extern bool btimeClient;
                 cad_done_flag = false;
                 cad_double_check = false;
                 cad_start_time = millis();
+                taskENTER_CRITICAL();
                 Radio.Standby();
                 Radio.StartCad();
+                taskEXIT_CRITICAL();
             }
             else if(cad_done_flag)
             {
@@ -1208,8 +1212,10 @@ extern bool btimeClient;
                     cad_in_progress = true;
                     cad_done_flag = false;
                     cad_start_time = millis();
+                    taskENTER_CRITICAL();
                     Radio.Standby();
                     Radio.StartCad();
+                    taskEXIT_CRITICAL();
                 }
                 else
                 {
@@ -1224,7 +1230,9 @@ extern bool btimeClient;
                             cad_attempt, csma_timeout);
                     }
 
+                    taskENTER_CRITICAL();
                     Radio.Rx(RX_TIMEOUT_VALUE);
+                    taskEXIT_CRITICAL();
                     iReceiveTimeOutTime = millis();
                 }
             }
@@ -1236,7 +1244,9 @@ extern bool btimeClient;
 
                 cad_in_progress = false;
                 cad_done_flag = false;
+                taskENTER_CRITICAL();
                 Radio.Rx(RX_TIMEOUT_VALUE);
+                taskEXIT_CRITICAL();
                 iReceiveTimeOutTime = millis();
             }
         }


### PR DESCRIPTION
## Zusammenfassung

Behebt einen stillen Freeze auf RAK4630 (nRF52) Nodes nach ~14 Stunden Betrieb.
Ursache: Race Condition in der CSMA/CA State Machine + fehlender SPI-Schutz.

## Problem

Wenn `OnRxDone` waehrend einer laufenden CAD-Operation im Radio-Background-Task feuert, ruft der Callback `Radio.Rx()` auf. Das bricht die CAD-Operation im SX1262 ab, aber die Flags `cad_in_progress`/`cad_done_flag` im Main Loop werden nicht zurueckgesetzt. Die State Machine wartet dann auf ein `OnCadDone` das nie kommt. Ohne Watchdog friert der Node permanent ein.

Zusaetzlich gibt es keinen Mutex fuer SPI-Zugriffe zwischen Main Loop (`Radio.Standby/StartCad/Rx`) und dem Radio Background Task (`RadioBgIrqProcess`) — gleichzeitige SPI-Operationen koennen den Bus korrumpieren.

## Analyse

- **Log**: OE3XOC-12, 2026-03-16 14:47 bis 2026-03-17 04:56 — Node friert nach 14h9m ein
- **Letzte Logzeile**: `[MC-SM] RX_PROCESS -> RX_LISTEN rc=0` — voellig normal, kein Crash/Panic/Watchdog
- **State zum Zeitpunkt des Freeze**: `TX_GATE_ENTER qlen=3 cad_attempt=1` — 3 Pakete in Queue, CAD lief
- **MTBF**: Bei ~700 Paketen/h und ~1ms Race-Window: ~14h (passt zur Beobachtung)

## Fix

### P1: CAD-State Reset in Radio Callbacks
- `cad_in_progress`, `cad_done_flag`, `cad_double_check` werden in `OnRxDone`, `OnRxTimeout` und `OnRxError` zurueckgesetzt, wenn eine CAD-Operation lief
- `cad_in_progress` und `cad_double_check` als `volatile` deklariert (werden von Radio-Task und Main-Loop-Task geteilt)
- Neuer Debug-Log: `[MC-DBG] CAD_ABORT_BY_RX`

### P2: SPI-Bus-Schutz
- `taskENTER_CRITICAL()`/`taskEXIT_CRITICAL()` um alle `Radio.*`-Aufrufe im Main Loop und `Radio.Send()` in doTX
- Verhindert, dass der DIO1-ISR den Radio Background Task weckt waehrend der Main Loop SPI nutzt
- Critical Sections sind kurz (~50-300us fuer SPI-Transfers)

## Betroffene Dateien

- `src/nrf52/nrf52_main.cpp` — volatile Deklarationen, taskENTER/EXIT_CRITICAL um 5 Radio.*-Aufrufe
- `src/lora_functions.cpp` — CAD-State Reset in 3 Callbacks, taskENTER/EXIT_CRITICAL um 3 Radio.Send()
- `src/loop_functions_extern.h` — extern Deklarationen fuer CAD-Flags

Keine Library-Aenderungen. Nur nRF52/RAK4630 betroffen (alle Aenderungen unter `#if defined BOARD_RAK4630`).

## Test plan

- [x] `pio run -e wiscore_rak4631` kompiliert fehlerfrei
- [ ] Deploy auf RAK4630 Node, >24h Monitoring
- [ ] `CAD_ABORT_BY_RX` erscheint im Log (bestaetigt P1 greift)
- [ ] Kein Freeze ueber Nacht
- [ ] TX-Durchsatz und Relay-Verhalten unveraendert

🤖 Generated with [Claude Code](https://claude.com/claude-code)