### PR TITLE
fix(lora): findAndStopRingSlot len=0 (Doppel-Send v2)

### DIFF
--- a/src/lora_functions.cpp
+++ b/src/lora_functions.cpp
@@ -178,6 +178,7 @@ static int findAndStopRingSlot(uint32_t msgId)
             if(extractRingMsgId(i) == msgId)
             {
                 ringBuffer[i][1] = RING_STATUS_DONE;
+                ringBuffer[i][0] = 0;  // clear len so getNextTxSlot skips this slot
                 retryCount[i] = 0;
                 return i;
             }


### PR DESCRIPTION
## Zusammenfassung

Folge-Fix zu PR #792. Der erste Fix (doTX prueeft aktuellen Status statt gespeicherten) reicht nicht aus — der Doppel-Send tritt weiterhin auf, wenn das binaere ACK **nach** OnTxDone eintrifft.

## Problem

`findAndStopRingSlot()` setzt bei binaером ACK nur `status=DONE`, aber **nicht** `len=0`:

```cpp
ringBuffer[i][1] = RING_STATUS_DONE;
retryCount[i] = 0;
// len bleibt > 0!
```

Der implizite ACK-Pfad (eigenes Paket zurueckgehoert, Zeile 399-401) setzt dagegen korrekt auch `len=0`.

### Ablauf

```
T1: doTX() liest Slot → status=READY, len=98
T2: status=SENT, len=0, Radio sendet
T3: OnTxDone → status=SENT != DONE → len=98 wiederhergestellt (fuer Retransmit)
T4: Binaeres ACK → findAndStopRingSlot() → status=DONE, aber len bleibt 98
T5: getNextTxSlot() → len>0 + status==DONE → Doppel-Send!
```

## Fix

Eine Zeile in `findAndStopRingSlot()` — `ringBuffer[i][0] = 0` nach dem Setzen von `RING_STATUS_DONE`:

```cpp
ringBuffer[i][1] = RING_STATUS_DONE;
ringBuffer[i][0] = 0;  // clear len so getNextTxSlot skips this slot
retryCount[i] = 0;
```

## Geaenderte Datei

- `src/lora_functions.cpp` Zeile 181: `ringBuffer[i][0] = 0` eingefuegt

## Testergebnis

| Szenario | Vorher (mit PR #792) | Nachher |
|----------|---------------------|---------|
| RAK4631, eigene Textnachrichten | 12 von 28 doppelt (43%) | 0 von 7 doppelt (0%) |
| Heltec V3 | 0 (zu wenig eigene TX) | 0 |

Alle 7 Build-Targets kompilieren erfolgreich.