### PR TITLE
feat: Heap/RAM Monitoring via Serial (ESP32 + nRF52)

### DIFF
--- a/src/configuration_global.h
+++ b/src/configuration_global.h
@@ -1,7 +1,7 @@
 #define SOURCE_VERSION "4.35"
 #define SOURCE_VERSION_SUB "p"
 
-#define FLASH_VERSION 20260323
+#define FLASH_VERSION 20260324
 
 //Hardware Types
 #define TLORA_V2 1

--- a/src/esp32/esp32_main.cpp
+++ b/src/esp32/esp32_main.cpp
@@ -631,7 +631,8 @@ void esp32setup()
     Serial.println("CLIENT SETUP");
     Serial.println("============");
 
-    Serial.printf("%s;[HEAP];%d;(free)\n", getTimeString().c_str(), ESP.getFreeHeap());
+    Serial.printf("%s;[HEAP];%d;%d;%d;(init)\n", getTimeString().c_str(),
+        ESP.getFreeHeap(), ESP.getMinFreeHeap(), ESP.getMaxAllocHeap());
     Serial.printf("%s;[PSRM];%d\n", getTimeString().c_str(), ESP.getFreePsram());
     
     check_efuse();
@@ -2963,6 +2964,28 @@ void esp32loop()
             #endif
 
             BattTimeWait = millis();
+        }
+    }
+
+    // Heap Monitor — always active, 60s interval
+    {
+        static unsigned long heapMonTimer = 0;
+        if (heapMonTimer == 0)
+            heapMonTimer = millis();
+
+        if ((heapMonTimer + 60000) < millis())
+        {
+            Serial.printf("%s;[HEAP];%d;%d;%d;(mon)\n",
+                getTimeString().c_str(),
+                ESP.getFreeHeap(),
+                ESP.getMinFreeHeap(),
+                ESP.getMaxAllocHeap());
+            #if defined(BOARD_HAS_PSRAM)
+            Serial.printf("%s;[PSRM];%d;(mon)\n",
+                getTimeString().c_str(),
+                ESP.getFreePsram());
+            #endif
+            heapMonTimer = millis();
         }
     }
 

--- a/src/nrf52/nrf52_main.cpp
+++ b/src/nrf52/nrf52_main.cpp
@@ -28,18 +28,32 @@
 #include <malloc.h>
 OneButton btn;
 
-// nRF52 heap monitoring: heap_3 wraps libc malloc, so we use mallinfo()
-// fordblks = free bytes within arena already obtained from system
-// The gap between current sbrk and stack is additional free memory
-extern "C" char *sbrk(int incr);
+// nRF52 heap monitoring using Adafruit framework APIs (debug.h)
+// dbgHeapTotal() = __HeapLimit - __HeapBase (linker symbols)
+// dbgHeapUsed()  = mallinfo().uordblks (allocated bytes)
+extern int dbgHeapTotal(void);
+extern int dbgHeapUsed(void);
+
 static uint32_t nrf52_getFreeHeap(void)
 {
-    struct mallinfo mi = mallinfo();
-    char topOfStack;
-    // free = (stack pointer - current program break) + free chunks inside arena
-    uint32_t freeFromSbrk = (uint32_t)(&topOfStack) - (uint32_t)sbrk(0);
-    return freeFromSbrk + mi.fordblks;
+    return (uint32_t)(dbgHeapTotal() - dbgHeapUsed());
 }
+
+// Largest contiguous free block — binary search probe (fragmentation indicator)
+static uint32_t nrf52_getMaxFreeBlock(void)
+{
+    uint32_t lo = 0, hi = nrf52_getFreeHeap();
+    while (lo + 64 < hi) {
+        uint32_t mid = (lo + hi) / 2;
+        void *p = malloc(mid);
+        if (p) { free(p); lo = mid; }
+        else   { hi = mid; }
+    }
+    return lo;
+}
+
+// Min-free watermark since boot
+static uint32_t nrf52_heapMinFree = UINT32_MAX;
 
 // Ethernet Object
 NrfETH neth;
