### PR TITLE
fix(nrf52): BLE CR/BW Anzeige + RX_PROCESS State-Log

### DIFF
--- a/docs/nRF52-cr-bw-fix.md
+++ b/docs/nRF52-cr-bw-fix.md
@@ -1,0 +1,70 @@
+# nRF52 BLE: Falsche Bandwidth / Coding Rate im WebApp
+
+**Datum:** 2026-03-21
+**Branch:** v4.35p_prio
+**Plattform:** nRF52840 (RAK4631)
+**Symptom:** WebApp zeigt Bandwidth = 1 kHz (statt 250) und Coding Rate = 2 (statt 6) bei EU8
+
+---
+
+## Problem
+
+Die Funktion `sendNodeSetting()` in `src/command_functions.cpp` (Zeile 4729–4730) sendet die
+rohen `meshcom_settings`-Werte per BLE-JSON an die WebApp:
+
+```c
+nsetdoc["MCR"] = meshcom_settings.node_cr;   // RAK: encoded 2
+nsetdoc["MBW"] = meshcom_settings.node_bw;   // RAK: encoded 1
+```
+
+Auf **ESP32** werden Bandwidth und Coding Rate als physikalische Werte gespeichert
+(`node_bw = 250.0`, `node_cr = 6`), daher stimmt die Anzeige.
+
+Auf **nRF52 (RAK4631)** verwendet die SX126x-Library jedoch einen **Index-basierten Encoding**:
+
+| Setting      | RAK-Rohwert | Bedeutung       | WebApp zeigt |
+|--------------|-------------|-----------------|--------------|
+| `node_bw`    | `0`         | 125.0 kHz       | 0 kHz        |
+| `node_bw`    | `1`         | 250.0 kHz       | **1 kHz**    |
+| `node_bw`    | `2`         | 500.0 kHz       | 2 kHz        |
+| `node_cr`    | `1`         | CR 4/5          | 1            |
+| `node_cr`    | `2`         | CR 4/6          | **2**        |
+| `node_cr`    | `3`         | CR 4/7          | 3            |
+| `node_cr`    | `4`         | CR 4/8          | 4            |
+
+Die Konvertierung existiert bereits in `src/lora_setchip.cpp`:
+
+- **`getBW()`** (Zeile 98–117) — wandelt RAK-Index → kHz-Wert
+- **`getCR()`** (Zeile 128–149) — wandelt RAK-Index → CR-Wert (5–8)
+
+Diese Funktionen werden aber beim BLE-Versand nicht verwendet.
+
+## Ursache
+
+Country-Profile (z.B. EU8) in `lora_setchip.cpp` setzen plattformspezifische Werte:
+
+```c
+case 8:  // EU8
+    #if defined BOARD_RAK4630
+        meshcom_settings.node_bw = 1;      // Index für 250 kHz
+        meshcom_settings.node_cr = 2;      // Index für CR 4/6
+    #else
+        meshcom_settings.node_bw = 250.0;  // Direkt kHz
+        meshcom_settings.node_cr = 6;      // Direkt CR
+    #endif
+```
+
+Die `sendNodeSetting()`-Funktion gibt diese Rohwerte ohne Dekodierung weiter.
+
+## Fix
+
+In `src/command_functions.cpp`, `sendNodeSetting()`:
+
+```diff
+- nsetdoc["MCR"] = meshcom_settings.node_cr;
+- nsetdoc["MBW"] = meshcom_settings.node_bw;
++ nsetdoc["MCR"] = getCR();
++ nsetdoc["MBW"] = getBW();
+```
+
+Damit werden auf allen Plattformen die physikalischen Werte gesendet.

--- a/src/command_functions.cpp
+++ b/src/command_functions.cpp
@@ -4726,8 +4726,8 @@ void sendNodeSetting()
     nsetdoc["TXP"] = meshcom_settings.node_power;
     nsetdoc["MQRG"] = node_qrg;
     nsetdoc["MSF"] = meshcom_settings.node_sf;
