### PR TITLE
[ESP32] HMAC Console replaces TLS Console + 4 Bug Fixes

### DIFF
--- a/build_output.txt
+++ b/build_output.txt
@@ -1,0 +1,2 @@
+Processing ttgo_tbeam (board: ttgo-t-beam; platform: espressif32@^6.13.0; framework: arduino)
+--------------------------------------------------------------------------------

--- a/src/command_functions.cpp
+++ b/src/command_functions.cpp
@@ -14,7 +14,7 @@
 #include "spectral_scan.h"
 #include "rtc_functions.h"
 #ifdef ESP32
-#include "tls_console.h"
+#include "net_console.h"
 #endif
 #include "tinyxml_functions.h"
 #include "clock.h"
@@ -624,8 +624,8 @@ void commandAction(char *umsg_text, bool ble)
             Serial.printf("--info      show info\n--mheard    show MHeard\n--gateway   on/off/pos/nopos\n--webserver on/off\n--webpwd    xxxx/none\n--mesh      on/off\n");
             delay(100);
             #ifdef ESP32
-                Serial.printf("--tlsconsole on/off  (TLS console port 2323)\n");
-                Serial.printf("--passwd xxxx/none   (TLS console password, none=clear)\n");
+                Serial.printf("--netconsole on/off  (net console port 2323)\n");
+                Serial.printf("--passwd xxxx/none   (net console password, none=clear)\n");
                 delay(100);
             #endif
             delay(100);
@@ -2036,33 +2036,33 @@ void commandAction(char *umsg_text, bool ble)
         }
     }
     else
-    #ifndef NO_TLS_CONSOLE
-    if(commandCheck(msg_text+2, (char*)"tlsconsole on") == 0)
+    #ifndef NO_NET_CONSOLE
+    if(commandCheck(msg_text+2, (char*)"netconsole on") == 0)
     {
-        bTLS_CONSOLE=true;
+        bNET_CONSOLE=true;
         meshcom_settings.node_sset2 |= 0x1000;
 
         save_settings();
 
-        Serial.printf("...TLS console on (port 2323)\n");
+        Serial.printf("...net console on (port 2323)\n");
         return;
     }
     else
-    if(commandCheck(msg_text+2, (char*)"tlsconsole off") == 0)
+    if(commandCheck(msg_text+2, (char*)"netconsole off") == 0)
     {
-        bTLS_CONSOLE=false;
+        bNET_CONSOLE=false;
         meshcom_settings.node_sset2 &= ~0x1000;
 
         save_settings();
 
-        Serial.printf("...TLS console off\n");
+        Serial.printf("...net console off\n");
         return;
     }
     else
-    if(commandCheck(msg_text+2, (char*)"tlsconsole") == 0)
+    if(commandCheck(msg_text+2, (char*)"netconsole") == 0)
     {
-        // show current TLS console status; return early to prevent match against --tls... handler
-        Serial.printf("...TLS console is %s\n", bTLS_CONSOLE ? "on (port 2323)" : "off");
+        // show current net console status; return early to prevent match against --tls... handler
+        Serial.printf("...net console is %s\n", bNET_CONSOLE ? "on (port 2323)" : "off");
         return;
     }
     else
@@ -2864,16 +2864,16 @@ void commandAction(char *umsg_text, bool ble)
         {
             // --passwd none clears the password (open access)
             memset(meshcom_settings.node_passwd, 0, sizeof(meshcom_settings.node_passwd));
-            #if defined(ESP32) && !defined(DISABLE_TLS_CONSOLE)
-            tlsConsoleSetPassword("");
+            #if defined(ESP32) && !defined(DISABLE_NET_CONSOLE)
+            netConsoleSetPassword("");
             #endif
-            Serial.printf("...TLS console password cleared (open access)\n");
+            Serial.printf("...net console password cleared (open access)\n");
         }
         else
         {
             snprintf(meshcom_settings.node_passwd, sizeof(meshcom_settings.node_passwd), "%-14.14s", _owner_c);
-            #if defined(ESP32) && !defined(DISABLE_TLS_CONSOLE)
-            tlsConsoleSetPassword(meshcom_settings.node_passwd);
+            #if defined(ESP32) && !defined(DISABLE_NET_CONSOLE)
+            netConsoleSetPassword(meshcom_settings.node_passwd);
             #endif
         }
 

--- a/src/configuration_global.h
+++ b/src/configuration_global.h
@@ -127,6 +127,10 @@
 #define CSMA_MAX_ATTEMPTS   3       // Ab hier: Rapid-fire CAD bis Kanal frei
 #define CSMA_RAPID_RX_MS    100     // Preamble-Check Fenster im Rapid-fire Modus (ms)
 
+// TX-IRQ Watchdog: Maximale Zeit (ms) fuer einen LoRa-TX-Vorgang bevor Zwangs-Recovery
+// SF11 BW250 CR6 255 Bytes ToA ~6s -> 15s gibt ausreichend Sicherheitsabstand
+#define TX_WATCHDOG_MS      15000
+
 // OnRxDone processing time monitoring
 #define ONRXDONE_WARN_MS    50      // Warnung wenn OnRxDone laenger als X ms dauert
 

--- a/src/debugconf.h
+++ b/src/debugconf.h
@@ -2,8 +2,8 @@
 // DEBUG
 // -----------------------------------------------------------------------------
 
-// TLS console serial bridge — must be included before any Serial usage
-#include "tls_console.h"
+// net console serial bridge — must be included before any Serial usage
+#include "net_console.h"
 
 // If not on PIO or not defined in platformio.ini
 #ifndef DO_DEBUG

--- a/src/esp32/esp32_main.cpp
+++ b/src/esp32/esp32_main.cpp
@@ -129,7 +129,7 @@ Arduino_GFX *gfx = new Arduino_ST7796(
 #include <lora_setchip.h>
 #include "esp32_functions.h"
 #include "tft_display_functions.h"
-#include "tls_console.h"
+#include "net_console.h"
 
 #ifdef BOARD_HELTEC_V4
     #include "pa_control.h"
@@ -756,9 +756,9 @@ void esp32setup()
     bWEBSERVER = meshcom_settings.node_sset2 & 0x0040;
     bWIFIAP = meshcom_settings.node_sset2 & 0x0080;
     bGATEWAY_NOPOS =  meshcom_settings.node_sset2 & 0x0100;
-    bTLS_CONSOLE = meshcom_settings.node_sset2 & 0x1000;
-    #ifndef DISABLE_TLS_CONSOLE
-    tlsConsoleSetPassword(meshcom_settings.node_passwd);
+    bNET_CONSOLE = meshcom_settings.node_sset2 & 0x1000;
+    #ifndef DISABLE_NET_CONSOLE
+    netConsoleSetPassword(meshcom_settings.node_passwd);
     #endif
     bSMALLDISPLAY =  false;
     bSOFTSERREAD = meshcom_settings.node_sset2 & 0x0200;
@@ -3516,11 +3516,11 @@ void esp32loop()
             loopWebserver();
         }
 
-        #ifndef DISABLE_TLS_CONSOLE
-        if(bTLS_CONSOLE && iWlanWait == 0)
+        #ifndef DISABLE_NET_CONSOLE
+        if(bNET_CONSOLE && iWlanWait == 0)
         {
-            startTlsConsole();
-            loopTlsConsole();
+            startNetConsole();
+            loopNetConsole();
         }
         #endif
 
@@ -3744,21 +3744,21 @@ void checkSerialCommand(void)
     if(Serial.available() > 0)
     {
         char rd = (char)Serial.read();
-        Serial.print(rd);   // echo to USB + TLS console via MSerial
+        Serial.print(rd);   // echo to USB + net console via MSerial
         strText += rd;
     }
 
-    // Check TLS console input
-    #ifndef DISABLE_TLS_CONSOLE
-    if(tlsConsoleAvailable())
+    // Check net console input
+    #ifndef DISABLE_NET_CONSOLE
+    if(netConsoleAvailable())
     {
-        char rd = (char)tlsConsoleRead();
+        char rd = (char)netConsoleRead();
         // Skip Telnet IAC negotiation bytes (0xFF and following 2 bytes)
         if((uint8_t)rd == 0xFF)
         {
             // Consume the 2 option bytes that follow IAC
-            if(tlsConsoleAvailable()) tlsConsoleRead();
-            if(tlsConsoleAvailable()) tlsConsoleRead();
+            if(netConsoleAvailable()) netConsoleRead();
+            if(netConsoleAvailable()) netConsoleRead();
         }
         else if(rd != '\r')         // strip CR, keep LF
         {

--- a/src/esp32/esp32_main.cpp
+++ b/src/esp32/esp32_main.cpp
@@ -1945,6 +1945,46 @@ void esp32loop()
                 stat_csma_hwm_attempts, trickle_interval_ms);
         }
 
