### PR TITLE
fix: updateHeyPath überschreibt RSSI/SNR/MOD mit Relay-Werten

### DIFF
--- a/src/mheard_functions.cpp
+++ b/src/mheard_functions.cpp
@@ -390,7 +390,7 @@ void updateHeyPath(struct mheardLine &mheardLine)
 
                         char cBuffer[sizeof(mheardBuffer[imh])];
                         snprintf(cBuffer, sizeof(cBuffer), "%s|%s|%c|%i|%u|%i|%i|%.1lf|%i|%i|%i|", mheardLine.mh_date.c_str(), mheardLine.mh_time.c_str(), mheardLine.mh_payload_type, mheardLine_save.mh_hw,
-                        mheardLine.mh_mod, mheardLine.mh_rssi, mheardLine.mh_snr, mheardLine.mh_dist, mheardLine.mh_path_len, mheardLine.mh_mesh, mheardLine.mh_ncount);
+                        mheardLine_save.mh_mod, mheardLine_save.mh_rssi, mheardLine_save.mh_snr, mheardLine.mh_dist, mheardLine.mh_path_len, mheardLine.mh_mesh, mheardLine.mh_ncount);
                         memcpy(mheardBuffer[imh], cBuffer, sizeof(cBuffer));
                     }
                 }


### PR DESCRIPTION
## Zusammenfassung

**Bug:** Wenn ein Hey-Paket über einen Relay-Node empfangen wird, zeigt der Webserver falsche RSSI-, SNR- und MOD-Werte für den Original-Sender an. Die angezeigten Werte stammen stattdessen vom Relay-Node.

## Ursache

In `updateHeyPath()` (`src/mheard_functions.cpp`, Zeile 391-393) wird der mheard-Buffer des Original-Senders mit Werten aus `mheardLine` aktualisiert. Diese Struktur enthält jedoch die RSSI/SNR/MOD-Werte des **Relay-Nodes** (letzter Sender), nicht des Original-Senders:

- `mheardLine.mh_rssi` / `mh_snr` → vom Funk-Empfang des Relay-Nodes gemessen
- `mheardLine.mh_mod` → Modulation des Relay-Nodes

Die Hardware (`mh_hw`) wurde bereits korrekt aus dem bestehenden Buffer bewahrt (`mheardLine_save.mh_hw`), aber MOD, RSSI und SNR wurden fälschlicherweise mit den Relay-Werten überschrieben.

## Beispiel (beobachtet im Feld)

| Node | Tatsächliche HW | Angezeigt im Webserver |
|------|-----------------|----------------------|
| DO1TFS-99 | E22 | TDECK_PLUS (falsch) |
| DO1FZL-90 | TDeck | EBYTE_E22 (falsch) |

RSSI/SNR-Werte waren ebenfalls vertauscht — z.B. zeigte ein TDeck die Signalwerte, die eigentlich zum E22-Relay gehörten.

## Änderung

**Datei:** `src/mheard_functions.cpp`, Funktion `updateHeyPath()`

Statt `mheardLine.mh_mod`, `mheardLine.mh_rssi`, `mheardLine.mh_snr` (Relay-Werte) werden jetzt `mheardLine_save.mh_mod`, `mheardLine_save.mh_rssi`, `mheardLine_save.mh_snr` (bestehende Werte des Original-Senders) verwendet.

**Vorher:**
```c
snprintf(cBuffer, ..., mheardLine_save.mh_hw,
    mheardLine.mh_mod, mheardLine.mh_rssi, mheardLine.mh_snr, ...);
```

**Nachher:**
```c
snprintf(cBuffer, ..., mheardLine_save.mh_hw,
    mheardLine_save.mh_mod, mheardLine_save.mh_rssi, mheardLine_save.mh_snr, ...);
```

## Testplan

- [ ] Build für alle 7 Targets erfolgreich (Heltec V3 getestet ✓)
- [ ] Webserver zeigt korrekte Hardware-Zuordnung nach Hey über Relay
- [ ] RSSI/SNR-Werte im Webserver stimmen mit direktem Empfang überein
- [ ] Neighbor Count (NCOUNT) wird weiterhin korrekt aktualisiert

🤖 Generated with [Claude Code](https://claude.com/claude-code)