### PR TITLE
nrf52: add optional SX1262 boosted RX gain support

### DIFF
--- a/src/command_functions.cpp
+++ b/src/command_functions.cpp
@@ -645,7 +645,7 @@ void commandAction(char *umsg_text, bool ble)
             Serial.printf("--ptime 99 messuring interval minutes\n");
 
             #if defined(SX126X_V3) || defined(SX1262_E290) || defined(SX1262X) || defined(SX126X) || \
-                defined(SX1262_V3) || defined(USING_SX1262)
+                defined(SX1262_V3) || defined(USING_SX1262) || defined(BOARD_RAK4630)
                 delay(100);
                 Serial.printf("--setboostedgain    on/off  enable/disable boosted rx gain\n");
             #endif
@@ -2322,7 +2322,7 @@ void commandAction(char *umsg_text, bool ble)
         return;
     }
     #if defined(SX126X_V3) || defined(SX1262_E290) || defined(SX1262X) || defined(SX126X) || \
-        defined(SX1262_V3) || defined(USING_SX1262)
+        defined(SX1262_V3) || defined(USING_SX1262) || defined(BOARD_RAK4630)
     else
     if(commandCheck(msg_text+2, (char*)"setboostedgain on") == 0)
     {

--- a/src/loop_functions.h
+++ b/src/loop_functions.h
@@ -10,6 +10,7 @@
     #include <esp32/esp32_flash.h>
 #else
     #include <nrf52/WisBlock-API.h>
+    #include <nrf52/nrf52_radio.h>
 #endif
 
 unsigned long getUnixClock();

--- a/src/lora_functions.cpp
+++ b/src/lora_functions.cpp
@@ -59,6 +59,10 @@
 #include <t5-epaper/t5epaper_main.h>
 #endif
 
+#if defined(BOARD_RAK4630)
+#include <nrf52/nrf52_radio.h>
+#endif
+
 #include "lora_functions.h"
 #include "loop_functions.h"
 #include <loop_functions_extern.h>
@@ -331,7 +335,7 @@ void OnRxDone(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr)
     if(bSPI_ETH_Active) {
         bPendingRadioRx = true;
     } else {
-        Radio.Rx(RX_TIMEOUT_VALUE);
+        startReceive();
     }
     // RACE-05 fix: CAD abort under critical section
     taskENTER_CRITICAL();
@@ -1169,7 +1173,7 @@ void OnRxDone(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr)
 void OnRxTimeout(void)
 {
     #if defined BOARD_RAK4630
-        Radio.Rx(RX_TIMEOUT_VALUE);
+        startReceive();
         // RACE-05 fix: CAD abort under critical section
         taskENTER_CRITICAL();
         if(cad_in_progress) {
@@ -1198,7 +1202,7 @@ void OnRxTimeout(void)
 void OnRxError(void)
 {
     #if defined BOARD_RAK4630
-        Radio.Rx(RX_TIMEOUT_VALUE);
+        startReceive();
         // RACE-05 fix: CAD abort under critical section
         taskENTER_CRITICAL();
         if(cad_in_progress) {
@@ -1842,7 +1846,7 @@ void OnTxDone(void)
         if(bSPI_ETH_Active) {
             bPendingRadioRx = true;
         } else {
-            Radio.Rx(RX_TIMEOUT_VALUE);
+            startReceive();
         }
         iReceiveTimeOutTime = millis();  // force full CSMA timeout before next TX
         csma_reset();
@@ -1880,7 +1884,7 @@ void OnTxTimeout(void)
             bSetLoRaAPRS = false;
         }
 
-        Radio.Rx(RX_TIMEOUT_VALUE);
+        startReceive();
 
     #endif
 

--- a/src/lora_setchip.cpp
+++ b/src/lora_setchip.cpp
@@ -497,7 +497,7 @@ bool lora_setchip_meshcom()
         TX_TIMEOUT_VALUE);
 
     //  Start receiving LoRa packets
-    Radio.Rx(RX_TIMEOUT_VALUE);
+    startReceive();
     
 #else
     // Set MeshCom parameter

--- a/src/nrf52/nrf52_main.cpp
+++ b/src/nrf52/nrf52_main.cpp
@@ -10,6 +10,7 @@
 #include <debugconf.h>
 #include <time.h>
 #include <nrf52_functions.h>
+#include <nrf52_radio.h>
 #include <extudp_functions.h>
 
 #include <TinyGPSPlus.h>
@@ -988,7 +989,7 @@ void nrf52setup()
     Serial.printf("[INIT]...Radio-Status: %i\n", Radio.GetStatus());
 
     //  Start receiving LoRa packets
-    Radio.Rx(RX_TIMEOUT_VALUE);
+    startReceive();
 
     // Configure CAD parameters: 4 symbols, DETPEAK/DETMIN from config, CAD_ONLY mode
     Radio.SetCadParams(LORA_CAD_04_SYMBOL, RADIOLIB_SX126X_DETPEAK, RADIOLIB_SX126X_DETMIN, LORA_CAD_ONLY, 0);
@@ -1284,7 +1285,7 @@ void nrf52loop()
                 rx_irq_defer_count = 0;
                 iReceiveTimeOutTime = 0;
                 taskENTER_CRITICAL();
-                Radio.Rx(RX_TIMEOUT_VALUE);
+                startReceive();
                 taskEXIT_CRITICAL();
                 if(bLORADEBUG)
                 {
@@ -1363,7 +1364,7 @@ void nrf52loop()
                         if(bLORADEBUG)
                             Serial.printf("[MC-DBG] CAD_FREE_NO_TX restoring RX\n");
                         taskENTER_CRITICAL();
-                        Radio.Rx(RX_TIMEOUT_VALUE);
+                        startReceive();
                         taskEXIT_CRITICAL();
                         iReceiveTimeOutTime = millis();
                     }
@@ -1399,7 +1400,7 @@ void nrf52loop()
                     }
 
                     taskENTER_CRITICAL();
-                    Radio.Rx(RX_TIMEOUT_VALUE);
+                    startReceive();
                     taskEXIT_CRITICAL();
                     iReceiveTimeOutTime = millis();
                 }
@@ -1415,7 +1416,7 @@ void nrf52loop()
                 cad_done_flag = false;
                 taskEXIT_CRITICAL();
                 taskENTER_CRITICAL();
-                Radio.Rx(RX_TIMEOUT_VALUE);
+                startReceive();
                 taskEXIT_CRITICAL();
                 iReceiveTimeOutTime = millis();
             }