+        // TX-IRQ Watchdog: Wenn bEnableInterruptTransmit zu lange true bleibt
+        // (TX-Done-IRQ wurde nie gefeuert), ist die State Machine eingefroren.
+        // iReceiveTimeOutTime == 0 waehrend TX => normaler CSMA-Timeout greift nicht.
+        // Fix: nach TX_WATCHDOG_MS Zwangs-Recovery zurueck in RX.
+        {
+            unsigned long _tx_s = (unsigned long)ch_util_tx_start;
+            if(bEnableInterruptTransmit && _tx_s > 0 &&
+               (millis() - _tx_s) > TX_WATCHDOG_MS)
+            {
+                Serial.printf("[MC-WDT] TX_WATCHDOG fired after %lums — forcing RX recovery\n",
+                    millis() - _tx_s);
+
+                ch_util_tx_start = 0;
+                transmittedFlag   = false;
+                bEnableInterruptTransmit = false;
+                bEnableInterruptReceive  = false;
+
+                radio.clearPacketSentAction();
+                radio.clearPacketReceivedAction();
+                radio.finishTransmit();
+
+                #ifdef BOARD_HELTEC_V4
+                disablePATransmit();
+                #endif
+                #ifdef RADIO_CTRL
+                    digitalWrite(RADIO_CTRL, HIGH);  // RX Mode
+                    delay(2);
+                #endif
+
+                radio.startReceive(RADIOLIB_SX126X_RX_TIMEOUT_INF,
+                    RADIOLIB_IRQ_RX_DEFAULT_FLAGS | (1UL << RADIOLIB_IRQ_PREAMBLE_DETECTED),
+                    RADIOLIB_IRQ_RX_DEFAULT_MASK, 0);
+                radio.setPacketReceivedAction(setFlagReceive);
+                bEnableInterruptReceive = true;
+
+                iReceiveTimeOutTime = millis();
+                csma_reset();
+            }
+        }
+
         if(iReceiveTimeOutTime > 0)
         {
             // Timeout csma_timeout (slot-basierter Backoff)

--- a/src/extudp_functions.cpp
+++ b/src/extudp_functions.cpp
@@ -535,7 +535,7 @@ void resetExternUDP()
 
   hasExternIPaddress = false;
   
-  if(bEXTUDP && hasExternIPaddress && (int)strlen(meshcom_settings.node_extern) > 7)
+  if(bEXTUDP && (int)strlen(meshcom_settings.node_extern) > 7)
   {
     startExternUDP();
   }

--- a/src/loop_functions.cpp
+++ b/src/loop_functions.cpp
@@ -140,7 +140,7 @@ bool bVIA = false;
 bool bWEBSERVER = false;
 bool bWIFIAP = false;
 bool bEXTUDP = false;
-bool bTLS_CONSOLE = false;
+bool bNET_CONSOLE = false;
 
 bool bSHORTPATH = false;
 //bool bGPSDEBUG = false;

--- a/src/loop_functions.cpp
+++ b/src/loop_functions.cpp
@@ -3346,11 +3346,14 @@ void SendAckMessage(String dest_call, unsigned int iAckId)
         Serial.println();
     }
 
+    int savedAckSlot = iWrite;
     ringBuffer[iWrite][0]=aprsmsg.msg_len;
-    ringBuffer[iWrite][1]=0xFF;    // ACK-Status byte 0xFF for no retransmission
+    ringBuffer[iWrite][1]=0x00;  // temp READY (0x00) so getMessagePriority parses destination correctly
     memcpy(ringBuffer[iWrite]+2, msg_buffer, aprsmsg.msg_len);
 
     addTxRingEntry("beacon");
+
+    ringBuffer[savedAckSlot][1]=0xFF;   // no retransmission (set after priority is recorded)
 
     /*
     iWrite++;

--- a/src/loop_functions_extern.h
+++ b/src/loop_functions_extern.h
@@ -123,7 +123,7 @@ extern bool bVIA;
 extern bool bWEBSERVER;
 extern bool bWIFIAP;
 extern bool bEXTUDP;
-extern bool bTLS_CONSOLE;
+extern bool bNET_CONSOLE;
 
 extern float fBaseAltidude;
 extern float fBasePress;

--- a/src/lora_functions.cpp
+++ b/src/lora_functions.cpp
@@ -1595,6 +1595,14 @@ bool doTX()
                         enablePATransmit();
                         #endif
                         transmissionState = radio.startTransmit(lora_tx_buffer, sendlng);
+                        if(transmissionState != RADIOLIB_ERR_NONE)
+                        {
+                            tx_is_active = false;
+                            ringBuffer[save_read][0] = sendlng;
+                            ringBuffer[save_read][1] = save_ring_status;
+                            iRead = iReadBeforeAdvance;
+                            return false;
+                        }
                         #endif
                         bLED_RED = true;
                     #endif
@@ -1627,6 +1635,14 @@ bool doTX()
                     enablePATransmit();
                     #endif
                     transmissionState = radio.startTransmit(lora_tx_buffer, sendlng);
+                    if(transmissionState != RADIOLIB_ERR_NONE)
+                    {
+                        tx_is_active = false;
+                        ringBuffer[save_read][0] = sendlng;
+                        ringBuffer[save_read][1] = save_ring_status;
+                        iRead = iReadBeforeAdvance;
+                        return false;
+                    }
                     #endif
                     bLED_ORANGE = true;
                 #endif

--- a/src/lora_functions.cpp
+++ b/src/lora_functions.cpp
@@ -1597,6 +1597,7 @@ bool doTX()
                         transmissionState = radio.startTransmit(lora_tx_buffer, sendlng);
                         if(transmissionState != RADIOLIB_ERR_NONE)
                         {
+                            Serial.printf("[LoRa] startTransmit(track) failed: %d\n", transmissionState);
                             tx_is_active = false;
                             ringBuffer[save_read][0] = sendlng;
                             ringBuffer[save_read][1] = save_ring_status;
@@ -1637,6 +1638,7 @@ bool doTX()
                     transmissionState = radio.startTransmit(lora_tx_buffer, sendlng);
                     if(transmissionState != RADIOLIB_ERR_NONE)
                     {
+                        Serial.printf("[LoRa] startTransmit(aprs) failed: %d\n", transmissionState);
                         tx_is_active = false;
                         ringBuffer[save_read][0] = sendlng;
                         ringBuffer[save_read][1] = save_ring_status;
@@ -1823,11 +1825,7 @@ bool updateRetransmissionStatus()
                     Serial.println("");
                 }
 
-                // Mark original as done and free slot
-                ringBuffer[ircheck][1] = RING_STATUS_DONE;
-                ringBuffer[ircheck][0] = 0;  // free slot so getNextTxSlot skips it
-
-                // Copy message to new slot at iWrite
+                // Copy message to new slot BEFORE clearing original (len must still be valid)
                 memcpy(ringBuffer[iWrite], ringBuffer[ircheck], size + 2);
 
                 if (ringBuffer[iWrite][2] == MSG_TYPE_TEXT) // text messages
@@ -1837,6 +1835,10 @@ bool updateRetransmissionStatus()
 
                 // Transfer and increment retry count
                 retryCount[iWrite] = retryCount[ircheck] + 1;
+
+                // Mark original as done and free slot (after copy, so len is correct in new slot)
+                ringBuffer[ircheck][1] = RING_STATUS_DONE;
+                ringBuffer[ircheck][0] = 0;  // free slot so getNextTxSlot skips it
 
                 addTxRingEntry("retransmit");
 

--- a/src/lora_functions.cpp
+++ b/src/lora_functions.cpp
@@ -1558,6 +1558,7 @@ bool doTX()
 
         // For out-of-order reads: clear slot data length so getNextTxSlot skips it
         // and advance iRead past any empty leading slots
+        int iReadBeforeAdvance = iRead; // saved for startTransmit failure rollback
         ringBuffer[txSlot][0] = 0; // Mark as consumed (data is in lora_tx_buffer)
         advanceIReadPastEmpty();
 
@@ -1683,6 +1684,17 @@ bool doTX()
                             Serial.printf("[MC-DBG] RADIO_TX len=%d\n", sendlng);
 
                         transmissionState = radio.startTransmit(lora_tx_buffer, sendlng);
+                        if(transmissionState != RADIOLIB_ERR_NONE)
+                        {
+                            Serial.printf("[LoRa] startTransmit failed: %d\n", transmissionState);
+                            tx_is_active = false;
+                            ringBuffer[save_read][0] = sendlng;
+                            #ifndef BOARD_TLORA_OLV216
+                            ringBuffer[save_read][1] = save_ring_status;
+                            #endif
+                            iRead = iReadBeforeAdvance; // re-include slot in scan window
+                            return false;
+                        }
                         #endif
                         bLED_RED = true;
                     #endif

--- a/src/net_console.cpp
+++ b/src/net_console.cpp
@@ -3,6 +3,8 @@
 // Uses mbedtls/md.h (already in ESP-IDF) — zero extra library, zero Flash overhead.
 // RAM during active session: ~0 KB (vs 36 KB for TLS I/O buffers).
 //
+// Author: Ralf Altenbrand (DH1FR), 2026
+//
 // Protocol:
 //   <- "NONCE: <32 hex chars>\r\n"
 //   -> "<64 hex HMAC-SHA256(password, nonce)>\r\n"
@@ -17,9 +19,9 @@
 //
 // No password: connect with plain  nc <ip> 2323
 
-#if defined(ESP32) && !defined(DISABLE_TLS_CONSOLE)
+#if defined(ESP32) && !defined(DISABLE_NET_CONSOLE)
 
-// !! Include Arduino BEFORE tls_console.h so we can capture the real
+// !! Include Arduino BEFORE net_console.h so we can capture the real
 // HardwareSerial reference before #define Serial MSerial takes effect.
 #include <Arduino.h>
 #include <WiFi.h>
@@ -38,7 +40,7 @@
 // HardwareSerial on classic ESP32/S3-UART, USBCDC on S3/S2/C3 USB-CDC builds.
 static auto& s_hwSerial = Serial;
 
-#include "tls_console.h"
+#include "net_console.h"
 // From here: Serial == MSerial
 
 // ── Password ──────────────────────────────────────────────────────────────────
@@ -55,7 +57,7 @@ static volatile bool     s_server_pending = false;
 static bool              s_authenticated  = false;
 static volatile bool     s_hs_running     = false;
 
-// 1-byte lookahead for tlsConsoleAvailable()
+// 1-byte lookahead for netConsoleAvailable()
 static bool     s_peek_valid = false;
 static uint8_t  s_peek_byte  = 0;
 
@@ -208,7 +210,7 @@ static void authTask(void* arg)
         xSemaphoreGive(s_mutex);
     }
     s_hwSerial.printf("[CON] Client authenticated on port %d. free heap=%u\n",
-                      TLS_CONSOLE_PORT, (unsigned)esp_get_free_heap_size());
+                      NET_CONSOLE_PORT, (unsigned)esp_get_free_heap_size());
     s_hs_running = false;
     vTaskDelete(nullptr);
 }
@@ -252,7 +254,7 @@ size_t MeshSerialClass::write(const uint8_t* buf, size_t size)
 }
 
 // ── Public API ────────────────────────────────────────────────────────────────
-void tlsConsoleSetPassword(const char* pw)
+void netConsoleSetPassword(const char* pw)
 {
     snprintf(s_password, sizeof(s_password), "%s", pw ? pw : "");
     // --passwd stores the value left-padded to 14 chars with spaces ("%-14.14s").
@@ -262,18 +264,18 @@ void tlsConsoleSetPassword(const char* pw)
 }
 
 
-void startTlsConsole()
+void startNetConsole()
 {
     if (s_started) return;
     s_started        = true;
     s_mutex          = xSemaphoreCreateMutex();
-    s_server_pending = true;   // open socket on next loopTlsConsole() call
+    s_server_pending = true;   // open socket on next loopNetConsole() call
     s_hwSerial.println("[CON] HMAC console init.");
 }
 
-void loopTlsConsole()
+void loopNetConsole()
 {
-    // Open listening socket on first call (triggered by startTlsConsole)
+    // Open listening socket on first call (triggered by startNetConsole)
     if (s_server_pending)
     {
         s_server_pending = false;
@@ -290,7 +292,7 @@ void loopTlsConsole()
         struct sockaddr_in addr;
         memset(&addr, 0, sizeof(addr));
         addr.sin_family      = AF_INET;
-        addr.sin_port        = htons(TLS_CONSOLE_PORT);
+        addr.sin_port        = htons(NET_CONSOLE_PORT);
         addr.sin_addr.s_addr = INADDR_ANY;
 
         if (::bind(s_listen_fd, (struct sockaddr*)&addr, sizeof(addr)) < 0 ||
@@ -302,7 +304,7 @@ void loopTlsConsole()
         }
         int fl = fcntl(s_listen_fd, F_GETFL, 0);
         fcntl(s_listen_fd, F_SETFL, fl | O_NONBLOCK);
-        s_hwSerial.printf("[CON] Console started on port %d\n", TLS_CONSOLE_PORT);
+        s_hwSerial.printf("[CON] Console started on port %d\n", NET_CONSOLE_PORT);
     }
 
     if (s_listen_fd < 0) return;
@@ -353,14 +355,14 @@ void loopTlsConsole()
     }
 }
 
-bool isTlsConsoleConnected()
+bool isNetConsoleConnected()
 {
     return s_authenticated;
 }
 
-int tlsConsoleRead()
+int netConsoleRead()
 {
-    if (!isTlsConsoleConnected()) return -1;
+    if (!isNetConsoleConnected()) return -1;
 
     if (s_peek_valid)
     {
@@ -383,9 +385,9 @@ int tlsConsoleRead()
     return -1;
 }
 
-bool tlsConsoleAvailable()
+bool netConsoleAvailable()
 {
-    if (!isTlsConsoleConnected()) return false;
+    if (!isNetConsoleConnected()) return false;
     if (s_peek_valid) return true;
 
     uint8_t c;
@@ -403,4 +405,4 @@ bool tlsConsoleAvailable()
     return false;
 }
 
-#endif // defined(ESP32) && !defined(DISABLE_TLS_CONSOLE)
+#endif // defined(ESP32) && !defined(DISABLE_NET_CONSOLE)

--- a/src/net_console.cpp
+++ b/src/net_console.cpp
@@ -3,7 +3,7 @@
 // Uses mbedtls/md.h (already in ESP-IDF) — zero extra library, zero Flash overhead.
 // RAM during active session: ~0 KB (vs 36 KB for TLS I/O buffers).
 //
-// Author: Ralf Altenbrand (DH1FR), 2026
+// Author: Ralf Altenbrand (DH1FR), 05/2026
 //
 // Protocol:
 //   <- "NONCE: <32 hex chars>\r\n"

--- a/src/net_console.h
+++ b/src/net_console.h
@@ -1,8 +1,9 @@
 #pragma once
 
 // HMAC console server (port 2323) — raw TCP serial bridge for ESP32
-// Replaces the TLS console to free the 36 KB mbedTLS I/O buffer overhead.
+// Replaces the net console to free the 36 KB mbedTLS I/O buffer overhead.
 // Only active on ESP32 with WiFi or Ethernet (not on nRF52/RAK4631).
+// Author: Ralf Altenbrand (DH1FR), 2026
 //
 // Security model:
 //   - HMAC-SHA256 challenge-response: server sends a 16-byte random nonce,
@@ -22,30 +23,30 @@
 //   nc <ip> 2323         (Linux / macOS)
 //   ncat.exe <ip> 2323   (Windows — Nmap-Paket)
 
-#if defined(ESP32) && !defined(DISABLE_TLS_CONSOLE)
+#if defined(ESP32) && !defined(DISABLE_NET_CONSOLE)
 
 #include <Arduino.h>
 #include <Print.h>
 #include <WiFi.h>
 
-#define TLS_CONSOLE_PORT 2323
+#define NET_CONSOLE_PORT 2323
 
-void startTlsConsole();
-void loopTlsConsole();
-bool isTlsConsoleConnected();
+void startNetConsole();
+void loopNetConsole();
+bool isNetConsoleConnected();
 
 // Set the password checked after TLS handshake (empty = no auth).
 // Call once from setup after loading settings.
-void tlsConsoleSetPassword(const char* pw);
+void netConsoleSetPassword(const char* pw);
 
 // Read one character from TLS client (-1 if none)
-int  tlsConsoleRead();
-bool tlsConsoleAvailable();
+int  netConsoleRead();
+bool netConsoleAvailable();
 
 /**
  * MeshSerialClass — drop-in wrapper around HardwareSerial.
  * All write() calls are forwarded to both the real UART and the TLS client
- * (when connected and authenticated). Method bodies are in tls_console.cpp
+ * (when connected and authenticated). Method bodies are in net_console.cpp
  * to avoid the circular #define issue.
  */
 class MeshSerialClass : public Stream
