### PR TITLE
corr ESP32-E22-PCB BATT

### DIFF
--- a/src/batt_functions.cpp
+++ b/src/batt_functions.cpp
@@ -2,8 +2,8 @@
  * @file batt_functions.cpp
  * @author W.Zelinka (OE3WAS, https://github.com/karamo)
  * @brief 
- * @version 0.4
- * @date 2026-05-13
+ * @version 0.5
+ * @date 2026-06-06
  * 
  * @copyright Copyright (c) 2026
  * 
@@ -223,6 +223,10 @@ float read_batt(void)
 	BatVoltage = filteredVoltage;
 
 	// Board spezifische Modifikation
+	#if defined(BOARD_E22)       // TODO: und auch die anderen E22 !!!
+		if (BatVoltage < 3.0) { BatVoltage = 0; }	// ADC-Eingang nicht mit Versorgungsspannung verbunden
+	#endif
+
 	#if defined(BOARD_TBEAM_1W)
 		// T-Beam 1W uses 7.4V 2S-battery (max. 8.1V)
 		// USB-Spannung kann nicht gemessen werden, nur die AKKU-Spannung
@@ -237,7 +241,10 @@ float read_batt(void)
 		// letzte Ausgabe erzwingen
 		snprintf(Buffer, sizeof(Buffer), "[BATT];%s; raw: ;%.3f; V max: ;%.2f; V fact: ;%.4f; filt: ;%.3f; V ;%.0f; %%",
 			getTimeString().c_str(), rawVoltage, fBattMax, fBattFaktor, filteredVoltage, mv_to_percent(filteredVoltage*1000.0));
-		// Abschaltmeldung ausgeben
+			// durchlaufe Array, bis Ende-Zeichen '\0' und '.' => ',' für deutsche CSV-Kompatibilität
+			for (int i = 0; Buffer[i] != '\0'; i++) { if (Buffer[i] == '.') { Buffer[i] = ','; } }
+			Serial.printf("%s\n",Buffer);
+			// Abschaltmeldung ausgeben
 		Serial.print("[ERR]...low Voltage Accu > goto deepsleep\n");
 		delay(1000); // für Ausgabe ermöglichen !!!
 
@@ -293,6 +300,7 @@ float mv_to_percent(float mvolts)
 	// fBattMax = Parameter aus Flash
   float rproz = (mvolts/1000.0 - BAT_MIN_VOLTAGE)/(fBattMax - BAT_MIN_VOLTAGE) *100.0;
   if (rproz > 100.0) { rproz = 100.0; }
+  if (rproz < 0.0) { rproz = 0.0; }
 	return round(rproz);
 
 #else

--- a/src/esp32/esp32_main.cpp
+++ b/src/esp32/esp32_main.cpp
@@ -1333,7 +1333,7 @@ void esp32setup()
         save_settings();
         printfdeb("[LoRa]...RF_POWER: %d dBm\n", tx_power);
 
-        if (radio.setOutputPower(tx_power) == RADIOLIB_ERR_INVALID_OUTPUT_POWER) {
+        if (radio.setOutputPower(tx_power,false) == RADIOLIB_ERR_INVALID_OUTPUT_POWER) {
             printlndeb(F("Selected output power is invalid for this module!"));
             while (true);
         }

--- a/variants/E22-DevKitC/configuration.h
+++ b/variants/E22-DevKitC/configuration.h
@@ -29,12 +29,12 @@ definitions for E22 Board
   #define BATTERY_PIN             32
   #define BAT_VOLT_PIN            BATTERY_PIN
   // voltage divider connected here to measure battery voltage
-  #define BAT_ADC_PULLUP_RES      100000.0  //extern
-  #define BAT_ADC_PULLDOWN_RES    100000.0  //extern
+  #define BAT_ADC_PULLUP_RES      47000.0  //extern
+  #define BAT_ADC_PULLDOWN_RES    47000.0  //extern
   #define BAT_MULTIPLIER (BAT_ADC_PULLUP_RES+BAT_ADC_PULLDOWN_RES)/BAT_ADC_PULLDOWN_RES
   #define BAT_MAX_VOLTAGE         4.1     //für Volt => Proz Umrechnung, definiert durch Akku
   #define BAT_MIN_VOLTAGE         3.3       //für Volt => Proz Umrechnung, definiert durch LDO
-  #define BAT_VOLT_OFFSET         0         //offset
+  #define BAT_VOLT_OFFSET         -0.28     //offset
   #define BAT_VOLT_FACTOR         1      //factor
   #define BAT_ATTEN               ADC_11db
   #define BAT_WIDTH               12

--- a/variants/E22_1262-DevKitC/configuration.h
+++ b/variants/E22_1262-DevKitC/configuration.h
@@ -34,13 +34,13 @@ definitions for E22 Board
   #define BATTERY_PIN             32
   #define BAT_VOLT_PIN            BATTERY_PIN
   // voltage divider connected here to measure battery voltage
-  #define BAT_ADC_PULLUP_RES      100000.0  //extern
-  #define BAT_ADC_PULLDOWN_RES    100000.0  //extern
+  #define BAT_ADC_PULLUP_RES      47000.0  //extern
+  #define BAT_ADC_PULLDOWN_RES    47000.0  //extern
   #define BAT_MULTIPLIER (BAT_ADC_PULLUP_RES+BAT_ADC_PULLDOWN_RES)/BAT_ADC_PULLDOWN_RES
   #define BAT_MAX_VOLTAGE         4.1     //für Volt => Proz Umrechnung, definiert durch Akku
-  #define BAT_MIN_VOLTAGE         3.3       //für Volt => Proz Umrechnung, definiert durch LDO
-  #define BAT_VOLT_OFFSET         0         //offset
-  #define BAT_VOLT_FACTOR         1      //factor
+  #define BAT_MIN_VOLTAGE         3.3     //für Volt => Proz Umrechnung, definiert durch LDO
+  #define BAT_VOLT_OFFSET         -0.28   //offset
+  #define BAT_VOLT_FACTOR         1       //factor
   #define BAT_ATTEN               ADC_11db
   #define BAT_WIDTH               12
 #endif


### PR DESCRIPTION
Korrekturen für BATT-Messung auf den ESP32-E22-PCB