-    nsetdoc["MCR"] = meshcom_settings.node_cr;
-    nsetdoc["MBW"] = meshcom_settings.node_bw;
+    nsetdoc["MCR"] = getCR();
+    nsetdoc["MBW"] = getBW();
     nsetdoc["GWNPOS"] = bGATEWAY_NOPOS;
     nsetdoc["NOALL"] = bNoMSGtoALL;
     nsetdoc["BLED"] = bUSER_BOARD_LED;

--- a/src/lora_functions.cpp
+++ b/src/lora_functions.cpp
@@ -329,6 +329,10 @@ void OnRxDone(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr)
         Serial.printf("[MC-DBG] CAD_ABORT_BY_RX\n");
     if(bLORADEBUG)
         Serial.printf("[MC-DBG] RX_RESTART_EARLY src=OnRxDone\n");
+    // Log RX_LISTEN -> RX_PROCESS here (not in OnHeaderDetect ISR where
+    // Serial.printf is unreliable on nRF52)
+    if(bLORADEBUG)
+        Serial.printf("[MC-SM] RX_LISTEN -> RX_PROCESS rc=0\n");
     #endif
 
     // only for Test T5_EPAPER


### PR DESCRIPTION
## Zusammenfassung

Zwei gezielte Fixes fuer die nRF52-Plattform (RAK4631):

### 1. BLE Coding Rate / Bandwidth Anzeige korrigiert

**Datei:** `src/command_functions.cpp` (Zeile 4729–4730)

**Problem:** Die Funktion `sendNodeSetting()` sendet die rohen `meshcom_settings`-Werte
(`node_cr`, `node_bw`) per BLE-JSON an die WebApp. Auf nRF52 verwendet die SX126x-Library
jedoch index-basiertes Encoding (z.B. `node_bw = 1` fuer 250 kHz, `node_cr = 2` fuer CR 4/6).
Die WebApp zeigt dadurch falsche Werte an: Bandwidth = 1 kHz statt 250, Coding Rate = 2 statt 6.

**Ursache:** Country-Profile (z.B. EU8) setzen plattformspezifische Werte — auf ESP32 direkt
physikalisch (`250.0`, `6`), auf nRF52 als Index (`1`, `2`). Die Konvertierungsfunktionen
`getBW()` und `getCR()` existieren bereits in `lora_setchip.cpp`, werden aber beim BLE-Versand
nicht verwendet.

**Fix:** `meshcom_settings.node_cr` → `getCR()` und `meshcom_settings.node_bw` → `getBW()`.
Damit werden auf allen Plattformen die korrekten physikalischen Werte gesendet.

### 2. RX_PROCESS State-Log in OnRxDone

**Datei:** `src/lora_functions.cpp` (Zeile 332–335)

**Problem:** Der State-Uebergang RX_LISTEN → RX_PROCESS wurde bisher im `OnHeaderDetect`-ISR
geloggt, wo `Serial.printf` auf nRF52 unzuverlaessig ist (ISR-Kontext).

**Fix:** State-Log `[MC-SM] RX_LISTEN -> RX_PROCESS` in `OnRxDone()` verschoben, wo der
Serial-Output zuverlaessig funktioniert. Nur aktiv wenn `bLORADEBUG` gesetzt ist.

### Dokumentation

- `docs/nRF52-cr-bw-fix.md`: Detaillierte Analyse des BLE-Anzeigeproblems mit
  Encoding-Tabelle und Plattformvergleich.

## Testplan

- [x] Alle 7 Build-Targets kompilieren erfolgreich (Heltec V3, E22, T-Beam, T-Beam Supreme, T-Deck, T-Deck Plus, RAK4631)
- [ ] RAK4631: WebApp zeigt korrekte BW (250 kHz) und CR (6) bei EU8
- [ ] RAK4631: `[MC-SM] RX_LISTEN -> RX_PROCESS` erscheint im Serial-Monitor bei Paketempfang (mit LORADEBUG)
- [ ] ESP32: Keine Regression — BW/CR-Anzeige weiterhin korrekt

🤖 Generated with [Claude Code](https://claude.com/claude-code)