@@ -73,4 +74,4 @@ extern MeshSerialClass MSerial;
 #undef  Serial
 #define Serial MSerial
 
-#endif // defined(ESP32) && !defined(DISABLE_TLS_CONSOLE)
+#endif // defined(ESP32) && !defined(DISABLE_NET_CONSOLE)

--- a/src/nrf52/WisBlock-API.h
+++ b/src/nrf52/WisBlock-API.h
@@ -333,7 +333,7 @@ struct s_meshcom_settings
 	int node_gpsdebug = 0;
 
 	int node_relay = 0x0000;
-	
+
 	char node_via[10] = {0};
 
 	// nicht im Flash

--- a/src/tls_console.cpp
+++ b/src/tls_console.cpp
@@ -1,7 +1,21 @@
-// TLS console server — encrypted Serial bridge for ESP32
-// Port 2323, single client, TLS 1.2+, password auth, bidirectional
-// Uses mbedTLS directly on the raw socket fd because WiFiServerSecure /
-// X509List / PrivateKey are not available in ESP32 Arduino 3.x (IDF 5.x).
+// HMAC console — raw TCP serial bridge with HMAC-SHA256 challenge-response auth
+// Port 2323, single client, plaintext data, no TLS overhead.
+// Uses mbedtls/md.h (already in ESP-IDF) — zero extra library, zero Flash overhead.
+// RAM during active session: ~0 KB (vs 36 KB for TLS I/O buffers).
+//
+// Protocol:
+//   <- "NONCE: <32 hex chars>\r\n"
+//   -> "<64 hex HMAC-SHA256(password, nonce)>\r\n"
+//   <- "OK\r\n<banner>"  or  "FAIL\r\n" + disconnect
+//
+// Python helper (hmac_connect.py):
+//   import sys, socket, hmac, hashlib
+//   s = socket.create_connection((sys.argv[1], 2323))
+//   nonce = bytes.fromhex(s.makefile().readline().split()[1].strip())
+//   resp  = hmac.new(sys.argv[2].encode(), nonce, hashlib.sha256).hexdigest()
+//   s.sendall((resp + chr(10)).encode()); print(s.makefile().readline())
+//
+// No password: connect with plain  nc <ip> 2323
 
 #if defined(ESP32) && !defined(DISABLE_TLS_CONSOLE)
 
@@ -9,24 +23,15 @@
 // HardwareSerial reference before #define Serial MSerial takes effect.
 #include <Arduino.h>
 #include <WiFi.h>
-#include <Preferences.h>
 #include <netinet/in.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/semphr.h>
 #include <freertos/task.h>
-#include <mbedtls/ssl.h>
-#include <mbedtls/pk.h>
-#include <mbedtls/x509_crt.h>
-#include <mbedtls/x509_csr.h>
-#include <mbedtls/entropy.h>
-#include <mbedtls/ctr_drbg.h>
-#include <mbedtls/error.h>
-#include <mbedtls/bignum.h>
-#include <mbedtls/ecp.h>
-#include <mbedtls/debug.h>
+#include <mbedtls/md.h>     // HMAC-SHA256 — already in ESP-IDF, no extra library
 #include <sys/socket.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <esp_random.h>     // hardware TRNG
 
 // Capture real Serial reference — must happen before the #define Serial MSerial.
 // Using auto& so the compiler deduces the exact type on each board:
@@ -36,37 +41,19 @@ static auto& s_hwSerial = Serial;
 #include "tls_console.h"
 // From here: Serial == MSerial
 
-// ── NVS keys ──────────────────────────────────────────────────────────────────
-static const char* NVS_NS   = "tls_creds";
-static const char* NVS_CERT = "srv_cert";
-static const char* NVS_KEY  = "srv_key";
-static const char* NVS_ALG  = "key_alg";   // "EC" = P-256 (v2), absent/other = RSA (v1)
-
 // ── Password ──────────────────────────────────────────────────────────────────
 static char s_password[15] = {0};
 
 // ── Globals ───────────────────────────────────────────────────────────────────
 MeshSerialClass MSerial;
 
