### PR TITLE
fix: RAK4630 Radio-Watchdog bei leerer TX-Queue

### DIFF
--- a/src/nrf52/nrf52_main.cpp
+++ b/src/nrf52/nrf52_main.cpp
@@ -1250,6 +1250,13 @@ extern bool btimeClient;
                 iReceiveTimeOutTime = millis();
             }
         }
+        else
+        {
+            // Nothing to send — restart timeout cycle (radio watchdog).
+            // Matches ESP32 esp32_main.cpp behaviour: periodic Radio.Rx()
+            // prevents silent SX1262 stall when queue is empty.
+            iReceiveTimeOutTime = millis();
+        }
     }
 
     // SOFTSER


### PR DESCRIPTION
## Zusammenfassung

Fehlender Radio-Watchdog im nRF52 Main Loop fuehrt zu unbegrenzter Funkstille,
wenn die TX-Queue leer ist und der SX1262 keine RX-Interrupts mehr liefert.

## Problem

In `src/nrf52/nrf52_main.cpp` prueft der Main Loop:

```cpp
if(iReceiveTimeOutTime == 0 && is_receiving == false && tx_is_active == false)
{
    if (iWrite != iRead)
    {
        // CAD/TX-Logik...
    }
    // KEIN else-Branch!
}
```

Wenn die TX-Queue leer ist (`iWrite == iRead`), wird `iReceiveTimeOutTime` **nicht** gesetzt.
Ohne diesen Timer-Zyklus feuert `RX_TIMEOUT_FIRE` nie, und `Radio.Rx()` wird nicht periodisch
aufgerufen. Stoppt der SX1262 die Interrupt-Erzeugung (bekanntes Hardware-Verhalten: verpasste
DIO1-Flanke, SPI-Timing), bleibt die State Machine unbegrenzt stehen.

**Beobachtet**: 46 Sekunden Funkstille auf OE1KBC-12 (RAK4630), aufgeloest erst durch einen
extern ausgeloesten TX (`IDLE->TX_PREPARE`).

## Ursache

Der **ESP32-Code hat diesen Schutz bereits** (`esp32_main.cpp`, Zeilen 2203-2207):

```cpp
else
{
    // Nothing to send — restart timeout cycle
    iReceiveTimeOutTime = millis();
}
```

Dieser `else`-Branch stellt sicher, dass der CSMA-Timeout-Zyklus (~3-5s) weiterlaeuft,
auch wenn nichts zu senden ist. Dadurch wird `Radio.Rx()` periodisch aufgerufen und ein
stumm gewordener SX1262 neu gestartet.

Dem nRF52-Code fehlt dieser `else`-Branch.

## Fix

Identischer `else`-Branch wie ESP32 in `src/nrf52/nrf52_main.cpp` eingefuegt:

```cpp
        else
        {
            // Nothing to send — restart timeout cycle (radio watchdog).
            // Matches ESP32 esp32_main.cpp behaviour: periodic Radio.Rx()
            // prevents silent SX1262 stall when queue is empty.
            iReceiveTimeOutTime = millis();
        }
```

## Betroffene Datei

- `src/nrf52/nrf52_main.cpp` (1 Stelle, +7 Zeilen)

