### PR TITLE
fix: conffin nur einmal senden, nach Queue-Drain

### DIFF
--- a/release.md
+++ b/release.md
@@ -1,9 +1,28 @@
-# Release Notes -- MeshCom Firmware v4.35* (2026-03-19)
+# Release Notes -- MeshCom Firmware v4.35* (2026-03-21)
 
 Nachrichtenprioritaet, Trickle-HEY, erweiterte Statistik,
 APRS-Parser Hardening und diverse Bugfixes auf Basis von `oe1kbc_v4.35p`.
 
 Kein On-Air-Change — alte Firmware empfaengt alle Pakete korrekt.
+
+---
+
+## Upstream-Sync 2026-03-21 (oe1kbc_v4.35p)
+
+Rebase auf aktuellen upstream. Alle lokalen Commits wurden upstream uebernommen
+(inkl. MHeard RSSI/SNR Fix via PR #785, mit zusaetzlichen Korrekturen vom Maintainer).
+
+Neue Aenderungen aus upstream:
+- BLE connect confirmation nach Nachrichten-Empfang
+- BLE connect confirmation allgemein
+- T-Deck Fonts und Symbole ueberarbeitet
+- Neuer Befehl `cleanflash` / `clearflash`
+- GPS HDOP Anpassung
+- MHeard: Distanz nur bei Berechnung setzen (Maintainer-Fix zu unserem PR)
+- MHeard: HEY-Distanz aus MHeard-Buffer (Maintainer-Fix zu unserem PR)
+- Merge PR #785 (unser MHeard RSSI/SNR Fix)
+
+Unsere uebernommenen Commits: alle (Branch ist jetzt identisch mit upstream)
 
 ---
 

--- a/src/esp32/esp32_main.cpp
+++ b/src/esp32/esp32_main.cpp
@@ -236,6 +236,7 @@ uint32_t PIN = 000000;             // pairing password PIN Passwort PIN-Code Ken
 
 // Queue for sending config jsons to phone
 bool config_to_phone_prepare = false;
+bool conffin_sent = false;
 unsigned long config_to_phone_prepare_timer = 0;
 unsigned long config_to_phone_datetime_timer = 0;
 const uint8_t json_configs_cnt = 10;
@@ -252,6 +253,7 @@ class MyServerCallbacks: public NimBLEServerCallbacks {
     {
         deviceConnected = true;
         config_to_phone_prepare = true;
+        conffin_sent = false;
 
         Serial.printf("BLE Connected with: %s\n", connInfo.getAddress().toString().c_str());
         pServer->updateConnParams(connInfo.getConnHandle(), 24, 48, 0, 180);
@@ -2553,24 +2555,22 @@ void esp32loop()
                         ble_wait = millis();
                     }
                 }
-                else
+                else if (toPhoneWrite != toPhoneRead)
                 {
-                    // check if we have messages for BLE to send
-                    if (toPhoneWrite != toPhoneRead)
+                    // wait for each message to send to phone
+                    if ((ble_wait + 400) < millis())
                     {
-                        // wait for each message to send to phone
-                        if ((ble_wait + 400) < millis())
-                        {
-                            sendToPhone();
+                        sendToPhone();
 
-                            ble_wait = millis();
-                        }
+                        ble_wait = millis();
                     }
                 }
-
-
-                // set the config finish msg for phone at the end of the queue, so it comes after the offline TXT msgs
-                commandAction((char*)"--conffin", isPhoneReady, true);
+                else if (!conffin_sent)
+                {
+                    // both queues empty — send config finish once
+                    commandAction((char*)"--conffin", isPhoneReady, true);
+                    conffin_sent = true;
+                }
 
                 iPhoneState = 0;
             }

--- a/src/nrf52/nrf52_ble.cpp
+++ b/src/nrf52/nrf52_ble.cpp
@@ -29,6 +29,7 @@ extern uint8_t txt_msg_len_phone;
 extern bool bInitDisplay;
 extern uint8_t dmac[6];
 extern bool config_to_phone_prepare;
+extern bool conffin_sent;
 
 // Create device name
 char helper_string[256] = {0};