-static int                      s_listen_fd     = -1; // raw BSD listening socket
-
-static mbedtls_ssl_config       s_conf;
-static mbedtls_x509_crt         s_cert;
-static mbedtls_pk_context       s_srv_key;
-static mbedtls_entropy_context  s_entropy;
-static mbedtls_ctr_drbg_context s_ctr_drbg;
-// ssl context allocated ONCE in startTlsConsole(), reused via mbedtls_ssl_session_reset().
-// This avoids the 2×16 KB I/O-buffer re-allocation on every connection that causes
-// heap fragmentation and "ssl_setup failed" from the second connection onwards.
-static mbedtls_ssl_context      s_ssl;
-static int                      s_fd            = -1;
-
-static SemaphoreHandle_t        s_mutex         = nullptr;
-static bool                     s_started       = false;
-static volatile bool            s_conf_ready    = false;
-static volatile bool            s_server_pending = false; // set by tlsInitTask, consumed by loopTlsConsole()
-static bool                     s_authenticated = false;
-static volatile bool            s_hs_running    = false;
+static int               s_listen_fd      = -1;
+static int               s_fd             = -1;
+static SemaphoreHandle_t s_mutex          = nullptr;
+static bool              s_started        = false;
+static volatile bool     s_server_pending = false;
+static bool              s_authenticated  = false;
+static volatile bool     s_hs_running     = false;
 
 // 1-byte lookahead for tlsConsoleAvailable()
 static bool     s_peek_valid = false;
@@ -75,48 +62,44 @@ static uint8_t  s_peek_byte  = 0;
 // ── ISR check ─────────────────────────────────────────────────────────────────
 static inline bool isInISR() { return xPortInIsrContext() == pdTRUE; }
 
-// ── mbedTLS error debug callback (level ≤ 1 = errors/warnings only) ─────────────
-static void tls_debug_cb(void*, int level, const char* file, int line, const char* str)
+// ── Hex encoding helpers ───────────────────────────────────────────────────────
+static void bytes_to_hex(const uint8_t* in, size_t len, char* out)
 {
-    if (level <= 1)
-        s_hwSerial.printf("[TLS-DBG] %s:%d: %s", file, line, str);
+    for (size_t i = 0; i < len; i++)
+        snprintf(out + i * 2, 3, "%02x", in[i]);
+    out[len * 2] = '\0';
 }
 
-// ── mbedTLS bio callbacks ─────────────────────────────────────────────────────
-static int bio_send(void* ctx, const unsigned char* buf, size_t len)
+static bool hex_to_bytes(const char* hex, size_t hexLen, uint8_t* out, size_t outLen)
 {
-    int fd = *static_cast<int*>(ctx);
-    int n  = ::send(fd, buf, len, 0);
-    if (n < 0) {
-        if (errno == EAGAIN || errno == EWOULDBLOCK) return MBEDTLS_ERR_SSL_WANT_WRITE;
-        return MBEDTLS_ERR_SSL_INTERNAL_ERROR;
+    if (hexLen != outLen * 2) return false;
+    for (size_t i = 0; i < outLen; i++) {
+        unsigned int b;
+        if (sscanf(hex + i * 2, "%02x", &b) != 1) return false;
+        out[i] = (uint8_t)b;
     }
-    return n;
+    return true;
 }
 
-static int bio_recv(void* ctx, unsigned char* buf, size_t len)
+// ── Constant-time compare (prevent timing attack) ─────────────────────────────
+static bool ct_equal(const uint8_t* a, const uint8_t* b, size_t n)
 {
-    int fd = *static_cast<int*>(ctx);
-    int n  = ::recv(fd, buf, len, 0);
-    if (n < 0) {
-        if (errno == EAGAIN || errno == EWOULDBLOCK || errno == ETIMEDOUT) return MBEDTLS_ERR_SSL_WANT_READ;
-        return MBEDTLS_ERR_SSL_INTERNAL_ERROR;
-    }
-    if (n == 0) return MBEDTLS_ERR_SSL_CONN_EOF;
-    return n;
+    uint8_t diff = 0;
+    for (size_t i = 0; i < n; i++) diff |= a[i] ^ b[i];
+    return diff == 0;
 }
 
-// ── TLS write with retry ──────────────────────────────────────────────────────
-// Socket is O_NONBLOCK after authentication. On WANT_WRITE the TCP send buffer
-// is full — do NOT spin here as this runs in the main-loop context and would
-// block LoRa RX/TX. Instead drop the remaining bytes (debug output is best-effort).
-static void tls_write_all(const uint8_t* buf, size_t size)
+// ── Raw write (non-blocking, best-effort) ─────────────────────────────────────
+// Socket is O_NONBLOCK after authentication. On EAGAIN the TCP send buffer is
+// full — do NOT spin here (main-loop context). Drop remaining bytes (best-effort).
+static void raw_write_all(const uint8_t* buf, size_t size)
 {
+    if (s_fd < 0) return;
     size_t off = 0;
     while (off < size) {
-        int r = mbedtls_ssl_write(&s_ssl, buf + off, size - off);
+        int r = ::send(s_fd, buf + off, size - off, MSG_DONTWAIT);
         if (r > 0) { off += r; }
-        else        { break; }  // WANT_WRITE (TCP full), error, or disconnect — give up
+        else        { break; }
     }
 }
 
@@ -125,231 +108,112 @@ static void teardownClient()
 {
     s_authenticated = false;
     s_peek_valid    = false;
-    mbedtls_ssl_close_notify(&s_ssl);
-    mbedtls_ssl_free(&s_ssl);    // release I/O buffers (~36 KB) back to heap until next connection
     if (s_fd >= 0) { ::close(s_fd); s_fd = -1; }
-    s_hwSerial.printf("[TLS] Client disconnected. free heap=%u\n", (unsigned)esp_get_free_heap_size());
+    s_hwSerial.printf("[CON] Client disconnected. free heap=%u\n",
+                      (unsigned)esp_get_free_heap_size());
 }
 
-// ── Key + cert generation (EC P-256 — ~1 KB heap for handshake vs ~16 KB RSA) ──
-static bool generateAndStoreTlsCredentials()
+// ── Auth task — HMAC-SHA256 challenge-response ────────────────────────────────
+struct AuthArgs { int fd; };
+
+static void authTask(void* arg)
 {
-    s_hwSerial.println("[TLS] Generating EC P-256 key...");
-
-    mbedtls_pk_context     key;
-    mbedtls_x509write_cert crt;
-    mbedtls_mpi            serial;
-
-    mbedtls_pk_init(&key);
-    mbedtls_x509write_crt_init(&crt);
-    mbedtls_mpi_init(&serial);
-
-    bool ok = false;
-
-    if (mbedtls_pk_setup(&key, mbedtls_pk_info_from_type(MBEDTLS_PK_ECKEY)) != 0 ||
-        mbedtls_ecp_gen_key(MBEDTLS_ECP_DP_SECP256R1, mbedtls_pk_ec(key),
-                            mbedtls_ctr_drbg_random, &s_ctr_drbg) != 0)
-    {
-        s_hwSerial.println("[TLS] Key generation failed");
-        goto cleanup;
-    }
-    s_hwSerial.println("[TLS] Key done, building certificate...");
-
-    mbedtls_x509write_crt_set_version(&crt, MBEDTLS_X509_CRT_VERSION_3);
-    mbedtls_x509write_crt_set_md_alg(&crt, MBEDTLS_MD_SHA256);
-    mbedtls_x509write_crt_set_subject_key(&crt, &key);
-    mbedtls_x509write_crt_set_issuer_key(&crt, &key);
-    mbedtls_x509write_crt_set_subject_name(&crt, "CN=MeshCom,O=MeshCom,C=AT");
-    mbedtls_x509write_crt_set_issuer_name(&crt,  "CN=MeshCom,O=MeshCom,C=AT");
-    mbedtls_mpi_lset(&serial, 1);
-    mbedtls_x509write_crt_set_serial(&crt, &serial);
-    mbedtls_x509write_crt_set_validity(&crt, "20240101000000", "20340101000000");
-
-    {
-        // EC P-256 key PEM ~300 bytes, cert PEM ~700 bytes — much smaller than RSA
-        char* keyPem = new char[512];
-        char* crtPem = new char[1024];
-        bool pemOk   = false;
-
-        if (keyPem && crtPem &&
-            mbedtls_pk_write_key_pem(&key, (unsigned char*)keyPem, 512) == 0 &&
-            mbedtls_x509write_crt_pem(&crt, (unsigned char*)crtPem, 1024,
-                                      mbedtls_ctr_drbg_random, &s_ctr_drbg) == 0)
-        {
-            Preferences prefs;
-            prefs.begin(NVS_NS, false);
-            prefs.putString(NVS_KEY,  keyPem);
-            prefs.putString(NVS_CERT, crtPem);
-            prefs.putString(NVS_ALG,  "EC");  // version marker
-            prefs.end();
-            s_hwSerial.println("[TLS] EC credentials stored in NVS.");
-            pemOk = true;
-        }
-        else
-        {
-            s_hwSerial.println("[TLS] PEM serialisation failed");
-        }
-        delete[] keyPem;
-        delete[] crtPem;
-        if (!pemOk) goto cleanup;
-        ok = true;
-    }
-
-cleanup:
-    mbedtls_pk_free(&key);
-    mbedtls_x509write_crt_free(&crt);
-    mbedtls_mpi_free(&serial);
-    return ok;
-}
-
-// ── Handshake task ────────────────────────────────────────────────────────────
-struct HandshakeArgs { int fd; };
-
-static void handshakeTask(void* arg)
-{
-    HandshakeArgs* a = static_cast<HandshakeArgs*>(arg);
-    int fd           = a->fd;
+    AuthArgs* a = static_cast<AuthArgs*>(arg);
+    int fd      = a->fd;
     delete a;
-
     if (fd < 0) { s_hs_running = false; vTaskDelete(nullptr); return; }
 
-    // Force blocking mode for the handshake (WiFiServer may accept as non-blocking)
-    {
-        int flg = fcntl(fd, F_GETFL, 0);
-        s_hwSerial.printf("[TLS] New client fd=%d, was_nonblocking=%d\n", fd, (flg & O_NONBLOCK) ? 1 : 0);
-        fcntl(fd, F_SETFL, flg & ~O_NONBLOCK);
-    }
+    // Blocking mode for the auth exchange
+    { int fl = fcntl(fd, F_GETFL, 0); fcntl(fd, F_SETFL, fl & ~O_NONBLOCK); }
 
-    // Allocate the ssl context for this connection (~36 KB I/O buffers).
-    // Freed in teardownClient() so the heap is returned between connections.
-    if (!s_conf_ready)
-    {
-        s_hwSerial.println("[TLS] conf not ready");
-        ::close(fd);
-        s_hs_running = false; vTaskDelete(nullptr); return;
-    }
-    mbedtls_ssl_init(&s_ssl);
-    s_hwSerial.printf("[HEAP] before ssl_setup: free=%u min=%u\n",
-        (unsigned)esp_get_free_heap_size(), (unsigned)esp_get_minimum_free_heap_size());
-    if (mbedtls_ssl_setup(&s_ssl, &s_conf) != 0)
-    {
-        s_hwSerial.printf("[TLS] ssl_setup failed (OOM? free=%u)\n", (unsigned)esp_get_free_heap_size());
-        mbedtls_ssl_free(&s_ssl);
-        ::close(fd);
-        s_hs_running = false; vTaskDelete(nullptr); return;
-    }
-    s_hwSerial.printf("[HEAP] after  ssl_setup: free=%u min=%u\n",
-        (unsigned)esp_get_free_heap_size(), (unsigned)esp_get_minimum_free_heap_size());
+    bool authOk = false;
 
-    mbedtls_ssl_set_bio(&s_ssl, &fd, bio_send, bio_recv, nullptr);
-
-    // Set a short periodic wakeup for bio_recv so the handshake deadline below
-    // can fire. On lwIP (ESP-IDF), SO_RCVTIMEO on a blocking socket returns EAGAIN
-    // when it expires; bio_recv maps EAGAIN → MBEDTLS_ERR_SSL_WANT_READ, so the
-    // handshake loop retries rather than aborting. The millis()-based deadline
-    // below catches a raw TCP connect (no TLS ClientHello) within 15 s.
+    if (s_password[0] == '\0')
     {
-        struct timeval tv500 = {0, 500000}; // 500 ms wakeup interval
-        setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv500, sizeof(tv500));
+        authOk = true;  // no password configured — grant immediately
     }
-
-    // TLS handshake (15 s wall-clock deadline)
-    int ret;
-    uint32_t hsStart = millis();
-    while ((ret = mbedtls_ssl_handshake(&s_ssl)) != 0)
+    else
     {
-        if (ret != MBEDTLS_ERR_SSL_WANT_READ && ret != MBEDTLS_ERR_SSL_WANT_WRITE)
+        // 1. Generate 16-byte nonce via hardware TRNG
+        uint8_t nonce[16];
+        esp_fill_random(nonce, sizeof(nonce));
+
+        // 2. Send challenge: "NONCE: <32 hex chars>\r\n"
+        char chalBuf[48];
+        strcpy(chalBuf, "NONCE: ");
+        bytes_to_hex(nonce, sizeof(nonce), chalBuf + 7);
+        strcat(chalBuf, "\r\n");
+        ::send(fd, chalBuf, strlen(chalBuf), 0);
+
+        // 3. Receive response line (30 s timeout)
+        struct timeval tv = {30, 0};
+        setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+        char respBuf[72] = {0};
+        uint8_t idx = 0;
+        bool readOk = false;
+        while (idx < sizeof(respBuf) - 1)
         {
-            char errbuf[80];
-            mbedtls_strerror(ret, errbuf, sizeof(errbuf));
-            s_hwSerial.printf("[TLS] Handshake failed: %s\n", errbuf);
-            mbedtls_ssl_session_reset(&s_ssl);
-            ::close(fd);
-            s_hs_running = false; vTaskDelete(nullptr); return;
-        }
-        if (millis() - hsStart > 15000)
-        {
-            s_hwSerial.println("[TLS] Handshake timeout (no ClientHello)");
-            mbedtls_ssl_session_reset(&s_ssl);
-            ::close(fd);
-            s_hs_running = false; vTaskDelete(nullptr); return;
-        }
-    }
-    s_hwSerial.println("[TLS] Handshake OK, sending password prompt");
-
-    // 30 s receive timeout for password prompt; no send timeout
-    {
-        struct timeval tv30 = {30, 0};
-        setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv30, sizeof(tv30));
-        struct timeval tv0  = {0, 0};
-        setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv0,  sizeof(tv0));
-    }
-
-    // Password authentication
-    bool authOk = (s_password[0] == '\0');
-    if (!authOk)
-    {
-        // Leading \r\n forces OpenSSL (line-buffered stdout on Windows) to flush
-        // and display the prompt before waiting for input.
-        const char* prompt = "\r\nPassword: ";
-        mbedtls_ssl_write(&s_ssl, (const uint8_t*)prompt, strlen(prompt));
-
-        char buf[16] = {0};
-        uint8_t idx  = 0;
-        while (idx < sizeof(buf) - 1)
-        {
-            uint8_t c;
-            int r = mbedtls_ssl_read(&s_ssl, &c, 1);
+            char c;
+            int r = ::recv(fd, &c, 1, 0);
             if (r <= 0) break;
             if (c == '\r') continue;
-            if (c == '\n') break;
-            buf[idx++] = (char)c;
+            if (c == '\n') { readOk = true; break; }
+            respBuf[idx++] = c;
         }
 
-        // Constant-time compare (prevent timing attack)
-        size_t pwLen = strlen(s_password);
-        size_t inLen = strlen(buf);
-        bool match = (pwLen == inLen);
-        for (size_t i = 0; i < pwLen; i++)
-            if (i >= inLen || buf[i] != s_password[i]) match = false;
-
-        if (!match)
+        if (readOk)
         {
-            const char* denied = "Access denied.\r\n";
-            mbedtls_ssl_write(&s_ssl, (const uint8_t*)denied, strlen(denied));
-            mbedtls_ssl_close_notify(&s_ssl);
-            mbedtls_ssl_session_reset(&s_ssl);
-            ::close(fd);
-            s_hwSerial.println("[TLS] Authentication failed.");
-            s_hs_running = false; vTaskDelete(nullptr); return;
+            // 4. Compute expected HMAC-SHA256(password, nonce)
+            uint8_t expected[32];
+            const mbedtls_md_info_t* md = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
+            if (md && mbedtls_md_hmac(md,
+                                      (const uint8_t*)s_password, strlen(s_password),
+                                      nonce, sizeof(nonce), expected) == 0)
+            {
+                // 5. Hex-decode response, constant-time compare
+                uint8_t received[32];
+                if (strlen(respBuf) == 64 &&
+                    hex_to_bytes(respBuf, 64, received, 32) &&
+                    ct_equal(expected, received, 32))
+                {
+                    authOk = true;
+                }
+            }
         }
     }
 
