### PR TITLE
fix: BLE-Ringpuffer speichert Offline-Nachrichten

### DIFF
--- a/release.md
+++ b/release.md
@@ -7,6 +7,25 @@ Kein On-Air-Change — alte Firmware empfaengt alle Pakete korrekt.
 
 ---
 
+## BLE-Ringpuffer Offline-Nachrichten Bugfix (2026-03-19)
+
+Nachrichten wurden nicht im BLE-Ringpuffer gespeichert wenn kein Telefon verbunden war.
+Beim spaeteten Verbinden eines Telefons war der Puffer daher leer — keine Offline-Nachrichten.
+
+**Root Cause**: Guard in `addBLEOutBuffer()` (`!g_ble_uart_is_connected && !bWEBSERVER`)
+verwarf alle Nachrichten wenn weder BLE-Telefon noch Webserver aktiv war.
+E22 zeigte 7 Nachrichten weil dort der Webserver aktiv war (Guard griff nicht).
+Heltec V2, RAK (GW und Non-GW) zeigten 0 Nachrichten.
+
+**Fix** (2 Aenderungen in `src/loop_functions.cpp`):
+- Guard entfernt — Nachrichten werden immer im Ringpuffer gespeichert
+- Overflow-Debug-Log fuer "phone"-Puffer unterdrueckt (Ueberlauf gewuenscht,
+  aelteste Eintraege werden ueberschrieben)
+
+**Betroffene Datei**: `src/loop_functions.cpp`
+
+---
+
 ## TX-Loop und UDP-Dedup Bugfix (2026-03-19)
 
 Zwei Bugs behoben, die gemeinsam massive Duplikat-Sendungen verursachten.

--- a/src/loop_functions.cpp
+++ b/src/loop_functions.cpp
@@ -398,9 +398,6 @@ unsigned long getUnixClock()
  */
 void addBLEOutBuffer(uint8_t *buffer, uint16_t len)
 {
-    if (!g_ble_uart_is_connected && !bWEBSERVER)
-        return;
-
     if (len > UDP_TX_BUF_SIZE)
         len = UDP_TX_BUF_SIZE-4; // just for safety
 
@@ -3854,7 +3851,7 @@ void addRingPointer(volatile int &pWrite, volatile int &pRead, int iMAX, const c
             if (pRead >= iMAX) // if the buffer is full we start at index 0 -> take care of overwriting!
                 pRead = 0;
 
-            if(bLORADEBUG && strcmp(bufName, "raw_rx") != 0)
+            if(bLORADEBUG && strcmp(bufName, "raw_rx") != 0 && strcmp(bufName, "phone") != 0)
             {
                 Serial.printf("[MC-DBG] RING_OVERFLOW buf=%s\n", bufName);
             }


### PR DESCRIPTION
## Zusammenfassung

Bugfix: Nachrichten wurden nicht im BLE-Ringpuffer gespeichert wenn kein Telefon per BLE verbunden war. Beim späteren Verbinden eines Telefons war der Puffer leer — keine Offline-Nachrichten verfügbar.

## Root Cause

Die Guard-Bedingung in `addBLEOutBuffer()` (`loop_functions.cpp:401`) verwarf alle Nachrichten wenn weder BLE-Telefon noch Webserver aktiv war:

```cpp
if (!g_ble_uart_is_connected && !bWEBSERVER)
    return;
```

**Beobachtung im Feld:**
- E22 zeigte 7 Nachrichten im Puffer → Webserver war dort aktiv, Guard griff nicht
- Heltec V2: 0 Nachrichten → kein Webserver, Guard verwarf alles
- RAK (GW und Non-GW): 0 Nachrichten → kein Webserver, Guard verwarf alles

## Änderungen

### 1. Guard in `addBLEOutBuffer()` entfernt (`src/loop_functions.cpp`)

Nachrichten werden jetzt immer im Ringpuffer gespeichert, unabhängig vom BLE-Verbindungsstatus. Wenn der Puffer voll ist, werden die ältesten Einträge überschrieben (gewünschtes Ringpuffer-Verhalten).

### 2. Overflow-Debug-Log für "phone"-Puffer gefiltert (`src/loop_functions.cpp`)

Da der BLE-Puffer jetzt auch ohne verbundenes Telefon befüllt wird, ist ein Überlauf normal und gewünscht. Das `RING_OVERFLOW`-Debug-Log wird für den "phone"-Puffer unterdrückt, bleibt aber für alle anderen Ringpuffer (TX, UDP, etc.) aktiv.

## Betroffene Datei

- `src/loop_functions.cpp` (2 Stellen, netto -3 Zeilen)

## Testplan

- [ ] Node ohne BLE-Telefon laufen lassen, Textnachrichten von anderen Nodes senden
- [ ] BLE-Telefon verbinden → gepufferte Textnachrichten müssen zugestellt werden
- [ ] Positionsnachrichten sollen **nicht** im Puffer erscheinen (bestehender `isPhoneReady`-Guard in `lora_functions.cpp:928` bleibt unverändert)
- [ ] Alle 7 Build-Targets kompilieren erfolgreich

🤖 Generated with [Claude Code](https://claude.com/claude-code)