@@ -1844,7 +1845,7 @@ if (isPhoneReady == 1)
                     Serial.println("LOOP GATEWAY actions UDP received");
             }
             bSPI_ETH_Active = false;  // SPI guard: release bus
-            if(bPendingRadioRx) { bPendingRadioRx = false; Radio.Rx(RX_TIMEOUT_VALUE); }
+            if(bPendingRadioRx) { bPendingRadioRx = false; startReceive(); }
         }
         else
         {
@@ -2220,7 +2221,7 @@ if (isPhoneReady == 1)
         getExternUDP();
         flushExternQueue();
         bSPI_ETH_Active = false;  // SPI guard: release bus
-        if(bPendingRadioRx) { bPendingRadioRx = false; Radio.Rx(RX_TIMEOUT_VALUE); }
+        if(bPendingRadioRx) { bPendingRadioRx = false; startReceive(); }
     }
 
     if(bWEBSERVER || bEXTUDP)
@@ -2244,7 +2245,7 @@ if (isPhoneReady == 1)
                 bSPI_ETH_Active = true;
                 startWebserver();
                 bSPI_ETH_Active = false;
-                if(bPendingRadioRx) { bPendingRadioRx = false; Radio.Rx(RX_TIMEOUT_VALUE); }
+                if(bPendingRadioRx) { bPendingRadioRx = false; startReceive(); }
             }
 
             if(bEXTUDP)
@@ -2252,7 +2253,7 @@ if (isPhoneReady == 1)
                 bSPI_ETH_Active = true;
                 startExternUDP();
                 bSPI_ETH_Active = false;
-                if(bPendingRadioRx) { bPendingRadioRx = false; Radio.Rx(RX_TIMEOUT_VALUE); }
+                if(bPendingRadioRx) { bPendingRadioRx = false; startReceive(); }
             }
         }
 
@@ -2261,7 +2262,7 @@ if (isPhoneReady == 1)
             bSPI_ETH_Active = true;   // SPI guard: Ethernet owns bus (web page delivery)
             loopWebserver();
             bSPI_ETH_Active = false;  // SPI guard: release bus
-            if(bPendingRadioRx) { bPendingRadioRx = false; Radio.Rx(RX_TIMEOUT_VALUE); }
+            if(bPendingRadioRx) { bPendingRadioRx = false; startReceive(); }
         }
 
     }

--- a/src/nrf52/nrf52_radio.cpp
+++ b/src/nrf52/nrf52_radio.cpp
@@ -1,0 +1,19 @@
+#include "nrf52_radio.h"
+
+#include <configuration.h>
+
+#include <LoRaWan-Arduino.h> // includes radio/radio.h which defines Radio
+
+extern bool bBOOSTEDGAIN;
+
+void startReceive()
+{
+    if (bBOOSTEDGAIN)
+    {
+        Radio.RxBoosted(RX_TIMEOUT_VALUE);
+    }
+    else
+    {
+        Radio.Rx(RX_TIMEOUT_VALUE);
+    }
+}

--- a/src/nrf52/nrf52_radio.h
+++ b/src/nrf52/nrf52_radio.h
@@ -1,0 +1,7 @@
+#pragma once
+
+/**
+ * Sets the radio to reception mode for the duration defined by RX_TIMEOUT_VALUE.
+ * If the global variable bBOOSTEDGAIN is set, the maximum LNA gain is used.
+ */
+void startReceive();


### PR DESCRIPTION
### Summary

Add optional boosted RX gain support for SX1262 on wiscore_rak4631.

### Changes

- Introduced `startReceive()` wrapper
- Replaced `Radio.Rx(RX_TIMEOUT_VALUE)` calls in the nrf52 tree
- Wrapper selects `Radio.Rx(RX_TIMEOUT_VALUE)` or `Radio.RxBoosted(RX_TIMEOUT_VALUE)` based on `bBOOSTEDGAIN`

### Testing

Tested enabling boosted gain via:
- tty command: `--setboostedgain on`
- MeshCom-App