-    // Send banner before handing over (no race possible here yet)
-    const char* banner = "MeshCom TLS Console\r\nType --help for commands\r\n";
-    mbedtls_ssl_write(&s_ssl, (const uint8_t*)banner, strlen(banner));
+    if (!authOk)
+    {
+        ::send(fd, "FAIL\r\n", 6, 0);
+        ::close(fd);
+        s_hwSerial.println("[CON] Authentication failed.");
+        s_hs_running = false;
+        vTaskDelete(nullptr);
+        return;
+    }
 
-    // Set socket non-blocking for main-loop polling
-    int flags = fcntl(fd, F_GETFL, 0);
-    fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+    const char* banner = "OK\r\nMeshCom Console\r\nType --help for commands\r\n";
+    ::send(fd, banner, strlen(banner), 0);
 
-    // Hand over to main state
+    // Switch to non-blocking for main-loop polling
+    { int fl = fcntl(fd, F_GETFL, 0); fcntl(fd, F_SETFL, fl | O_NONBLOCK); }
+
     if (s_mutex && xSemaphoreTake(s_mutex, portMAX_DELAY) == pdTRUE)
     {
-        if (s_fd >= 0) { ::close(s_fd); }
-        s_fd = fd;
-        mbedtls_ssl_set_bio(&s_ssl, &s_fd, bio_send, bio_recv, nullptr); // rebind BIO to global s_fd
+        if (s_fd >= 0) ::close(s_fd);
+        s_fd            = fd;
         s_peek_valid    = false;
         s_authenticated = true;
         xSemaphoreGive(s_mutex);
     }
-
-    s_hwSerial.printf("[TLS] Client authenticated on port %d\n", TLS_CONSOLE_PORT);
-    s_hwSerial.printf("[HEAP] after  handshake:  free=%u min=%u\n",
-        (unsigned)esp_get_free_heap_size(), (unsigned)esp_get_minimum_free_heap_size());
+    s_hwSerial.printf("[CON] Client authenticated on port %d. free heap=%u\n",
+                      TLS_CONSOLE_PORT, (unsigned)esp_get_free_heap_size());
     s_hs_running = false;
     vTaskDelete(nullptr);
 }
+
+
 
 // ── MeshSerialClass ───────────────────────────────────────────────────────────
 void MeshSerialClass::begin(unsigned long baud) { s_hwSerial.begin(baud); }
@@ -366,7 +230,7 @@ size_t MeshSerialClass::write(uint8_t c)
     {
         if (s_mutex && xSemaphoreTake(s_mutex, 0) == pdTRUE)
         {
-            tls_write_all(&c, 1);
+            raw_write_all(&c, 1);
             xSemaphoreGive(s_mutex);
         }
     }
@@ -380,7 +244,7 @@ size_t MeshSerialClass::write(const uint8_t* buf, size_t size)
     {
         if (s_mutex && xSemaphoreTake(s_mutex, 0) == pdTRUE)
         {
-            tls_write_all(buf, size);
+            raw_write_all(buf, size);
             xSemaphoreGive(s_mutex);
         }
     }
@@ -397,130 +261,19 @@ void tlsConsoleSetPassword(const char* pw)
     while (end >= s_password && *end == ' ') *end-- = '\0';
 }
 
