### PR TITLE
fix(lora): Doppel-Send nach ACK verhindert

### DIFF
--- a/src/lora_functions.cpp
+++ b/src/lora_functions.cpp
@@ -1607,7 +1607,7 @@ bool doTX()
 
                 // For text messages needing retransmit: restore length so
                 // updateRetransmissionStatus() can find and retransmit them.
-                if(save_ring_status != (char)RING_STATUS_DONE && ringBuffer[save_read][2] == MSG_TYPE_TEXT)
+                if(ringBuffer[save_read][1] != (char)RING_STATUS_DONE && ringBuffer[save_read][2] == MSG_TYPE_TEXT)
                     ringBuffer[save_read][0] = sendlng;
 
                 return true;
@@ -1670,7 +1670,7 @@ bool doTX()
 
                     // For text messages needing retransmit: restore length so
                     // updateRetransmissionStatus() can find and retransmit them.
-                    if(save_ring_status != (char)RING_STATUS_DONE && ringBuffer[save_read][2] == MSG_TYPE_TEXT)
+                    if(ringBuffer[save_read][1] != (char)RING_STATUS_DONE && ringBuffer[save_read][2] == MSG_TYPE_TEXT)
                         ringBuffer[save_read][0] = sendlng;
 
                     return true;


### PR DESCRIPTION
## Problembeschreibung

Text-Nachrichten werden nach erhaltenem ACK (binaer vom Gateway) ein zweites Mal gesendet. Beobachtet im Log: Nachricht `91A4350F` wurde 9 Sekunden nach dem ACK nochmals auf LoRa ausgestrahlt.

## Ursache: Race Condition in `doTX()`

In `doTX()` wird der Ring-Buffer-Status vor dem TX in `save_ring_status` gespeichert (Zeile 1505). Nach erfolgreichem TX wird anhand dieses **gespeicherten** Status entschieden, ob `len` wiederhergestellt wird (fuer Retransmit-Tracking):

```cpp
if(save_ring_status != (char)RING_STATUS_DONE && ringBuffer[save_read][2] == MSG_TYPE_TEXT)
    ringBuffer[save_read][0] = sendlng;
```

Wenn ein binaeres ACK **waehrend** des TX eintrifft, setzt `findAndStopRingSlot()` den Slot auf `RING_STATUS_DONE`. Aber `save_ring_status` ist noch `READY` (gespeichert vor dem TX) — daher wird `len` trotzdem wiederhergestellt. `getNextTxSlot()` findet den Slot erneut (`len > 0` UND `status == DONE`) und sendet die Nachricht ein zweites Mal.

### Ablauf der Race Condition

```
T1: doTX() liest Slot → save_ring_status = READY, len = 98
T2: doTX() setzt len=0, status=SENT → Radio sendet
T3: Binaeres ACK → findAndStopRingSlot() setzt status=DONE
T4: OnTxDone → save_ring_status(READY) != DONE → len=98 wiederhergestellt
T5: getNextTxSlot() → len>0, status==DONE → MATCH → Doppel-Send!
```

**Hinweis:** Das implizite ACK (eigenes Paket zurueckgehoert, Zeile 399-401) ist nicht betroffen, da dort `len=0` gesetzt wird.

## Fix

An beiden Stellen in `doTX()` (Zeile 1610 und 1673) den **aktuellen** `ringBuffer`-Status pruefen statt den gespeicherten `save_ring_status`:

```cpp
// vorher:
if(save_ring_status != (char)RING_STATUS_DONE && ...)
// nachher:
if(ringBuffer[save_read][1] != (char)RING_STATUS_DONE && ...)
```

## Geaenderte Datei

- `src/lora_functions.cpp` — Zeile 1610 und 1673: `save_ring_status` → `ringBuffer[save_read][1]`

## Auswirkungsanalyse

| Case | Vorher | Nachher | Aenderung? |
|------|--------|---------|------------|
| Relay (fire-and-forget) | len nicht restored | len nicht restored | Kein Unterschied |
| Implizites ACK | len=0 durch RX-Pfad | len=0 + status==DONE | Besser (doppelte Absicherung) |
| Binaeres ACK waehrend TX | len restored → **Doppel-Send** | status==DONE → len nicht restored | **Bug behoben** |
| Kein ACK (Retransmit) | len restored → Timer laeuft | status==SENT → len restored | Kein Unterschied |

## Test

Alle 7 Build-Targets kompilieren erfolgreich (Heltec V3, E22, T-Beam, T-Beam Supreme, T-Deck, T-Deck Plus, RAK4631).