### PR TITLE
Fix wiscore_rak4631 upload by setting board explicitly to resolve conflict with t_echo

### DIFF
--- a/variants/t_echo/platformio.ini
+++ b/variants/t_echo/platformio.ini
@@ -1,10 +1,10 @@
 [nrf52]
 platform = nordicnrf52
-board = nrf52840_dk_adafruit
 framework = arduino
 
 [env:t_echo]
 extends = nrf52
+board = nrf52840_dk_adafruit
 
 lib_ignore =
     AceButton

--- a/variants/wiscore_rak4631/platformio.ini
+++ b/variants/wiscore_rak4631/platformio.ini
@@ -1,6 +1,5 @@
 [nrf52]
 platform = nordicnrf52
-board = rak4630
 framework = arduino
 extends = upload_settings
 build_src_filter = 
@@ -25,6 +24,7 @@ build_flags =
 
 [env:wiscore_rak4631]
 extends = nrf52
+board = rak4630
 
 lib_ignore =
     AceButton


### PR DESCRIPTION
The shared `[nrf52]` section caused a conflict between `t_echo` and `wiscore_rak4631`. The board setting from `t_echo` (`nrf52840_dk_adafruit`) was preferred, causing the RAK4631 upload to use J-Link instead of nrfutil.

Fix: board is now set explicitly in both [env:t_echo] and [env:wiscore_rak4631].

**Console output now:**
```
Processing wiscore_rak4631 (board: rak4630; platform: nordicnrf52; framework: arduino)
...
PLATFORM: Nordic nRF52 (10.11.0) > WisCore RAK4631 Board
HARDWARE: NRF52840 64MHz, 243KB RAM, 796KB Flash
DEBUG: Current (jlink) External (jlink, stlink)
...
Configuring upload protocol...
AVAILABLE: jlink, nrfjprog, nrfutil, stlink
CURRENT: upload_protocol = nrfutil
```


**Console output before the fix tries jlink (which fails to open DLL):**
```
Processing wiscore_rak4631 (platform: nordicnrf52; board: nrf52840_dk_adafruit; framework: arduino)
...
PLATFORM: Nordic nRF52 (10.11.0) > Nordic nRF52840-DK (Adafruit BSP)
HARDWARE: NRF52840 64MHz, 243KB RAM, 796KB Flash
DEBUG: Current (jlink) On-board (jlink) External (blackmagic, cmsis-dap, stlink)
...
Configuring upload protocol...
AVAILABLE: blackmagic, cmsis-dap, jlink, nrfjprog, stlink
CURRENT: upload_protocol = jlink
...
J-Link connection not established yet but required for command.
Connecting to J-Link via USB...FAILED: Failed to open DLL
```