@@ -194,6 +195,7 @@ void connect_callback(uint16_t conn_handle)
 
 	isPhoneReady = 1;
 	config_to_phone_prepare = true;
+	conffin_sent = false;
 	g_ble_uart_is_connected = true;
 
 }

--- a/src/nrf52/nrf52_main.cpp
+++ b/src/nrf52/nrf52_main.cpp
@@ -192,6 +192,7 @@ bool bHeyFirst = true;
 // Queue for sending config jsons to phone
 uint8_t iPhoneState = 0;
 bool config_to_phone_prepare = false;
+bool conffin_sent = false;
 unsigned long config_to_phone_prepare_timer = 0;
 unsigned long config_to_phone_datetime_timer = 0;
 const uint8_t json_configs_cnt = 9;
@@ -1457,19 +1458,18 @@ if (isPhoneReady == 1)
                 // send JSON config to phone after BLE connection
                 if (ComToPhoneWrite != ComToPhoneRead)
                 {
-                    sendComToPhone();   
+                    sendComToPhone();
                 }
-                else
+                else if (toPhoneWrite != toPhoneRead)
                 {
-                    // check if we have messages for BLE to send
-                    if (toPhoneWrite != toPhoneRead)
-                    {
-                        sendToPhone();   
-                    }
+                    sendToPhone();
                 }
-
-                // set the config finish msg for phone at the end of the queue, so it comes after the offline TXT msgs
-                commandAction((char*)"--conffin", isPhoneReady, true);
+                else if (!conffin_sent)
+                {
+                    // both queues empty — send config finish once
+                    commandAction((char*)"--conffin", isPhoneReady, true);
+                    conffin_sent = true;
+                }
 
                 iPhoneState = 0;
             }


### PR DESCRIPTION
## Zusammenfassung

`--conffin` wird aktuell bei **jedem Loop-Durchlauf** gesendet (wenn `iPhoneState > 3`),
auch waehrend die BLE-Queues (`ComToPhone`, `toPhone`) noch Daten enthalten.
Die Phone-App empfaengt `conffin` bevor alle Register uebertragen sind und zeigt
fehlende Register als "nicht empfangen" an.

### Aenderungen

**Neues Flag `conffin_sent`** (bool, wird bei BLE-Connect auf `false` gesetzt):

- **esp32_main.cpp**: `conffin_sent` Deklaration + Reset im `onConnect` Callback.
  In der Main-Loop wird `--conffin` nur gesendet wenn beide Queues leer sind
  (`ComToPhoneWrite == ComToPhoneRead` UND `toPhoneWrite == toPhoneRead`)
  und `conffin_sent == false`. Danach wird das Flag auf `true` gesetzt.

- **nrf52_main.cpp**: Gleiche Logik wie esp32.

- **nrf52_ble.cpp**: `extern bool conffin_sent` + Reset im `connect_callback`.

### Vorher (IST)

```
iPhoneState > 3:
  → 1x Nachricht aus Queue senden
  → --conffin senden          ← JEDES MAL (auch bei vollen Queues)
  → iPhoneState = 0
```

### Nachher (SOLL)

```
iPhoneState > 3:
  → if ComToPhone hat Daten: 1x senden
  → else if toPhone hat Daten: 1x senden
  → else if !conffin_sent: --conffin senden (einmalig)
  → iPhoneState = 0
```

## Betroffene Dateien

- `src/esp32/esp32_main.cpp`
- `src/nrf52/nrf52_main.cpp`
- `src/nrf52/nrf52_ble.cpp`

## Test Plan

- [ ] ESP32: BLE verbinden, pruefen ob alle Node-Register (Info, SN, GPS, APRS, SW, etc.) gruen angezeigt werden
- [ ] ESP32: Pruefen ob conffin nur einmal im Serial-Log erscheint (nach letztem Register)
- [ ] nRF52 (RAK4631): Gleicher Test wie ESP32
- [ ] Reconnect-Test: BLE trennen und neu verbinden — Register muessen erneut vollstaendig uebertragen werden

🤖 Generated with [Claude Code](https://claude.com/claude-code)