### PR TITLE
fix: correct printf format specifier for % and remove errant n

### DIFF
--- a/src/batt_functions.cpp
+++ b/src/batt_functions.cpp
@@ -214,7 +214,7 @@ float read_batt(void)
         if(bDisplayCont)
 		{
 			bDEBUGLNG = true; // für den nächsten printfdeb language en/de aktivieren
-			printfdeb("[BATT];%s; raw:;%.3f;V max:;%.2f;V fact:;%.4f; filt:;%.3f;V ;%.0f;0/0 \n", getTimeString().c_str(), rawVoltage, fBattMax, fBattFaktor, filteredVoltage, mv_to_percent(filteredVoltage*1000.0));
+			printfdeb("[BATT];%s; raw:;%.3f;V max:;%.2f;V fact:;%.4f; filt:;%.3f;V ;%%;0/0 \n", getTimeString().c_str(), rawVoltage, fBattMax, fBattFaktor, filteredVoltage, mv_to_percent(filteredVoltage*1000.0));
 		}
 	}
 
@@ -239,7 +239,7 @@ float read_batt(void)
         if(bDisplayCont)
 		{
 			bDEBUGLNG = true; // für den nächsten printfdeb language en/de aktivieren
-			printfdeb("[BATT];%s; raw:;%.3f;V max:;%.2f;V fact:;%.4f; filt:;%.3f;V ;%.0f;0/0 \nn",
+			printfdeb("[BATT];%s; raw:;%.3f;V max:;%.2f;V fact:;%.4f; filt:;%.3f;V ;%.0f;0/0 \n",
 				getTimeString().c_str(), rawVoltage, fBattMax, fBattFaktor, filteredVoltage, mv_to_percent(filteredVoltage*1000.0));
 		}
 


### PR DESCRIPTION
## Summary

Fix two issues in `src/batt_functions.cpp`:

1. **Line 217**: Change `%.0f` to `%%`. In printf format strings, the correct way to output a literal `%` character is `%%` (the `%` character must be escaped as `%%`).

2. **Line 242**: Remove the errant `'n'` character after the newline escape sequence `\n`. The format string incorrectly ended with `\nn` which would print a newline followed by a literal `'n'`, instead of just a newline `\n`.

Both issues reported in `#991`. The issue author noted they are unable to create PRs, so this PR applies the fix on their behalf.

## Verification

- 1 file changed, 2 insertions, 2 deletions
- No unrelated changes (surgical fix)
- GH007 compliant (commit email: `166608075+Jah-yee@users.noreply.github.com`)