@@ -366,8 +380,11 @@ void nrf52setup()
 
     Serial.println("=====================================");
     Serial.println("[INIT] START CLIENT");
-    Serial.printf("%s;[HEAP];%lu;(free)\n", getTimeString().c_str(),
-        (unsigned long)nrf52_getFreeHeap());
+    nrf52_heapMinFree = nrf52_getFreeHeap();
+    Serial.printf("%s;[HEAP];%lu;%lu;%lu;(init)\n", getTimeString().c_str(),
+        (unsigned long)nrf52_getFreeHeap(),
+        (unsigned long)nrf52_heapMinFree,
+        (unsigned long)nrf52_getMaxFreeBlock());
 
     // init nach Reboot
     init_loop_function();
@@ -1808,7 +1825,26 @@ if (isPhoneReady == 1)
             BattTimeWait = millis();
         }
     }
-    
+
+    // Heap Monitor — always active, 60s interval
+    {
+        static unsigned long heapMonTimer = 0;
+        if (heapMonTimer == 0)
+            heapMonTimer = millis();
+
+        if ((heapMonTimer + 60000) < millis())
+        {
+            uint32_t freeHeap = nrf52_getFreeHeap();
+            if (freeHeap < nrf52_heapMinFree) nrf52_heapMinFree = freeHeap;
+
+            Serial.printf("%s;[HEAP];%lu;%lu;%lu;(mon)\n",
+                getTimeString().c_str(),
+                (unsigned long)freeHeap,
+                (unsigned long)nrf52_heapMinFree,
+                (unsigned long)nrf52_getMaxFreeBlock());
+            heapMonTimer = millis();
+        }
+    }
 
     if(bONEWIRE)
     {


### PR DESCRIPTION
## Heap/RAM Monitoring für ESP32 und nRF52 (RAK4631)

### Geänderte Dateien
- `src/configuration_global.h` — FLASH_VERSION auf 20260324 aktualisiert
- `src/esp32/esp32_main.cpp` — Heap-Monitoring für ESP32
- `src/nrf52/nrf52_main.cpp` — Heap-Monitoring für nRF52 (inkl. sbrk-Overflow-Fix)

### Was wurde geändert?

**Beide Plattformen:**
- Einheitliches Ausgabeformat über Serial: `timestamp;[HEAP];free;min_free;max_block;(init|mon)`
- Initiale Ausgabe beim Boot (`init`), danach alle 60 Sekunden (`mon`)
- Kein Debug-Flag nötig — Monitoring ist immer aktiv

**ESP32:**
- Nutzt native ESP-IDF APIs: `ESP.getFreeHeap()`, `ESP.getMinFreeHeap()`, `ESP.getMaxAllocHeap()`
- Für S3-Boards mit PSRAM: zusätzliche Ausgabe von `ESP.getFreePsram()`

**nRF52 (RAK4631):**
- **Fix eines kritischen Bugs:** Die bisherige sbrk()-basierte Berechnung lieferte im FreeRTOS-Task-Kontext einen uint32_t-Overflow (~4294937228 statt korrekter Werte)
- **Neue Lösung:** Verwendet Adafruit-Framework Debug-Symbole `dbgHeapTotal()` und `dbgHeapUsed()`, die auf den Linker-Symbolen `__HeapLimit` und `__HeapBase` basieren
- Binary-Search-Probe für den größten zusammenhängenden freien Block (Fragmentierungsindikator)
- Tracking des Heap-Minimum-Free-Watermarks seit Boot

### Warum diese Änderung?

Memory-Leaks und Heap-Fragmentierung sind auf Embedded-Systemen schwer zu diagnostizieren, besonders bei Langzeitbetrieb. Dieses Monitoring ermöglicht:
- Frühzeitige Erkennung von Memory-Leaks über die min_free-Watermark
- Erkennung von Heap-Fragmentierung über den max_block-Wert
- Vergleichbare Metriken auf ESP32 und nRF52 im selben Format