### PR TITLE
wireless-paper: V1.1-Panel (LCMEN2R13EFC1) Anzeige-Fix + LED-Kommando-Doku

### DIFF
--- a/src/loop_functions.cpp
+++ b/src/loop_functions.cpp
@@ -1514,6 +1514,16 @@ void sendDisplayMainline()
 // aufgerufen - sekuendliches Voll-Update waere auf E-Ink Verschleiss und unnoetig.
 void wpRefreshClock()
 {
+    // V1.1-Panel (LCMEN2R13EFC1) unterstuetzt KEIN partielles Fenster-Update: jedes update()
+    // ist ein Voll-Panel-Refresh aus dem Framebuffer. Der setWindow-Teilrefresh nur der
+    // Statuszeile leert dabei den Framebuffer (clear_page) - der naechste Voll-Refresh wuerde
+    // den darunterliegenden Nachrichtentext loeschen. Daher auf V1.1 KEINEN separaten 10-s-Uhr-
+    // Refresh: die Statuszeile wird beim naechsten regulaeren Seiten-Redraw mitaktualisiert,
+    // der Seiteninhalt bleibt erhalten. V1.2 (E0213A367, SSD1680 mit echtem HW-Fenster) laeuft
+    // unveraendert weiter.
+    if(memcmp(g_wp_panel_name, "LCMEN", 5) == 0)
+        return;
+
     char cbatt[10];
     if(bDisplayVolt)
         snprintf(cbatt, sizeof(cbatt), "%5.2fV", global_batt/1000.0);

--- a/variants/wireless-paper/configuration.h
+++ b/variants/wireless-paper/configuration.h
@@ -64,7 +64,7 @@ Chip-ID erkannt (detectEinkChipId() in esp32_functions.cpp):
 
 // Onboard-LED der Wireless Paper auf GPIO18 (active HIGH, einfache LED - KEIN NeoPixel).
 // MeshCom blinkt sie als Heartbeat ueber den BOARD_LED-Pfad; standardmaessig AUS
-// (bUSER_BOARD_LED=false), per App/--setbled on einschaltbar. Gleiche Belegung wie T-Beam-1W.
+// (bUSER_BOARD_LED=false), per Terminal-Kommando "--board led on" einschaltbar. Gleiche Belegung wie T-Beam-1W.
 #define BOARD_LED 18
 
 // --- Pins, die von NICHT board-spezifisch geschuetztem Code referenziert werden ---


### PR DESCRIPTION
Follow-up zu #969 (Heltec Wireless Paper). Zwei kleine, auf die Wireless Paper
beschränkte Korrekturen — alle Eingriffe unter `#if defined(BOARD_WIRELESS_PAPER)`
bzw. zur Laufzeit panel-spezifisch. **Die V1.2 (E0213A367) bleibt unverändert.**

## 1. `wpRefreshClock` auf V1.1-Panel (LCMEN2R13EFC1) überspringen — `src/loop_functions.cpp`
Auf der Wireless Paper **V1.1** (Controller **LCMEN2R13EFC1**) verschwand der
Nachrichtentext nach ~10 s; danach war nur noch die Statuszeile sichtbar.

Ursache: `wpRefreshClock()` aktualisiert alle 10 s nur die oberste Statuszeile per
Teilbereich (`setWindow`). Der LCMEN2R13EFC1 unterstützt jedoch **kein „partial
window"** (siehe Treiber-Kommentare: *„this controller doesn't actually support
partial window"*, *„Always write the full pagefile"*) — jedes `update()` ist ein
**Voll-Panel-Refresh aus dem Framebuffer**. Das abschließende `setWindow(...,full)`
leert per `clear_page` den Framebuffer, sodass der nächste Voll-Refresh den
darunterliegenden Text löscht. Auf der **V1.2** (SSD1680) maskiert das echte
Hardware-Fenster + E-Ink-Retention diesen Effekt — dort ist alles korrekt.

Fix: `wpRefreshClock()` kehrt auf V1.1 (`g_wp_panel_name == "LCMEN…"`) sofort zurück.
Die Statuszeile/Uhr wird dort beim nächsten regulären Seiten-Redraw mitaktualisiert,
der Seiteninhalt bleibt erhalten. Der V1.2-Codepfad ist unverändert.

## 2. LED-Kommando-Doku korrigieren — `variants/wireless-paper/configuration.h`
Reiner Kommentar: Das Terminal-Kommando zum Einschalten der Onboard-LED (GPIO18)
heißt **`--board led on`** (bzw. `--board led off`), nicht `--setbled on`.

## Test
Auf realer Hardware verifiziert: V1.2 (E0213A367) unverändert korrekt; auf V1.1
(LCMEN2R13EFC1) bleibt der Nachrichtentext nun stehen.