### PR TITLE
fix: UDP-to-LoRa Relay Race Condition + nrf_eth Ring Buffer Alignment

### DIFF
--- a/src/configuration_global.h
+++ b/src/configuration_global.h
@@ -1,7 +1,7 @@
 #define SOURCE_VERSION "4.35"
 #define SOURCE_VERSION_SUB "q"
 
-#define FLASH_VERSION 20260322
+#define FLASH_VERSION 20260323
 
 //Hardware Types
 #define TLORA_V2 1

--- a/src/lora_functions.cpp
+++ b/src/lora_functions.cpp
@@ -173,7 +173,7 @@ static int findAndStopRingSlot(uint32_t msgId)
 {
     for(int i = 0; i < MAX_RING; i++)
     {
-        if(ringBuffer[i][0] > 0 && ringBuffer[i][1] != RING_STATUS_DONE)
+        if(ringBuffer[i][0] > 0 && ringBuffer[i][1] != RING_STATUS_DONE && ringBuffer[i][1] != RING_STATUS_READY)
         {
             if(extractRingMsgId(i) == msgId)
             {
@@ -380,13 +380,21 @@ void OnRxDone(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr)
         int rxSlot = -1;
         for(int i = 0; i < MAX_RING; i++)
         {
-            if(ringBuffer[i][0] > 0 && ringBuffer[i][1] != RING_STATUS_DONE)
+            if(ringBuffer[i][0] > 0 && ringBuffer[i][1] != RING_STATUS_DONE && ringBuffer[i][1] != RING_STATUS_READY)
             {
                 if(memcmp(ringBuffer[i]+3, RcvBuffer+1, 4) == 0)
                 {
                     rxSlot = i;
                     dbg_msg_id = extractRingMsgId(i);
                     break;
+                }
+            }
+            else if(ringBuffer[i][0] > 0 && ringBuffer[i][1] == RING_STATUS_READY)
+            {
+                if(memcmp(ringBuffer[i]+3, RcvBuffer+1, 4) == 0)
+                {
+                    if(bLORADEBUG)
+                        Serial.printf("[MC-DBG] ACK_SKIP_READY slot=%d msg_id=%08X\n", i, extractRingMsgId(i));
                 }
             }
         }

--- a/src/nrf52/nrf_eth.cpp
+++ b/src/nrf52/nrf_eth.cpp
@@ -12,6 +12,7 @@
 #include <command_functions.h>
 #include <time_functions.h>
 #include <lora_setchip.h>
+#include <lora_functions.h>
 #include <extudp_functions.h>
 
 #include <NTPClient.h>
@@ -428,51 +429,49 @@ int NrfETH::getUDP()
               }
             }
 
-            int icheck = checkOwnTx(aprsmsg.msg_id);
+            // Check dedup ring first (same check that LoRa RX path uses)
+            uint8_t udp_mid[4] = {
+                (uint8_t)(aprsmsg.msg_id),
+                (uint8_t)(aprsmsg.msg_id >> 8),
+                (uint8_t)(aprsmsg.msg_id >> 16),
+                (uint8_t)(aprsmsg.msg_id >> 24)
+            };
 
-            if(bDisplayInfo)
-              Serial.printf("OWN-TX-CHECK-UDP msg_id:%08X check:%i\n", aprsmsg.msg_id, icheck);
-            
-            if(icheck < 0)
+            if(is_new_packet(udp_mid))
             {
-              // resend only Packet
-              if(bUDPtoLoraSend)
+              int icheck = checkOwnTx(aprsmsg.msg_id);
+
+              if(bDisplayInfo)
+                Serial.printf("OWN-TX-CHECK-UDP msg_id:%08X check:%i\n", aprsmsg.msg_id, icheck);
+
+              if(icheck < 0)
               {
-                // store last message to compare later on
-                insertOwnTx(aprsmsg.msg_id);
-
-                ringBuffer[iWrite][0] = size;
-                if (msg_type_b == 0x3A) // only Messages
+                // resend only Packet
+                if(bUDPtoLoraSend)
                 {
-                  if(aprsmsg.msg_payload.startsWith("{") > 0)
-                      ringBuffer[iWrite][1] = 0xFF; // retransmission Status ...0xFF no retransmission on {CET} & Co.
-                  else
-                      ringBuffer[iWrite][1] = 0x00; // retransmission Status ...0xFF no retransmission
-                }
-                else
-                  ringBuffer[iWrite][1] = 0xFF; // retransmission Status ...0xFF no retransmission
-                memcpy(ringBuffer[iWrite] + 2, convBuffer, size);
-                iWrite++;
-                if (iWrite >= MAX_RING) // if the buffer is full we start at index 0 -> take care of overwriting!
-                  iWrite = 0;
+                  // store last message to compare later on
+                  insertOwnTx(aprsmsg.msg_id);
 
-                if(bDEBUG)
-                {
-                  Serial.printf("RX-UDP addLoraRxBuffer\n");
-                }
+                  ringBuffer[iWrite][0] = size;
+                  ringBuffer[iWrite][1] = RING_STATUS_DONE; // fire-and-forget, no retransmission for UDP relay
+                  memcpy(ringBuffer[iWrite] + 2, convBuffer, size);
 
-                addLoraRxBuffer(aprsmsg.msg_id, true);
+                  retryCount[iWrite] = 0;
+                  addTxRingEntry("udp_rx");
 
-                // add rcvMsg to BLE out Buff
-                // size message is int -> uint16_t buffer size
-                if(isPhoneReady == 1 && bBLELoopOut) // wird schon vorher abgehandelt
-                {
-                    if(bDEBUG)
-                    {
-                      Serial.printf("RX-UDP addBLEOutBuffer\n");
-                    }
-                    
-                    addBLEOutBuffer(convBuffer, size);
+                  addLoraRxBuffer(aprsmsg.msg_id, true);
+
+                  // add rcvMsg to BLE out Buff
+                  // size message is int -> uint16_t buffer size
+                  if(isPhoneReady == 1 && bBLELoopOut) // wird schon vorher abgehandelt
+                  {
+                      if(bDEBUG)
+                      {
+                        Serial.printf("RX-UDP addBLEOutBuffer\n");
+                      }
+
+                      addBLEOutBuffer(convBuffer, size);
+                  }
                 }
               }
             }


### PR DESCRIPTION
## Zusammenfassung

Cherry-Pick von PR #802 (oe1kbc_v4.35p) auf oe1kbc_4.35q.

Behebt eine Race Condition, bei der Broadcast-Nachrichten vom MeshCom-Server lokale RF-Nodes nicht erreichen, wenn ein entfernter Gateway dieselbe Nachricht schneller per LoRa sendet als der lokale Gateway.

## Problem (Log-Nachweis: OE1KBC-12, msg_id AC573C4B)

1. OE1KBC-12 empfaengt eine Textnachricht (DL4QB-90) via UDP vom Server und stellt sie in die TX-Queue (status=READY)
2. OE3CZC-1 empfaengt dieselbe Nachricht ebenfalls via UDP und sendet sie **schneller** per LoRa
3. OE1KBC-12 hoert die LoRa-Uebertragung von OE3CZC-1 — die `ACK_RECEIVED`-Logik findet den noch nicht gesendeten TX-Slot und **loescht ihn**
4. T-DECK, E290 und E22 im lokalen Tischnetzwerk von OE1KBC-12 erhalten die Nachricht **nie**

## Aenderungen

### Fix 1: ACK_RECEIVED Status Guard (`src/lora_functions.cpp`)

- `findAndStopRingSlot()` und `OnRxDone()` ACK_RECEIVED-Block: Slots mit `RING_STATUS_READY` (noch nie gesendet) werden **nicht mehr geloescht**
- Nur bereits gesendete Slots (`RING_STATUS_SENT` und hoeher) werden gestoppt
- Debug-Log `ACK_SKIP_READY` wenn ein READY-Slot uebersprungen wird
- Betrifft **alle Plattformen** (ESP32 + nRF52)

### Fix 2: nrf_eth.cpp Ring Buffer Alignment (`src/nrf52/nrf_eth.cpp`)

Der nRF52 UDP-Empfangscode hatte drei Abweichungen gegenueber dem ESP32-Aequivalent (`udp_functions.cpp`):

| Aspekt | Vorher (nrf_eth.cpp) | Nachher |
|--------|---------------------|---------|
| Dedup-Check | fehlte | `is_new_packet()` vor Ring-Write |
| Ring-Write | direktes `iWrite++` | `addTxRingEntry("udp_rx")` mit Priority, Enqueue-Time, Overflow-Handling |
| Retransmission | `0x00` (READY) fuer Textnachrichten → bis zu 3 sinnlose Retransmits | `RING_STATUS_DONE` (fire-and-forget) fuer alle UDP-Relay-Nachrichten |
| retryCount | nicht initialisiert | `retryCount[iWrite] = 0` |

### Kein Code-Refactoring

Ausschliesslich minimale, gezielte Bugfixes. Keine Umstrukturierung bestehenden Codes.

## Test

- Alle 7 Targets kompilieren fehlerfrei (Heltec V3, E22, T-Beam, T-Beam Supreme, T-Deck, T-Deck Plus, RAK4631)
- RAK4631 geflasht und laeuft

🤖 Generated with [Claude Code](https://claude.com/claude-code)