### PR TITLE
wireless-paper: Zeit-Persistenz beim Boot laden (loadTimePersistence)

### DIFF
--- a/src/esp32/esp32_main.cpp
+++ b/src/esp32/esp32_main.cpp
@@ -729,6 +729,26 @@ void esp32setup()
 
     save_settings();
 
+    #if defined(BOARD_WIRELESS_PAPER)
+    // ====================================================================================
+    // [WP-FIX #3] Zeit-Persistenz beim Boot wiederherstellen (Wireless Paper hat KEINE RTC)
+    // ------------------------------------------------------------------------------------
+    // Die Firmware SPEICHERT die Uhrzeit ohnehin alle 15 Min in NVS (saveTimePersistence(),
+    // esp32loop), aber loadTimePersistence() wird im Original NUR am T-Deck aufgerufen - auf
+    // der WP NIE. Folge: nach jedem Reboot/Stromausfall startet die Uhr bei 2000-01-01, bis
+    // (irgendwann) NTP greift -> "Time Lost". Da die WP weder RTC noch GPS hat, ist NVS die
+    // einzige Bruecke ueber Netz-/NTP-Luecken.
+    // Hier additiv (kapern): einmal beim Boot die zuletzt gespeicherte Zeit laden.
+    // Den UTC-Offset wendet loadTimePersistence() seit dev-Commit 9e049d3 SELBST an
+    // (SetClock(unix + node_utcoff, /*boUseUTC=*/false) -> Lokalzeit). Frueher fehlte das
+    // (gmtime/UTC) -> Uhr/Start Date liefen nach Reboot auf UTC (vgl. icssw Issue #972). Unser
+    // frueherer eigener NVS-Read-Workaround ist damit ueberfluessig; der simple Aufruf genuegt.
+    // SetClock passiert nur bei gueltigem Wert; NTP/{CET}/Phone ueberschreiben das spaeter.
+    // initTimePersistence() (mit clear()) laeuft NUR bei Flash-Clear/Versionswechsel, unberuehrt.
+    // ====================================================================================
+    loadTimePersistence();
+    #endif
+
     bDisplayVolt = meshcom_settings.node_sset & 0x0001;
     bDisplayOff = meshcom_settings.node_sset & 0x0002;
     bPosDisplay = meshcom_settings.node_sset & 0x0004;


### PR DESCRIPTION
## Was

Auf der **Heltec Wireless Paper** wird die in NVS gespeicherte Uhrzeit beim Boot wiederhergestellt, indem `loadTimePersistence()` einmalig in `esp32setup()` aufgerufen wird (WP-guarded).

## Warum

Die Wireless Paper hat **weder RTC noch GPS**. Die Firmware *speichert* die Uhrzeit zwar alle 15 Min in NVS (`saveTimePersistence()` in `esp32loop`), aber der passende **Lade-Aufruf** `loadTimePersistence()` existiert im Original **nur im T-Deck-Pfad** (`src/t-deck/tdeck_main.cpp`) — auf der WP/ESP32 wird er **nie** aufgerufen.

**Folge:** Nach jedem Reboot/Stromausfall startet die Uhr bei `2000-01-01`, bis (irgendwann) NTP greift → *„Time Lost"*. Da die WP weder RTC noch GPS hat, ist NVS die **einzige Brücke** über Netz-/NTP-Lücken.

## Wie

- **Datei:** `src/esp32/esp32_main.cpp` — in `esp32setup()` direkt nach `save_settings()`.
- **Additiv** (kapern): ein einzelner `loadTimePersistence();`-Aufruf, vollständig in `#if defined(BOARD_WIRELESS_PAPER)` gekapselt → **andere Boards unberührt**.
- Den **UTC-Offset** wendet `loadTimePersistence()` seit dev-Commit `9e049d3` **selbst** an (`SetClock(unix + node_utcoff, /*boUseUTC=*/false)` → Lokalzeit, vgl. Issue #972). `SetClock` greift nur bei gültigem Wert; **NTP/{CET}/Phone überschreiben** das später wie gehabt.
- `initTimePersistence()` (mit `clear()`) läuft weiterhin nur bei Flash-Clear/Versionswechsel — unberührt.

## Test

- Build grün: `wireless-paper` **und** `vision-master-e290` (Gegenprobe, da geteilter Code).
- Verhalten: Reboot ohne Netz → Uhr läuft mit der zuletzt gespeicherten (lokalen) Zeit weiter statt bei `2000-01-01`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