-// ── TLS init task (runs once, then deletes itself) ────────────────────────────
-// Key generation (EC P-256) and ssl_setup take ~1-2 s on first boot.
-// Running this in a background task avoids blocking the main loop / LoRa stack.
-static void tlsInitTask(void*)
-{
-    // Init RNG
-    mbedtls_entropy_init(&s_entropy);
-    mbedtls_ctr_drbg_init(&s_ctr_drbg);
-    const char* pers = "meshcom_tls";
-    if (mbedtls_ctr_drbg_seed(&s_ctr_drbg, mbedtls_entropy_func, &s_entropy,
-                               (const unsigned char*)pers, strlen(pers)) != 0)
-    {
-        s_hwSerial.println("[TLS] RNG init failed — TLS console disabled.");
-        vTaskDelete(nullptr); return;
-    }
-
-    // Load or generate credentials
-    // Force regeneration if stored key is RSA (old format) — EC uses ~1 KB vs ~16 KB heap
-    Preferences prefs;
-    prefs.begin(NVS_NS, true);
-    String certPem = prefs.getString(NVS_CERT, "");
-    String keyPem  = prefs.getString(NVS_KEY,  "");
-    String keyAlg  = prefs.getString(NVS_ALG,  "");
-    prefs.end();
-
-    if (certPem.isEmpty() || keyPem.isEmpty() || keyAlg != "EC")
-    {
-        if (keyAlg != "EC" && !certPem.isEmpty())
-            s_hwSerial.println("[TLS] Upgrading RSA key to EC P-256 (less heap)...");
-        if (!generateAndStoreTlsCredentials()) { vTaskDelete(nullptr); return; }
-        prefs.begin(NVS_NS, true);
-        certPem = prefs.getString(NVS_CERT, "");
-        keyPem  = prefs.getString(NVS_KEY,  "");
-        prefs.end();
-    }
-
-    // Parse cert + key into global contexts
-    mbedtls_x509_crt_init(&s_cert);
-    mbedtls_pk_init(&s_srv_key);
-
-    if (mbedtls_x509_crt_parse(&s_cert,
-                                (const unsigned char*)certPem.c_str(),
-                                certPem.length() + 1) != 0)
-    {
-        s_hwSerial.println("[TLS] Certificate parse failed — TLS console disabled.");
-        vTaskDelete(nullptr); return;
-    }
-
-    if (mbedtls_pk_parse_key(&s_srv_key,
-                              (const unsigned char*)keyPem.c_str(),
-                              keyPem.length() + 1,
-                              nullptr, 0) != 0)
-    {
-        s_hwSerial.println("[TLS] Private key parse failed — TLS console disabled.");
-        vTaskDelete(nullptr); return;
-    }
-
-    // Build SSL server config
-    mbedtls_ssl_config_init(&s_conf);
-    if (mbedtls_ssl_config_defaults(&s_conf,
-                                    MBEDTLS_SSL_IS_SERVER,
-                                    MBEDTLS_SSL_TRANSPORT_STREAM,
-                                    MBEDTLS_SSL_PRESET_DEFAULT) != 0)
-    {
-        s_hwSerial.println("[TLS] ssl_config_defaults failed.");
-        vTaskDelete(nullptr); return;
-    }
-
-    mbedtls_ssl_conf_rng(&s_conf, mbedtls_ctr_drbg_random, &s_ctr_drbg);
-    mbedtls_ssl_conf_own_cert(&s_conf, &s_cert, &s_srv_key);
-    mbedtls_ssl_conf_authmode(&s_conf, MBEDTLS_SSL_VERIFY_NONE); // no client cert required
-    mbedtls_ssl_conf_dbg(&s_conf, tls_debug_cb, nullptr);
-
-    // Restrict ECDHE groups to exclude P-521 (and BP-512).
-    // The ESP-IDF mbedTLS 2.28 SDK has SECP521R1 and BP512R1 enabled. OpenSSL advertises
-    // P-521 in its ClientHello supported_groups, so the server selects P-521 for the
-    // ephemeral ECDH key — this requires ~16 KB of contiguous heap for BIGNUM operations.
-    // After the first handshake the heap is sufficiently fragmented that subsequent
-    // handshakes fail with "BIGNUM - Memory allocation failed".
-    //
-    // Curve25519, P-256, and P-384 each need ≤8 KB for ECDH, which is always available.
-    // The server certificate uses P-256, so Curve25519 and P-384 are only used for the
-    // ephemeral ECDHE key exchange — this is correct TLS behaviour.
-    //
-    // NOTE: A single-entry curve list {SECP256R1, NONE} causes "no usable ciphersuite"
-    // after reboot in ESP-IDF mbedTLS 2.28 (ssl_pick_cert() internal check fails).
-    // Using a multi-entry list that includes the cert curve (P-256) avoids this.
-    static const mbedtls_ecp_group_id s_tls_curves[] = {
-        MBEDTLS_ECP_DP_CURVE25519,
-        MBEDTLS_ECP_DP_SECP256R1,
-        MBEDTLS_ECP_DP_SECP384R1,
-        MBEDTLS_ECP_DP_NONE
-    };
-    mbedtls_ssl_conf_curves(&s_conf, s_tls_curves);
-
-    s_conf_ready = true;
-
-    // ssl context is allocated lazily in handshakeTask (per connection) and
-    // freed in teardownClient() — this returns the ~36 KB I/O buffers to the
-    // heap when no client is connected.
-
-    // Signal loopTlsConsole() to open the listening socket.
-    s_server_pending = true;
-    vTaskDelete(nullptr);
-}
 
 void startTlsConsole()
 {
     if (s_started) return;
-    s_started = true;
-    s_mutex   = xSemaphoreCreateMutex();
-
-    // Offload key generation + ssl_setup to a background task so the main loop
-    // (LoRa, BLE, GPS) is not blocked on first boot when the EC key is generated.
-    // Pinned to core 1 (same as Arduino loop) so that WiFiServer::begin() and the
-    // s_conf_ready / s_server_pending flags are visible without cross-core cache issues.
-    xTaskCreatePinnedToCore(tlsInitTask, "tls_init", 8192, nullptr, 1, nullptr, 1);
+    s_started        = true;
+    s_mutex          = xSemaphoreCreateMutex();
+    s_server_pending = true;   // open socket on next loopTlsConsole() call
+    s_hwSerial.println("[CON] HMAC console init.");
 }
 
 void loopTlsConsole()
 {
-    if (!s_conf_ready) return;
-
-    // Open the raw BSD listening socket (called once after tlsInitTask completes).
+    // Open listening socket on first call (triggered by startTlsConsole)
     if (s_server_pending)
     {
         s_server_pending = false;
@@ -528,7 +281,7 @@ void loopTlsConsole()
         s_listen_fd = ::socket(AF_INET, SOCK_STREAM, 0);
         if (s_listen_fd < 0)
         {
-            s_hwSerial.println("[TLS] socket() failed — TLS console disabled.");
+            s_hwSerial.println("[CON] socket() failed.");
             return;
         }
         int opt = 1;
@@ -543,14 +296,13 @@ void loopTlsConsole()
         if (::bind(s_listen_fd, (struct sockaddr*)&addr, sizeof(addr)) < 0 ||
             ::listen(s_listen_fd, 1) < 0)
         {
-            s_hwSerial.println("[TLS] bind/listen failed — TLS console disabled.");
+            s_hwSerial.println("[CON] bind/listen failed.");
             ::close(s_listen_fd); s_listen_fd = -1;
             return;
         }
-        // Non-blocking so loopTlsConsole() doesn't stall the main loop
         int fl = fcntl(s_listen_fd, F_GETFL, 0);
         fcntl(s_listen_fd, F_SETFL, fl | O_NONBLOCK);
-        s_hwSerial.printf("[TLS] Console started on port %d\n", TLS_CONSOLE_PORT);
+        s_hwSerial.printf("[CON] Console started on port %d\n", TLS_CONSOLE_PORT);
     }
 
     if (s_listen_fd < 0) return;
@@ -558,7 +310,6 @@ void loopTlsConsole()
     // Detect disconnect of active session
     if (s_authenticated)
     {
-        // Check disconnect via a zero-byte peek (non-blocking)
         char dummy;
         int r = ::recv(s_fd, &dummy, 1, MSG_PEEK | MSG_DONTWAIT);
         if (r == 0 || (r < 0 && errno != EAGAIN && errno != EWOULDBLOCK))
@@ -569,7 +320,7 @@ void loopTlsConsole()
                 xSemaphoreGive(s_mutex);
             }
         }
-        return; // don't accept new client while one is active
+        return;
     }
 
     // Non-blocking accept
@@ -579,26 +330,25 @@ void loopTlsConsole()
     if (client_fd < 0)
     {
         if (errno != EAGAIN && errno != EWOULDBLOCK)
-            s_hwSerial.printf("[TLS] accept() error: errno=%d\n", errno);
-        return; // EAGAIN = no client yet
+            s_hwSerial.printf("[CON] accept() error: errno=%d\n", errno);
+        return;
     }
 
-    s_hwSerial.printf("[TLS] accept() fd=%d\n", client_fd);
+    s_hwSerial.printf("[CON] accept() fd=%d free=%u\n", client_fd, (unsigned)esp_get_free_heap_size());
 
     if (s_hs_running)
     {
-        s_hwSerial.println("[TLS] Rejected: handshake already in progress");
+        s_hwSerial.println("[CON] Rejected: auth already in progress");
         ::close(client_fd);
         return;
     }
 
     s_hs_running = true;
-    HandshakeArgs* args = new HandshakeArgs{ client_fd };
-    s_hwSerial.printf("[TLS] Free heap before task: %u\n", (unsigned)esp_get_free_heap_size());
-    BaseType_t rc = xTaskCreatePinnedToCore(handshakeTask, "tls_hs", 4096, args, 1, nullptr, 1);
+    AuthArgs* args = new AuthArgs{ client_fd };
+    BaseType_t rc = xTaskCreatePinnedToCore(authTask, "con_auth", 3072, args, 1, nullptr, 1);
     if (rc != pdPASS)
     {
-        s_hwSerial.printf("[TLS] xTaskCreate failed: %d, free heap: %u\n", rc, (unsigned)esp_get_free_heap_size());
+        s_hwSerial.printf("[CON] xTaskCreate failed: %d\n", rc);
         delete args; ::close(client_fd); s_hs_running = false;
     }
 }
@@ -619,11 +369,10 @@ int tlsConsoleRead()
     }
 
     uint8_t c;
-    int r = mbedtls_ssl_read(&s_ssl, &c, 1);
+    int r = ::recv(s_fd, &c, 1, MSG_DONTWAIT);
     if (r == 1) return (int)c;
 
