### PR TITLE
Reduce compiler warnings found with stricter warning flags

### DIFF
--- a/src/aprs_functions.cpp
+++ b/src/aprs_functions.cpp
@@ -955,20 +955,11 @@ uint16_t encodeStartAPRS(uint8_t msg_buffer[UDP_TX_BUF_SIZE], struct aprsMessage
 
 uint16_t encodePayloadAPRS(uint8_t msg_buffer[MAX_MSG_LEN_PHONE], struct aprsMessage &aprsmsg)
 {
-    uint16_t ilng=aprsmsg.msg_payload.length();
-
-    char msg_start[ilng+1];
-    
-
-    memset(msg_start, 0x00, ilng+1);
-
-    snprintf(msg_start, sizeof(msg_start), "%s", aprsmsg.msg_payload.c_str());
-    
+    auto ilng = aprsmsg.msg_payload.length();
     if(ilng >= UDP_TX_BUF_SIZE)
         ilng = UDP_TX_BUF_SIZE - 1;
-    memcpy(msg_buffer, msg_start, ilng);
-    
-    return ilng;
+    memcpy(msg_buffer, aprsmsg.msg_payload.c_str(), ilng);
+    return static_cast<uint16_t>(ilng);
 }
 
 //10:30:29 RX-LoRa: 105 ! xAE48D54D 05 1 0 9V1LH-1,OE1KBC-12>*!0122.64N/10356.52E#/B=005/A=000161/P=1004.9/H=40.2/T=28.9/Q=1005.4/G232;2321 HW:04 MOD:03 FCS:15D5 FW:17 LH:09

--- a/src/clock.cpp
+++ b/src/clock.cpp
@@ -45,10 +45,7 @@
 #include <Arduino.h>
 #include "clock.h"
 
-//---| globals |----------------------------------------------------------------
-const char* Clock::Months[] = {
-  "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
-};
+#include <time.h>
 
 //----------------------------------------------------------------------------
 // constructor
@@ -151,7 +148,7 @@ bool Clock::EnableAlarm(/*const*/ bool boEnable /*= true*/)
 //const
 char* Clock::GetDateStr()
 {
-	snprintf(szDateStr_m, sizeof(szDateStr_m), "%2u. %s. %04u", suClock_m.tm_mday, Months[suClock_m.tm_mon], 1900 + suClock_m.tm_year);
+	strftime(szDateStr_m, sizeof(szDateStr_m), "%e. %b. %Y", &suClock_m);
 	return szDateStr_m;
 }
 

--- a/src/lora_functions.cpp
+++ b/src/lora_functions.cpp
@@ -1306,7 +1306,7 @@ uint8_t getMessagePriority(int slot)
         int dest_start = -1;
         int dest_end = -1;
 
-        for(int i = path_start; i < len + 2 && i < (int)(UDP_TX_BUF_SIZE + 4); i++)
+        for(int i = path_start; i < len + 2 && i < (UDP_TX_BUF_SIZE + 4); i++)
         {
             if(ringBuffer[slot][i] == '>' && dest_start < 0)
             {

--- a/src/nrf52/nrf52_main.cpp
+++ b/src/nrf52/nrf52_main.cpp
@@ -971,7 +971,7 @@ void nrf52setup()
         (uint32_t)meshcom_settings.node_sf,
         (uint8_t)meshcom_settings.node_cr,
         0, //  AFC bandwidth: Unused with LoRa
-        (uint16_t)preamble_length,
+        preamble_length,
         LORA_SYMBOL_TIMEOUT,
         LORA_FIX_LENGTH_PAYLOAD_ON,
         0,    //  Fixed payload length: N/A
@@ -992,7 +992,7 @@ void nrf52setup()
         (uint32_t)meshcom_settings.node_bw,
         (uint32_t)meshcom_settings.node_sf,
         (uint8_t)meshcom_settings.node_cr,
-        (uint16_t)preamble_length,
+        preamble_length,
         LORA_FIX_LENGTH_PAYLOAD_ON,
         true, // CRC ON
         0,    // fsk only frequ hop
@@ -1812,7 +1812,7 @@ if (isPhoneReady == 1)
             sendHey();
         }
 
-        trickle_interval_ms = min(trickle_interval_ms * 2, (unsigned long)(TRICKLE_IMAX_S * 1000UL));
+        trickle_interval_ms = min(trickle_interval_ms * 2, TRICKLE_IMAX_S * 1000UL);
         trickle_consistent_count = 0;
 
         heyinfo_timer = millis();

--- a/src/time_functions.cpp
+++ b/src/time_functions.cpp
@@ -58,11 +58,11 @@ void getDaysPerMonth(int year, unsigned long day[13])
 
 String getDateTime(unsigned long timestamp)
 {
-    unsigned long days = (unsigned long)SECONDS_PER_DAY;
+    unsigned long days = SECONDS_PER_DAY;
     days = timestamp / days;
 
     int year = EPOCH_YEAR;
-    while (days >= (unsigned long)getDaysForYear(year))
+    while (days >= getDaysForYear(year))
     {
         days -= getDaysForYear(year);
         year++;


### PR DESCRIPTION
This PR addresses some compiler warnings identified by enabling stricter warning flags locally (e.g. `-Wformat-truncation`, `-Wvla`, `-Wuseless-cast`).

The flags themselves are not part of this PR, but were used to uncover potential issues.

Changes include:

- Eliminating redundant casts
- `Clock::GetDateStr`: Replacing manual string formatting with safer alternative `strftime`
- `encodePayloadAPRS`: Simplifying code by removing unnecessary intermediate buffer (VLA, variable length array)

Fixes were only applied where they are considered safe and do not introduce behavioral changes.