-    // Any other result (0 = closed, negative error except WANT_*) = disconnect
-    if (r == 0 || (r != MBEDTLS_ERR_SSL_WANT_READ && r != MBEDTLS_ERR_SSL_WANT_WRITE))
+    if (r == 0 || (r < 0 && errno != EAGAIN && errno != EWOULDBLOCK))
     {
         if (s_mutex && xSemaphoreTake(s_mutex, 0) == pdTRUE)
         {
@@ -639,12 +388,11 @@ bool tlsConsoleAvailable()
     if (!isTlsConsoleConnected()) return false;
     if (s_peek_valid) return true;
 
-    // Non-blocking peek via mbedTLS (socket is O_NONBLOCK after auth)
     uint8_t c;
-    int r = mbedtls_ssl_read(&s_ssl, &c, 1);
+    int r = ::recv(s_fd, &c, 1, MSG_DONTWAIT);
     if (r == 1) { s_peek_valid = true; s_peek_byte = c; return true; }
 
-    if (r == 0 || (r != MBEDTLS_ERR_SSL_WANT_READ && r != MBEDTLS_ERR_SSL_WANT_WRITE))
+    if (r == 0 || (r < 0 && errno != EAGAIN && errno != EWOULDBLOCK))
     {
         if (s_mutex && xSemaphoreTake(s_mutex, 0) == pdTRUE)
         {

--- a/src/tls_console.h
+++ b/src/tls_console.h
@@ -1,41 +1,26 @@
 #pragma once
 
-// TLS console server (port 2323) — encrypted Serial bridge for ESP32
-// Replaces plain-text Telnet (port 23) — now renamed to TLS Console.
+// HMAC console server (port 2323) — raw TCP serial bridge for ESP32
+// Replaces the TLS console to free the 36 KB mbedTLS I/O buffer overhead.
 // Only active on ESP32 with WiFi or Ethernet (not on nRF52/RAK4631).
 //
 // Security model:
-//   - EC P-256 key + self-signed cert generated on first boot,
-//     stored in NVS namespace "tls_creds" (separate from user settings).
-//   - After TLS handshake the client must send the node password followed
-//     by '\n'. The password is taken from meshcom_settings.node_passwd.
-//     If node_passwd is empty no password is required (open access, same
-//     behaviour as the old plain-text Telnet).
-//   - The TLS handshake runs in a dedicated FreeRTOS task so the main loop
-//     (including LoRa processing) is never blocked.
+//   - HMAC-SHA256 challenge-response: server sends a 16-byte random nonce,
+//     client must respond with HMAC-SHA256(password, nonce) as 64 hex chars.
+//     The password is never transmitted — only its HMAC is.
+//   - If node_passwd is empty no authentication is required (open access).
+//   - Auth runs in a dedicated FreeRTOS task (non-blocking for LoRa).
 //
-// Password setzen (max. 14 Zeichen, wird in NVS gespeichert):
+// Password setzen (max. 14 Zeichen):
 //   --passwd MeinPasswort
 //
-// Verbindung herstellen (Windows — Git Bash oder cmd.exe):
-//   "C:\Program Files\Git\usr\bin\openssl.exe" s_client -connect <ip>:2323
+// Verbindung herstellen (Python, alle Plattformen):
+//   python3 hmac_connect.py <ip> MeinPasswort
+//   (Skript: nonce=recv; send(HMAC-SHA256(password,nonce).hex()+'\n'))
 //
-// Verbindung herstellen (Linux / macOS):
-//   openssl s_client -connect <ip>:2323
-//   ncat --ssl <ip> 2323
-//
-// Ablauf nach CONNECTED:
-//   1. TLS-Handshake (self-signed Cert — Verify error 18 ist normal, kein Problem)
-//   2. Prompt:  Password:
-//   3. Passwort eingeben + Enter  (kein Echo sichtbar)
-//   4. Bei Erfolg:  MeshCom TLS Console
-//                   Type --help for commands
-//
-// Hinweise:
-//   - openssl mit -quiet unterdrückt den TLS-Header, aber der Password-Prompt
-//     kann dadurch unsichtbar sein → ohne -quiet verwenden.
-//   - Test-NetConnection blockiert den Server für 15 s (kein TLS ClientHello).
-//     Danach ist der Server wieder frei.
+// Verbindung herstellen (kein Passwort gesetzt):
+//   nc <ip> 2323         (Linux / macOS)
+//   ncat.exe <ip> 2323   (Windows — Nmap-Paket)
 
 #if defined(ESP32) && !defined(DISABLE_TLS_CONSOLE)
 

--- a/src/web_functions/web_functions.cpp
+++ b/src/web_functions/web_functions.cpp
@@ -1115,7 +1115,7 @@ void sub_page_setup()
     _create_setup_switch_element("netmode", "Ethernet Mode", "switch between WiFi and Ethernet", meshcom_settings.node_netmode == 1);
     #endif
     _create_setup_switch_element("extudp", "ext UDP", "enable ext. UDP", bEXTUDP); // create Switch-Element inclucing Label and Description
-    _create_setup_switch_element("tlsconsole", "TLS Console", "enable TLS console (port 2323, encrypted)", bTLS_CONSOLE); // create Switch-Element inclucing Label and Description
+    _create_setup_switch_element("netconsole", "net console", "enable net console (port 2323, HMAC auth)", bNET_CONSOLE); // create Switch-Element inclucing Label and Description
     _create_setup_switch_element("gateway", "Gateway", "enable gateway", bGATEWAY);   // create Switch-Element inclucing Label and Description
 
     web_client.println("</div></div>");

--- a/src/web_functions/web_setup.cpp
+++ b/src/web_functions/web_setup.cpp
@@ -455,10 +455,10 @@ void webSetup_setParam(setupStruct *setupData){
         return;
     } else
 
-    if(setupData->paramName.equals("tlsconsole")) {
+    if(setupData->paramName.equals("netconsole")) {
         commandAction(message_text, bPhoneReady);
-        setupData->returnCode = (bTLS_CONSOLE == (setupData->paramValue.compareTo("on")==0))?WS_RETURNCODE_OKAY:WS_RETURNCODE_FAIL;
-        setupData->returnValue = bTLS_CONSOLE?"on":"off";
+        setupData->returnCode = (bNET_CONSOLE == (setupData->paramValue.compareTo("on")==0))?WS_RETURNCODE_OKAY:WS_RETURNCODE_FAIL;
+        setupData->returnValue = bNET_CONSOLE?"on":"off";
         return;
     } else
 
@@ -842,7 +842,7 @@ void webSetup_getParam(setupStruct *setupData){
         return;
     }
 
-    if(setupData->paramName.equals("tlsconsole")) {
+    if(setupData->paramName.equals("netconsole")) {
         return;
     }
 

--- a/tools/hmac_connect.ps1
+++ b/tools/hmac_connect.ps1
@@ -1,0 +1,87 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Connect to the MeshCom HMAC console (port 2323).
+.EXAMPLE
+    .\hmac_connect.ps1 192.168.1.100
+    .\hmac_connect.ps1 192.168.1.100 MeinPasswort
+    .\hmac_connect.ps1 192.168.1.100 MeinPasswort 2323
+#>
+param(
+    [Parameter(Mandatory)][string]$Host,
+    [string]$Password = "",
+    [int]$Port = 2323
+)
+
+$tcp = [Net.Sockets.TcpClient]::new($Host, $Port)
+$stream = $tcp.GetStream()
+$rd = [IO.StreamReader]::new($stream)
+$wr = [IO.StreamWriter]::new($stream)
+$wr.AutoFlush = $true
+
+if ($Password -ne "") {
+    # Read "NONCE: <32 hex chars>"
+    $nonceHex = ($rd.ReadLine() -split " ")[1].Trim()
+
+    # Hex string -> byte[] (PS 5.1 compatible — no FromHexString)
+    $nonce = [byte[]]@(0..($nonceHex.Length / 2 - 1) | ForEach-Object {
+        [Convert]::ToByte($nonceHex.Substring($_ * 2, 2), 16)
+    })
+
+    # HMAC-SHA256(key=password, data=nonce)
+    $hmac = [Security.Cryptography.HMACSHA256]::new(
+        [Text.Encoding]::UTF8.GetBytes($Password))
+    $hash = $hmac.ComputeHash($nonce)
+
+    # byte[] -> lowercase hex (PS 5.1 compatible — no ToHexString)
+    $response = [BitConverter]::ToString($hash).Replace('-', '').ToLower()
+
+    $wr.WriteLine($response)
+
+    $result = $rd.ReadLine().Trim()
+    if ($result -ne "OK") {
+        Write-Error "Authentication failed: $result"
+        $tcp.Close(); exit 1
+    }
+    Write-Host "Authentication OK." -ForegroundColor Green
+}
+
+# Read banner
+$stream.ReadTimeout = 800
+try {
+    while ($true) {
+        $line = $rd.ReadLine()
+        if ($null -eq $line) { break }
+        Write-Host $line
+    }
+} catch { }
+$stream.ReadTimeout = [Threading.Timeout]::Infinite
+
+Write-Host "--- Connected (Ctrl+C to quit) ---" -ForegroundColor Cyan
+
+# Receive loop (background job)
+$job = [PowerShell]::Create()
+$null = $job.AddScript({
+    param($rd)
+    try {
+        while ($true) {
+            $line = $rd.ReadLine()
+            if ($null -eq $line) { break }
+            Write-Host $line
+        }
+    } catch { }
+}).AddArgument($rd)
+$handle = $job.BeginInvoke()
+
+# Send loop (foreground)
+try {
+    while ($true) {
+        $line = Read-Host
+        $wr.WriteLine($line)
+    }
+} catch [Management.Automation.PipelineStoppedException] {
+    # Ctrl+C
+} finally {
+    $job.Stop()
+    $tcp.Close()
+}

--- a/tools/hmac_connect.py
+++ b/tools/hmac_connect.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""
+hmac_connect.py — Connect to the MeshCom HMAC console (port 2323).
+
+Usage:
+    python3 hmac_connect.py <ip>                   # no password
+    python3 hmac_connect.py <ip> <password>         # with HMAC auth
+    python3 hmac_connect.py <ip> <password> <port>  # custom port
+
+Protocol:
+    <- "NONCE: <32 hex chars>\\r\\n"
+    -> "<64 hex HMAC-SHA256(password, nonce)>\\r\\n"
+    <- "OK\\r\\n<banner>"  or  "FAIL\\r\\n"
+    -- bidirectional plaintext afterwards --
+
+Requires: Python 3.6+, no external dependencies.
+"""
+
+import sys
+import socket
+import hmac
+import hashlib
+import threading
+import os
+
+def main():
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <ip> [password] [port]", file=sys.stderr)
+        sys.exit(1)
+
+    host     = sys.argv[1]
+    password = sys.argv[2].encode() if len(sys.argv) > 2 else b""
+    port     = int(sys.argv[3]) if len(sys.argv) > 3 else 2323
+
+    print(f"Connecting to {host}:{port} ...", flush=True)
+    s = socket.create_connection((host, port), timeout=10)
+    s.settimeout(35)
+
+    f = s.makefile("r", newline="\n")
+
+    # Read challenge line
+    line = f.readline()
+    if not line:
+        print("Connection closed before challenge.", file=sys.stderr)
+        sys.exit(1)
+
+    line = line.strip()
+
+    if password:
+        # Expect "NONCE: <hex>"
+        if not line.upper().startswith("NONCE:"):
+            print(f"Unexpected server response: {line!r}", file=sys.stderr)
+            sys.exit(1)
+        nonce_hex = line.split()[1].strip()
+        nonce     = bytes.fromhex(nonce_hex)
+        response  = hmac.new(password, nonce, hashlib.sha256).hexdigest()
+        s.sendall((response + "\n").encode())
+
+        # Read OK / FAIL
+        result = f.readline().strip()
+        if result != "OK":
+            print(f"Authentication failed: {result!r}", file=sys.stderr)
+            sys.exit(1)
+        print("Authentication OK.", flush=True)
+    else:
+        # No password — server sends banner directly
+        print(line, flush=True)
+
+    # Read banner lines until empty line or prompt
+    s.settimeout(1.0)
+    try:
+        while True:
+            banner_line = f.readline()
+            if not banner_line:
+                break
+            print(banner_line, end="", flush=True)
+    except socket.timeout:
+        pass
+    s.settimeout(None)
+
+    # Interactive bidirectional I/O
+    def recv_loop():
+        try:
+            while True:
+                data = s.recv(256)
+                if not data:
+                    break
+                sys.stdout.write(data.decode(errors="replace"))
+                sys.stdout.flush()
+        except Exception:
+            pass
+        print("\n[Disconnected]", flush=True)
+        os._exit(0)
+
+    t = threading.Thread(target=recv_loop, daemon=True)
+    t.start()
+
+    try:
+        while True:
+            line = input()
+            s.sendall((line + "\r\n").encode())
+    except (EOFError, KeyboardInterrupt):
+        pass
+
+    s.close()
+
+if __name__ == "__main__":
+    main()

--- a/variants/E22_XML-DevKitC/configuration.h
+++ b/variants/E22_XML-DevKitC/configuration.h
@@ -27,6 +27,7 @@ definitions for E22 Board
 #define ENABLE_RTC
 
 #define ENABLE_SOFTSER
+#define NO_NET_CONSOLE
 
 #define ANALOG_PIN 32
 #define ANALOG_REFRESH_INTERVAL 30 // sec messure intervall

--- a/variants/E22_XML-DevKitC/platformio.ini
+++ b/variants/E22_XML-DevKitC/platformio.ini
@@ -31,5 +31,4 @@ build_flags =
 	${common.build_flags}
 	-D BOARD_E22="az-delivery-devkit-v4"
 	-I variants/${this.__env__}
-	-D DISABLE_TLS_CONSOLE
-	
+	-D DISABLE_NET_CONSOLE


### PR DESCRIPTION
## Zusammenfassung / Summary

Ersatz der deaktivierten TLS-Console durch eine RAM-effiziente HMAC-SHA256-Console sowie vier unabhängige Bugfixes.

Replaces the disabled TLS console with a RAM-efficient HMAC-SHA256 console, and fixes four independent bugs.

---

## 1. `src/net_console.cpp` — HMAC-Console ersetzt TLS-Console / HMAC Console replaces TLS Console

**Problem (DE):** Die TLS-Console benötigte mbedTLS SSL-Setup, X.509-Zertifikate und NVS-Schlüsselspeicherung (~36 KB RAM pro aktiver Session). Auf RAM-knappen Boards führte dies zu OOM-Fehlern.

**Problem (EN):** The TLS console required mbedTLS SSL setup, X.509 certificates and NVS key storage (~36 KB RAM per active session). On RAM-constrained boards this caused OOM crashes.

**Änderung / Change:** TLS wird durch ein HMAC-SHA256 Challenge-Response-Protokoll über Raw TCP ersetzt. `mbedtls/md.h` ist bereits im ESP-IDF enthalten — keine zusätzliche Bibliothek notwendig. Protokoll: Node sendet 16-Byte-NONCE → Client antwortet mit HMAC-SHA256(Passwort, NONCE) → `OK`/`FAIL`. RAM-Verbrauch aktive Session: ~0 KB. Die öffentliche API (`net_console.h`) ist zur bisherigen `tls_console.h` kompatibel.

TLS is replaced by an HMAC-SHA256 challenge-response protocol over raw TCP. `mbedtls/md.h` is already part of ESP-IDF — no additional library required. Protocol: node sends a 16-byte NONCE → client responds with HMAC-SHA256(password, NONCE) → `OK`/`FAIL`. RAM per active session: ~0 KB. Public API (`net_console.h`) is compatible with the previous `tls_console.h`.

Neue Client-Tools / New client tools: `tools/hmac_connect.py` (Linux/macOS/Windows, keine Abhängigkeiten / no dependencies) und / and `tools/hmac_connect.ps1` (Windows PowerShell 5.1+).

---

## 2. `src/lora_functions.cpp` — `startTransmit()` Fehlerbehandlung / Error Recovery

**Problem (DE):** Wenn `radio.startTransmit()` im Track→MeshCom- oder APRS-TX-Pfad fehlschlug, wurde `doTX()` trotzdem mit `return true` beendet. Kein TX-done-IRQ folgte → State-Machine blockierte für `TX_WATCHDOG_MS` (15 Sekunden).

**Problem (EN):** When `radio.startTransmit()` failed in the Track→MeshCom or APRS TX path, `doTX()` still returned `true`. No TX-done IRQ followed → state machine stalled for `TX_WATCHDOG_MS` (15 seconds).

**Änderung / Change:** Bei `startTransmit()`-Fehler: `tx_is_active` zurücksetzen, Ring-Slot wiederherstellen, `iRead` zurückrollen, `false` zurückgeben → sofortiger Retry ohne 15s-Wartezeit. / On failure: reset `tx_is_active`, restore the ring slot, roll back `iRead`, return `false` → immediate retry without the 15 s stall.

---

## 3. `src/lora_functions.cpp` — `updateRetransmissionStatus()`: Retransmit-Slot `len=0`

**Problem (DE):** Bei einem DM-Retry wurde `ringBuffer[ircheck][0] = 0` **vor** `memcpy(ringBuffer[iWrite], ...)` gesetzt → `len=0` in der Kopie → leere Payload beim Empfänger. Im Log sichtbar als `RING_WRITE ... len=0 src=retransmit`.

**Problem (EN):** During a DM retry `ringBuffer[ircheck][0] = 0` was set **before** `memcpy(ringBuffer[iWrite], ...)` → `len=0` in the copy → empty payload at the receiver. Visible in the log as `RING_WRITE ... len=0 src=retransmit`.

**Änderung / Change:** `memcpy` wird vor dem Löschen des Original-Slots ausgeführt. / `memcpy` is now executed before the original slot is cleared.

---

## 4. `src/loop_functions.cpp` — `SendAckMessage()`: APRS-ACK Priorität prio=3 statt prio=1

**Problem (DE):** `ringBuffer[iWrite][1] = 0xFF` wurde **vor** `addTxRingEntry()` gesetzt. `getMessagePriority()` interpretiert `RING_STATUS_DONE (0xFF)` als Relay-Nachricht → `MSG_PRIO_NORMAL` (prio=3) statt `MSG_PRIO_CRITICAL` (prio=1). Im Log sichtbar als `RING_TX_READ ... prio=3`.

**Problem (EN):** `ringBuffer[iWrite][1] = 0xFF` was set **before** `addTxRingEntry()`. `getMessagePriority()` interprets `RING_STATUS_DONE (0xFF)` as a relay message → `MSG_PRIO_NORMAL` (prio=3) instead of `MSG_PRIO_CRITICAL` (prio=1). Visible in the log as `RING_TX_READ ... prio=3`.

**Änderung / Change:** Status=`0x00` beim Einreihen, `addTxRingEntry()` aufrufen (Priorität korrekt als prio=1 bewertet), danach `status=0xFF` auf dem gesicherten Slot-Index setzen. / Status is set to `0x00` when enqueuing, `addTxRingEntry()` is called (priority correctly evaluated as prio=1), then `status=0xFF` is applied to the saved slot index.

---

## 5. `src/extudp_functions.cpp` — `resetExternUDP()`: UDP-Socket nach Fehler nie neu gestartet

**Problem (DE):** Nach einem UDP-TX-Fehler: `hasExternIPaddress = false` → sofort `if(bEXTUDP && hasExternIPaddress && ...)` — **immer false**. `startExternUDP()` wurde nie aufgerufen. Symptom: UDP-Empfang dauerhaft tot; Reboot nötig.

**Problem (EN):** After a UDP TX error: `hasExternIPaddress = false` → immediately `if(bEXTUDP && hasExternIPaddress && ...)` — **always false**. `startExternUDP()` was never called. Symptom: UDP reception permanently dead; reboot required.

**Änderung / Change:** `&& hasExternIPaddress` aus der Bedingung entfernt. / `&& hasExternIPaddress` removed from the condition.

---

## Getestete Boards / Tested Boards

- `ttgo_tbeam` ✓
- `heltec_wifi_lora_32_V3` ✓

## Ziel-Branch / Target Branch

`DEV` — `icssw-org/MeshCom-Firmware`
