### PR TITLE
Neues Board: Heltec E213 (ESP32-S3 + SX1262 + 2.13" E-Ink)

### DIFF
--- a/src/Platforms/VisionMasterE213/VisionMasterE213.h
+++ b/src/Platforms/VisionMasterE213/VisionMasterE213.h
@@ -19,6 +19,8 @@
         // Don't use fallback settings
         #define PLATFORM_SUPPORTED
 
+        #define DISABLE_SDCARD                          // Nobody is going to solder an SD Card reader onto these boards.. right?
+
         // SPI
         #define CAN_MOVE_SPI_PINS       false
         #define ALL_IN_ONE              true            // Allow a short constructor: display pins are fixed
@@ -66,6 +68,8 @@
             extern void VExtOn();                                                                           // Enable power to peripherals
             extern void VExtOff();                                                                          // Disable power to perpiherals
             extern void toggleResetPin();                                                                   // Trigger the displays' reset pin
+            extern void loraToSleep();                                                                      // SX1262 -> SLEEP (Software-SPI), vor dem Deepsleep
+            extern void prepareToSleep();                                                                   // Board/Peripherie fuer Deepsleep (~18uA)
         }
 
     #endif

--- a/src/Platforms/VisionMasterE213/power_controls.cpp
+++ b/src/Platforms/VisionMasterE213/power_controls.cpp
@@ -28,12 +28,65 @@ namespace Platform {
     void toggleResetPin() {
         pinMode(PIN_DISPLAY_RST, OUTPUT);
         digitalWrite(PIN_DISPLAY_RST, LOW);
-        
+
         uint32_t start = millis();              // Non-blocking wait for reset
         while (millis() - start < 10)           // 10 ms
             yield();
 
         digitalWrite(PIN_DISPLAY_RST, HIGH);
+    }
+
+    // SX1262 in den SLEEP-Modus (Software-SPI, damit wir die Pins "uebernehmen" koennen).
+    // 1:1 von der Wireless Paper portiert - gleiche LoRa-Pins (HT-RA62-Modul). Idempotent
+    // (prepareToSleep() ruft sie erneut auf). Spart vor dem Deepsleep den RX-Strom (~mehrere mA).
+    void loraToSleep() {
+
+        // Default pin states
+        digitalWrite(PIN_LORA_NSS, HIGH);
+        digitalWrite(PIN_LORA_SCK, LOW);        // Mode 0 - Idle Low
+        digitalWrite(PIN_LORA_MOSI, LOW);
+
+        // Set pin modes
+        pinMode(PIN_LORA_NSS, OUTPUT);
+        pinMode(PIN_LORA_SCK, OUTPUT);
+        pinMode(PIN_LORA_MOSI, OUTPUT);
+
+        // CS LOW
+        digitalWrite(PIN_LORA_NSS, LOW);
+
+        // TX data and params
+        shiftOut(PIN_LORA_MOSI, PIN_LORA_SCK, MSBFIRST, 0x84);  // Command: Enter SLEEP mode
+        shiftOut(PIN_LORA_MOSI, PIN_LORA_SCK, MSBFIRST, 0x04);  // Parameter: maintain chip config while sleeping
+
+        // CS HIGH - all done
+        digitalWrite(PIN_LORA_NSS, HIGH);
+    }
+
+    // Board + Peripherie fuer den Deepsleep konfigurieren (Ziel ~18uA). 1:1 von der Wireless
+    // Paper portiert - alle verwendeten Pin-Makros sind im E213-Header definiert.
+    void prepareToSleep() {
+
+        // SX1262 -> SLEEP (Software-SPI)
+        loraToSleep();
+
+        // Display-/Peripherie-Versorgung (VEXT, active HIGH) abschalten
+        VExtOff();
+
+        // LoRa-Pins hochohmig
+        pinMode(PIN_LORA_NRST, ANALOG);
+        pinMode(PIN_LORA_BUSY, ANALOG);
+        pinMode(PIN_LORA_SCK, ANALOG);
+        pinMode(PIN_LORA_MISO, ANALOG);
+        pinMode(PIN_LORA_MOSI, ANALOG);
+
+        // LoRa CS (NSS) muss HIGH bleiben, auch waehrend des Deepsleep
+        pinMode(PIN_LORA_NSS, OUTPUT);
+        digitalWrite(PIN_LORA_NSS, HIGH);
+        gpio_hold_en((gpio_num_t) PIN_LORA_NSS);    // "stay where you're told"
+
+        #if !defined(ESP_ARDUINO_VERSION_MAJOR) || ESP_ARDUINO_VERSION_MAJOR < 3
+            esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_OFF);
+        #endif
     }
 
 }   // End of namespace

--- a/src/batt_functions.cpp
+++ b/src/batt_functions.cpp
@@ -1,12 +1,12 @@
 /**
  * @file batt_functions.cpp
  * @author W.Zelinka (OE3WAS, https://github.com/karamo)
- * @brief 
+ * @brief
  * @version 0.6
  * @date 2026-06-09
- * 
+ *
  * @copyright Copyright (c) 2026
- * 
+ *
  */
 #include "batt_functions.h"
 
@@ -26,6 +26,7 @@ unsigned long batt_show_timer = 0;
 int BATTshowtime;
 #define CDcount 6
 static int CountDown = CDcount;
+
 
 // wird hier nicht verwendet, aber definiert, aber nicht freigegeben
 float global_batt = 0;  // in mV
@@ -78,9 +79,9 @@ void ADC_BATT_ON(void)
 		pinMode(ADC_CTRL_PIN, OUTPUT);
 		//Heltec V3.1 --- hat keine eigene variants !?!?
 		#if defined(BOARD_HELTEC_V31) || defined(BOARD_WIRELESS_PAPER)
-			digitalWrite(ADC_CTRL_PIN,LOW);
+			digitalWrite(ADC_CTRL_PIN,LOW);   // active LOW: LOW = Teiler durchgeschaltet/messen
 		#else
-			digitalWrite(ADC_CTRL_PIN, HIGH);
+			digitalWrite(ADC_CTRL_PIN, HIGH);   // E213/E290: active HIGH (am Geraet verifiziert: LOW->0mV, HIGH->840mV)
 		#endif
 	#endif
 }
@@ -93,7 +94,7 @@ void ADC_BATT_OFF(void)
 		#if defined(BOARD_HELTEC_V31) || defined(BOARD_WIRELESS_PAPER)
 			digitalWrite(ADC_CTRL_PIN,HIGH);
 		#else
-			digitalWrite(ADC_CTRL_PIN, LOW);
+			digitalWrite(ADC_CTRL_PIN, LOW);   // E213/E290: active HIGH -> OFF = LOW
 		#endif
 	#endif
 }
@@ -155,6 +156,33 @@ void init_batt(void)
  *
  * @return float Battery level in milli volts 0 ... 4200
  */
+#if defined(BOARD_WIRELESS_PAPER)
+// ----- "AKKU LOW"-Beobachtung (WP) -----
+// Ringpuffer der letzten Spannungs-Rohwerte. read_batt() laeuft hier mit 2x/Sekunde -> 12 Werte = 6 s.
+// bWpAkkuLow wird vor dem Low-Voltage-Deepsleep gesetzt; das WP-Display zeigt dann statt blank
+// "AKKU LOW" + diese Werte (E-Ink haelt das Bild auch im Schlaf -> ablesbar). Die Hysterese
+// (erst nach mehreren Low-Messungen schlafen) macht 0.6 selbst via CountDown.
+// WP_VHIST_MAX ist zentral in batt_functions.h definiert (auch vom Anzeige-Aufrufer genutzt).
+static float wpVHist[WP_VHIST_MAX];
+static int   wpVHistCount = 0;
+static int   wpVHistHead  = 0;
+bool bWpAkkuLow = false;
+static void wpPushVolt(float v)
+{
+    wpVHist[wpVHistHead] = v;
+    wpVHistHead = (wpVHistHead + 1) % WP_VHIST_MAX;
+    if(wpVHistCount < WP_VHIST_MAX) wpVHistCount++;
+}
+// Kopiert die letzten Werte NEUESTE ZUERST nach out[], liefert die Anzahl.
+int wpBattHistory(float* out, int maxn)
+{
+    int n = (wpVHistCount < maxn) ? wpVHistCount : maxn;
+    for(int i = 0; i < n; i++)
+        out[i] = wpVHist[(wpVHistHead - 1 - i + 2 * WP_VHIST_MAX) % WP_VHIST_MAX];
+    return n;
+}
+#endif
+
 float read_batt(void)
 {
 	#ifdef USE_BATT
@@ -180,8 +208,15 @@ float read_batt(void)
 
 		// einfache Filterfunktion: exponentielle Glättung 1. Ordnung
 		rawVoltage = (float)analogReadMilliVolts(BAT_VOLT_PIN)*BAT_MULTIPLIER/1000.0 * fBattFaktor + BAT_VOLT_OFFSET;
-		if (firstReading) { filteredVoltage = BAT_MAX_VOLTAGE; firstReading = false; } // verhindert deepsleep nach REBOOT
+		if (firstReading) { filteredVoltage = fBattMax; } // verhindert deepsleep nach REBOOT
 		else { filteredVoltage = alpha * rawVoltage + (1.0f - alpha) * filteredVoltage; }
+
+
+		firstReading = false;
+
+		#if defined(BOARD_WIRELESS_PAPER)
+		wpPushVolt(rawVoltage);   // 2x/s -> letzte 10 Rohwerte fuer die "AKKU LOW"-Anzeige
+		#endif
 
 		if ((batt_show_timer + (1000 * std::max(1,BATTshowtime))) < millis())  // 1 .. 99s
 		{
@@ -191,7 +226,7 @@ float read_batt(void)
 			{
 				bDEBUGLNG = true; // für den nächsten printfdeb language en/de aktivieren
 				printfdeb("[BATT];%s;raw:;%.3f;V;max:;%.2f;V;fact:;%.4f;filt:;%.3f;V;%.0f;%%\n",
-				getTimeString().c_str(), rawVoltage, fBattMax, fBattFaktor, filteredVoltage, mv_to_percent(filteredVoltage*1000.0));
+					getTimeString().c_str(), rawVoltage, fBattMax, fBattFaktor, filteredVoltage, mv_to_percent(filteredVoltage*1000.0));
 			}
 		}
 
@@ -211,6 +246,11 @@ float read_batt(void)
 		// falls die Akku-Spannung BAT_MIN_VOLTAGE erreicht wird, soll ein --deepsleep erfolgen.
 		// Dieses erlaubt es, nach einem händischen RESET zum Aufwecken noch kurz nachzusehen,
 		// da sich der Akku auch etwas erholt.
+		// E213: Akku-Messung am Geraet verifiziert 2026-06-23 (Faktor 4.9245, ADC_CTRL active HIGH):
+		// Voll ~4.14 V, Leer-Cutoff ~3.26 V (unter Last; im Boot ~3.5 V = Last-Sag bei leerem LiPo).
+		// Low-voltage-Deepsleep wieder scharf wie bei allen anderen Boards. BAT_MIN_VOLTAGE = 3.3 V
+		// loest knapp vor dem 3.26-V-Cutoff aus; der firstReading-Seed (filteredVoltage = fBattMax)
+		// verhindert den Boot-Deepsleep beim Laden.
 		if ((BatVoltage <= (BAT_MIN_VOLTAGE)) && (BatVoltage > 1.0))  // 6.5V für T-Beam 1W, 3.3V für andere Boards
 		{
 			CountDown--;
@@ -232,7 +272,11 @@ float read_batt(void)
 					//boardPWROff();  // nrf52_functions
 				#else
 					ADC_BATT_OFF();
+					// Andere Boards / Original: Display regulaer ausschalten (persistiert node_sset).
 					commandAction((char*)"--display off", isPhoneReady, false);
+					#if defined(BOARD_WIRELESS_PAPER)
+					bWpAkkuLow = true;   // WP-Display zeigt "AKKU LOW" + letzte Werte statt blank
+					#endif
 					commandAction((char*)"--deepsleep", isPhoneReady, false);
 				#endif
 				// Node stopped
@@ -280,7 +324,7 @@ float read_batt(void)
 /**
  * @brief Set the Max Batt object
  * @todo genauso wie fBattFaktor behandeln und in main
- * 
+ *
  * @param u_max_batt [mV]
  */
 void setMaxBatt(float u_max_batt)
@@ -295,7 +339,7 @@ void setMaxBatt(float u_max_batt)
 /**
  * @brief Volt => Prozent Umrechnung über lineare Näherung
  * @note max_batt = Parameter aus Flash
- * 
+ *
  * @param mvolts [mV]
  * @return rproz
  */

--- a/src/batt_functions.h
+++ b/src/batt_functions.h
@@ -24,6 +24,12 @@ void VextOFF(void);  // Vext default OFF
 void ADC_BATT_ON(void);
 void ADC_BATT_OFF(void);
 
+#if defined(BOARD_WIRELESS_PAPER)
+#define WP_VHIST_MAX 12                     // Anzahl gepufferter Spannungs-Rohwerte (AKKU-LOW-Anzeige: 4 Zeilen x 3)
+extern bool bWpAkkuLow;                    // true vor Low-Voltage-Deepsleep -> Display "AKKU LOW"
+int wpBattHistory(float* out, int maxn);   // letzte Spannungs-Rohwerte, neueste zuerst, liefert Anzahl
+#endif
+
 #else
 
 #if defined(BOARD_HELTEC_T114) || defined(BOARD_T_ECHO) || defined(NRF52_SERIES)

--- a/src/command_functions.cpp
+++ b/src/command_functions.cpp
@@ -43,13 +43,20 @@
 //TEST #include "compress_functions.h"
 
 // For display contrast control
-#if !defined(BOARD_E290) && !defined(BOARD_WIRELESS_PAPER) && !defined(BOARD_T_DECK) && !defined(BOARD_T_DECK_PLUS) && !defined(BOARD_TRACKER) && !defined(BOARD_HELTEC_T114) && !defined(BOARD_T_ECHO) && !defined(BOARD_T5_EPAPER) && !defined(BOARD_T_DECK_PRO) && !defined(BOARD_T_CONNECT_PRO)
+#if !defined(BOARD_E290) && !defined(BOARD_WIRELESS_PAPER) && !defined(BOARD_E213) && !defined(BOARD_T_DECK) && !defined(BOARD_T_DECK_PLUS) && !defined(BOARD_TRACKER) && !defined(BOARD_HELTEC_T114) && !defined(BOARD_T_ECHO) && !defined(BOARD_T5_EPAPER) && !defined(BOARD_T_DECK_PRO) && !defined(BOARD_T_CONNECT_PRO)
     #include <U8g2lib.h>
     extern U8G2 *u8g2;
 #endif
 
 #if defined(ENABLE_BMX680)
 #include "bme680.h"
+#endif
+
+#if defined(BOARD_E213)
+// prepareToSleep()/loraToSleep() sind im E213-Platform-Layer (Namespace Platform) definiert
+// (VisionMasterE213/power_controls.cpp). Forward-Deklaration statt schwergewichtigem
+// Platform-Header-Include. prepareToSleep(): voller Deepsleep-Strom-Spar-Pfad (E213-Long-Press).
+namespace Platform { void prepareToSleep(); void loraToSleep(); }
 #endif
 
 unsigned long rebootAuto = 0;
@@ -801,6 +808,30 @@ void commandAction(char *umsg_text, bool ble)
                 bDEEP_SLEEP = true;
             }
         #else
+            #if defined(WP_DISP)
+            // E-Ink vor dem Schlafen sichtbar loeschen (sonst bleibt das letzte Bild stehen und
+            // der Deepsleep ist am bistabilen Panel nicht erkennbar). #992.
+            wpShowDeepSleep();
+            #if defined(BOARD_E213)
+            // PRG-Button (GPIO0, active LOW) als Aufweckquelle armieren. Ohne Wakeup-Quelle
+            // schlaeft der ESP32-S3 nach dem Deepsleep bis zum Power-Cycle/RESET - das bistabile
+            // E-Ink bliebe scheinbar fuer immer eingefroren. Mit ext1 weckt ein Tastendruck.
+            // Wakeup-Quelle(n): immer GPIO0 (PRG/BOOT) + der TATSAECHLICH konfigurierte
+            // Bedien-Button (iButtonPin; E213 = GPIO21 aus node_button_pin, WP = GPIO0). Beide
+            // active LOW. Ohne den Bedien-Button wuerde ein per Long-Press (USER-Taste) ausgeloester
+            // Deepsleep an genau dieser Taste NICHT mehr aufwecken. iButtonPin 0..21 = RTC-faehiger
+            // GPIO (ESP32-S3 ext1); 99 = kein Button -> nur GPIO0.
+            uint64_t wake_mask = (1ULL << 0);
+            if (iButtonPin < 22) wake_mask |= (1ULL << iButtonPin);
+            esp_sleep_enable_ext1_wakeup(wake_mask, ESP_EXT1_WAKEUP_ANY_LOW);
+            // Schlafstrom senken. Kurzes Settle, damit der E-Ink-Voll-Refresh aus wpShowDeepSleep()
+            // sicher fertig ist, dann prepareToSleep(): SX1262 -> SLEEP (sonst Dauer-RX ~5 mA),
+            // VEXT (Display-/LoRa-Versorgung) aus, LoRa-Pins hochohmig -> Ziel ~18 uA. Ohne das
+            // entlaedt der "Deepsleep" den Akku weiter. E213 nutzt dieselbe Sequenz (gleiche Pins).
+            delay(100);
+            Platform::prepareToSleep();
+            #endif
+            #endif
             #if not defined(BOARD_RAK4630)
             esp_deep_sleep_start();
             #endif
@@ -811,7 +842,7 @@ void commandAction(char *umsg_text, bool ble)
     else
     if(commandCheck(msg_text+2, (char*)"contrast ") == 0)
     {
-        #if !defined(BOARD_E290) && !defined(BOARD_WIRELESS_PAPER) && !defined(BOARD_T_DECK) && !defined(BOARD_T_DECK_PLUS) && !defined(BOARD_HELTEC_T114) && !defined(BOARD_T_ECHO) && !defined(BOARD_T5_EPAPER) && !defined(BOARD_T_DECK_PRO) && !defined(BOARD_T_CONNECT_PRO)
+        #if !defined(BOARD_E290) && !defined(BOARD_WIRELESS_PAPER) && !defined(BOARD_E213) && !defined(BOARD_T_DECK) && !defined(BOARD_T_DECK_PLUS) && !defined(BOARD_HELTEC_T114) && !defined(BOARD_T_ECHO) && !defined(BOARD_T5_EPAPER) && !defined(BOARD_T_DECK_PRO) && !defined(BOARD_T_CONNECT_PRO)
         int contrast_value = atoi(msg_text + 11);  // "--" + "contrast " = 2 + 9 = 11
         if(contrast_value <= 0) contrast_value = 1;
         if(contrast_value > 255) contrast_value = 255;
@@ -832,7 +863,7 @@ void commandAction(char *umsg_text, bool ble)
             addBLECommandBack(response);
         }
         
-        #elif !defined(BOARD_E290) && !defined(BOARD_WIRELESS_PAPER) && !defined(BOARD_T_DECK) && !defined(BOARD_T_DECK_PLUS) && !defined(BOARD_TRACKER) && !defined(BOARD_HELTEC_T114) && !defined(BOARD_T_ECHO) && !defined(BOARD_T5_EPAPER) && !defined(BOARD_T_DECK_PRO) && !defined(BOARD_T_CONNECT_PRO)
+        #elif !defined(BOARD_E290) && !defined(BOARD_WIRELESS_PAPER) && !defined(BOARD_E213) && !defined(BOARD_T_DECK) && !defined(BOARD_T_DECK_PLUS) && !defined(BOARD_TRACKER) && !defined(BOARD_HELTEC_T114) && !defined(BOARD_T_ECHO) && !defined(BOARD_T5_EPAPER) && !defined(BOARD_T_DECK_PRO) && !defined(BOARD_T_CONNECT_PRO)
         if(u8g2 != NULL)
         {
             u8g2->setContrast(contrast_value);

--- a/src/configuration_global.h
+++ b/src/configuration_global.h
@@ -36,6 +36,15 @@
 #define T3_S3_V13 55
 #define T_CONNECT_PRO 56
 #define HELTEC_WIRELESS_PAPER 57
+#define HELTEC_E213 58
+
+// Boards mit dem 2.13"-E-Ink-Panel (E0213A367/SSD1680) UND dem gemeinsamen WP-Display-Pfad:
+// Wireless Paper + Vision Master E213. Beide nutzen identisches Layout, fette 9pt-Schrift,
+// wpApplyLayout/wpRefreshClock, Browse usw. -> der Display-Code prueft WP_DISP statt nur
+// BOARD_WIRELESS_PAPER. (Battery/Pins/USB bleiben board-spezifisch ueber BOARD_E213/-config.)
+#if defined(BOARD_WIRELESS_PAPER) || defined(BOARD_E213)
+#define WP_DISP
+#endif
 
 #define DEFAULT_PREAMPLE_LENGTH 32
 

--- a/src/esp32/esp32_functions.cpp
+++ b/src/esp32/esp32_functions.cpp
@@ -23,12 +23,12 @@
 #elif defined(BOARD_T_DECK_PLUS)
 #elif defined(BOARD_T_DECK_PRO)
 #elif defined(BOARD_T_CONNECT_PRO)
-#elif (defined(BOARD_E290) || defined(BOARD_WIRELESS_PAPER))
+#elif (defined(BOARD_E290) || defined(BOARD_WIRELESS_PAPER) || defined(BOARD_E213))
 #include "heltec-eink-modules.h"
 
 #if defined(BOARD_E290)
 extern EInkDisplay_VisionMasterE290 epaper_display;
-#elif defined(BOARD_WIRELESS_PAPER)
+#elif (defined(BOARD_WIRELESS_PAPER) || defined(BOARD_E213))
 // Display-Treiber wird zur Laufzeit per Chip-ID gewaehlt -> Zeiger statt festem Objekt.
 extern BaseDisplay* g_epaper_display;
 extern const char*  g_wp_panel_name;
@@ -48,12 +48,14 @@ extern const char*  g_wp_panel_name;
     extern U8G2 u8g2_2;
 #endif   
 
-#if defined(BOARD_WIRELESS_PAPER)
+#if (defined(BOARD_WIRELESS_PAPER) || defined(BOARD_E213))
 // Liest die Controller-Chip-ID des E-Ink-Panels per Software-SPI (Bit-Bang) aus.
 // Methode wie im Heltec-Factory-Test (Wireless_Paper_E0213A367_FactoryTest):
 // Reset -> Befehl 0x2F -> Datenleitung (SDI/MOSI) auf Eingang -> 8 Bit zuruecklesen.
-// Unterscheidet E0213A367 (V1.1.1/V1.2) von LCMEN2R13EFC1 (V1.1). Pins = WirelessPaper-Plattform.
-static uint8_t detectEinkChipId()
+// Unterscheidet E0213A367 (V1.1.1/V1.2) von LCMEN2R13EFC1 (V1.1). Pins = aktive Plattform.
+// Alte Chip-ID-Probe (Heltec-Factory-Test, Befehl 0x2F). Durch detectEinkPanelIsE0213()
+// (BUSY-Polaritaet, nicht-invasiv) abgeloest, aber als Referenz/Fallback behalten.
+static uint8_t __attribute__((unused)) detectEinkChipId()
 {
     // E-Ink mit Strom versorgen (VEXT = GPIO45, active LOW)
     pinMode(PIN_PCB_VEXT, OUTPUT);
@@ -99,27 +101,62 @@ static uint8_t detectEinkChipId()
 
     return chipId;
 }
+
+// Panel-Auto-Erkennung ueber die (invertierte) BUSY-Polaritaet der beiden 2.13"-Controller.
+// NICHT-INVASIV: kein SPI-Befehl (anders als detectEinkChipId()/0x2F, der den SSD1680 in einen
+// Dauer-BUSY-Zustand bringt -> wait()-Timeout -> Hang). Nach einem reinen Hardware-Reset-PULS und
+// kurzer Recovery treibt der Controller den BUSY-Pin auf seinen statischen IDLE-Pegel; dieser ist
+// zwischen den Controllern invertiert - bewiesen durch die wait()-Logik der Treiber:
+//   - LCMEN2R13EFC1:                wait() == "while(BUSY==LOW)"  -> IDLE = BUSY HIGH
+//   - E0213A367 (SSD1680, Base):    wait() == "while(BUSY==HIGH)" -> IDLE = BUSY LOW
+// WICHTIG: das gilt fuer den IDLE-Pegel NACH der Recovery. Das fluechtige Busy-Fenster direkt
+// nach dem Reset ist genau umgekehrt und timing-kritisch -> bewusst NICHT verwendet. Ebenso wird
+// RST nur GEPULST (nicht gehalten): im gehaltenen Reset ist der BUSY-Ausgang undefiniert.
+// Rueckgabe: true = E0213A367 (SSD1680), false = LCMEN2R13EFC1.
+static bool detectEinkPanelIsE0213()
+{
+    // E-Ink mit Strom versorgen (VEXT board-spezifisch: WP GPIO45/LOW, E213 GPIO18/HIGH)
+    pinMode(PIN_PCB_VEXT, OUTPUT);
+    digitalWrite(PIN_PCB_VEXT, VEXT_ACTIVE);
+    delay(100);
+
+    pinMode(PIN_DISPLAY_RST, OUTPUT);
+    pinMode(PIN_DISPLAY_BUSY, INPUT);
+
+    // Hardware-Reset-PULS (LOW -> HIGH), danach Recovery abwarten
+    digitalWrite(PIN_DISPLAY_RST, LOW);  delay(10);
+    digitalWrite(PIN_DISPLAY_RST, HIGH);
+    delay(100);
+
+    int busy = digitalRead(PIN_DISPLAY_BUSY);
+    printfdeb("[INIT]...2.13\" E-Ink BUSY-Probe: idle-Pegel=%s -> %s\n",
+              busy == HIGH ? "HIGH" : "LOW",
+              busy == LOW  ? "E0213A367" : "LCMEN2R13EFC1");
+    return (busy == LOW);   // IDLE LOW = SSD1680/E0213A367 ; IDLE HIGH = LCMEN2R13EFC1
+}
 #endif
 
 void initDisplay()
 {
-#if defined(BOARD_WIRELESS_PAPER)
-    // HW-Version anhand der Panel-Chip-ID bestimmen und passenden Treiber instanziieren.
-    uint8_t chipId = detectEinkChipId();
-    if ((chipId & 0x03) != 0x01)
+#if defined(WP_DISP)
+    // Gemeinsame Panel-Auto-Erkennung fuer Wireless Paper (V1.1 LCMEN / V1.1.1+V1.2 E0213) UND
+    // Vision Master E213. Nicht-invasiv ueber die invertierte BUSY-Polaritaet (siehe
+    // detectEinkPanelIsE0213()). Loest die alte 0x2F-Chip-ID-Probe ab: die war auf dem E213
+    // unzuverlaessig (waehlte faelschlich LCMEN -> Schlieren) und konnte den SSD1680 aufhaengen.
+    if (detectEinkPanelIsE0213())
+    {
+        g_epaper_display = new EInkDisplay_WirelessPaperV1_2();   // E0213A367-BW (SSD1680)
+        g_wp_panel_name  = "E0213A367";
+    }
+    else
     {
         g_epaper_display = new EInkDisplay_WirelessPaperV1_1();   // LCMEN2R13EFC1 (V1.1)
         g_wp_panel_name  = "LCMEN2R13EFC1";
     }
-    else
-    {
-        g_epaper_display = new EInkDisplay_WirelessPaperV1_2();   // E0213A367 (V1.0 / V1.1.1 / V1.2)
-        g_wp_panel_name  = "E0213A367";
-    }
-    printfdeb("[INIT]...Wireless Paper E-Ink chipId=0x%02X -> %s\n", chipId, g_wp_panel_name);
+    printfdeb("[INIT]...2.13\" E-Ink Panel -> %s\n", g_wp_panel_name);
 #endif
 
-#if ! (defined(BOARD_E290) || defined(BOARD_WIRELESS_PAPER)) && !defined(BOARD_T_DECK) && !defined(BOARD_T_DECK_PLUS) && !defined(BOARD_TRACKER) && !defined(BOARD_T5_EPAPER) && !defined(BOARD_T_DECK_PRO) && !defined(BOARD_T_CONNECT_PRO)
+#if ! (defined(BOARD_E290) || defined(BOARD_WIRELESS_PAPER) || defined(BOARD_E213)) && !defined(BOARD_T_DECK) && !defined(BOARD_T_DECK_PLUS) && !defined(BOARD_TRACKER) && !defined(BOARD_T5_EPAPER) && !defined(BOARD_T_DECK_PRO) && !defined(BOARD_T_CONNECT_PRO)
 
     printlndeb("[INIT]...Auto detecting display:");
         
@@ -155,7 +192,7 @@ void initDisplay()
 
 void startDisplay(char line1[20], char line2[20], char line3[20])
 {
-    #if (defined(BOARD_E290) || defined(BOARD_WIRELESS_PAPER))
+    #if (defined(BOARD_E290) || defined(BOARD_WIRELESS_PAPER) || defined(BOARD_E213))
 
     char cvers[20];
 
@@ -172,8 +209,8 @@ void startDisplay(char line1[20], char line2[20], char line3[20])
     // Der erkannte Panel-Controller wird zusaetzlich als DEBUG-Zeile am Terminal
     // ausgegeben (siehe initDisplay()).
     epaper_display.fillCircle(10, 10, 10, BLACK);
-    #if defined(BOARD_WIRELESS_PAPER)
-    // WP (250px schmal): 10pt-Fettschrift. Titel "MeshCom <version> <land>" so weit nach RECHTS
+    #if (defined(BOARD_WIRELESS_PAPER) || defined(BOARD_E213))
+    // WP / E213 (250px schmal): 10pt-Fettschrift. Titel "MeshCom <version> <land>" so weit nach RECHTS
     // (Richtung Original-Position x=20) setzen, wie er GARANTIERT in eine Zeile passt: Breite
     // messen, x = min(20, 250 - Breite - 4). So nie Umbruch, aber maximal rechts. E290: 12pt @ x20.
     {
@@ -193,15 +230,21 @@ void startDisplay(char line1[20], char line2[20], char line3[20])
     epaper_display.setCursor(20, 50);
     epaper_display.printf("MeshCom %s\n", cvers);
     #endif
-    #if defined(BOARD_WIRELESS_PAPER)
-    // WP: die unteren 3 Zeilen (Board-Name, @BY-Zeile, Rufzeichen) horizontal ZENTRIEREN.
-    // Textbreite per getTextBounds messen, x = (Panelbreite 250 - Breite) / 2.
+    #if (defined(BOARD_WIRELESS_PAPER) || defined(BOARD_E213))
+    // WP / E213 (beide 2.13", 250px): die unteren 3 Zeilen (Board-Name, @BY-Zeile, Rufzeichen)
+    // horizontal ZENTRIEREN. Textbreite per getTextBounds messen, x = (Panelbreite 250 - Breite) / 2.
     {
       const int WPW = 250;
       int16_t bx, by; uint16_t bw, bh;
+      #if defined(BOARD_E213)
+      const char *boardName = "Heltec Vision Master E213";
+      // laenger als "Heltec PaperW" -> kleinere 9pt-Schrift, sonst passt es nicht auf 250px
+      epaper_display.setFont( &FreeSans9pt7b );
+      #else
       const char *boardName = "Heltec PaperW";
-
       epaper_display.setFont( &FreeSans12pt7b );
+      #endif
+
       epaper_display.getTextBounds(boardName, 0, 80, &bx, &by, &bw, &bh);
       epaper_display.setCursor((WPW - (int)bw) / 2, 80);
       epaper_display.println(boardName);

--- a/src/esp32/esp32_main.cpp
+++ b/src/esp32/esp32_main.cpp
@@ -263,6 +263,7 @@ extern uint8_t txt_msg_len_phone;
 extern unsigned long last_upd_timer;
 extern bool hb_warn_logged;
 
+
 // FreeRTOS Queue for BLE data from NimBLE task to Main Loop
 #include "freertos/queue.h"
 
@@ -742,6 +743,14 @@ void esp32setup()
 
     bDisplayVolt = meshcom_settings.node_sset & 0x0001;
     bDisplayOff = meshcom_settings.node_sset & 0x0002;
+    #if defined(BOARD_WIRELESS_PAPER) || defined(BOARD_E213)
+    // WP / E213: Display-Aus-Zustand NICHT ueber Reboots persistieren. Der User-Button-Long-Press
+    // ("--display off") wuerde das Panel sonst dauerhaft aus lassen - und weil E-Ink sein
+    // Bild behaelt, sieht das aus wie "Display haengt am Startschirm" (kein Crash, nur nicht
+    // aktualisiert). Daher beim Boot immer mit Display AN starten: ein Reboot holt die Anzeige
+    // garantiert zurueck. Long-Press schaltet weiterhin zur Laufzeit aus/ein.
+    bDisplayOff = false;
+    #endif
     bPosDisplay = meshcom_settings.node_sset & 0x0004;
     bDEBUG = meshcom_settings.node_sset & 0x0008;
     bButtonCheck = meshcom_settings.node_sset & 0x0010;
@@ -1290,11 +1299,11 @@ void esp32setup()
     #else
     if(bRadio)
     {
-        #if defined(BOARD_WIRELESS_PAPER) || defined(BOARD_E290)
+        #if defined(BOARD_WIRELESS_PAPER) || defined(BOARD_E290) || defined(BOARD_E213)
         if(radio.setTCXO(1.8) != RADIOLIB_ERR_NONE)
             printlndeb(F("[LoRa]...TCXO 1.8V konnte nicht gesetzt werden"));
         else
-            printlndeb(F("[LoRa]...TCXO DIO3 = 1.8V (Wireless Paper)"));
+            printlndeb(F("[LoRa]...TCXO DIO3 = 1.8V (Wireless Paper / E213)"));
         #endif
 
         // set boosted gain
@@ -2486,6 +2495,7 @@ void esp32loop()
             strTime = udpUpdateTimeClient();
 
             updateTimeClient = millis();
+
         }
         else
         {
@@ -3484,6 +3494,7 @@ void esp32loop()
             {
                 unsigned long hb_age = millis() - last_upd_timer;
 
+
                 // Stage 1: diagnostic warning at 35s
                 if (hb_age > (HB_WARN_TIME * 1000) && !hb_warn_logged)
                 {
@@ -3831,6 +3842,7 @@ int checkRX(bool bRadio)
 
     return state;
 }
+
 
 void checkSerialCommand(void)
 {

--- a/src/heltec-eink-modules.h
+++ b/src/heltec-eink-modules.h
@@ -18,11 +18,11 @@
 #include "Displays/DEPG0290BNS800/DEPG0290BNS800.h"       // Heltec 2.9" BW V2    - Red Tab
 //#include "Displays/GDE029A1/GDE029A1.h"                 // Heltec 2.9" BW V2    - Blue tab
 
-// All-in-one "Wireless Paper" boards
-#ifdef WIRELESS_PAPER
+// All-in-one "Wireless Paper" boards / Vision Master E213 (gleiche 2.13"-Panel-Familie)
+#if defined(WIRELESS_PAPER) || defined(VISION_MASTER_E213)
 //#include "Displays/DEPG0213BNS800/DEPG0213BNS800.h"     // Wireless Paper V1.0 (SSD1680, vom E0213A367-Treiber mit abgedeckt)
 #include "Displays/LCMEN2R13EFC1/LCMEN2R13EFC1.h"         // Wireless Paper V1.1 / Vision Master E213
-#include "Displays/E0213A367/E0213A367.h"                 // Wireless Paper V1.1.1 / V1.2
+#include "Displays/E0213A367/E0213A367.h"                 // Wireless Paper V1.1.1 / V1.2 / Vision Master E213 V1.1.1
 #endif
 
 #endif

--- a/src/loop_functions.cpp
+++ b/src/loop_functions.cpp
@@ -55,7 +55,7 @@ bool gpsInitDone = false;
 // gps (TinyGPSPlus) wird in gps_functions.cpp unbedingt instanziiert und hier nur fuer
 // reine Distanz-/Kursberechnungen (distanceBetween/courseTo) genutzt - kein GPS-Modul noetig.
 // Daher auch fuer Wireless Paper (ohne ENABLE_GPS) sichtbar machen.
-#if defined(ENABLE_GPS) || defined(ENABLE_RAK_GPS) || defined(BOARD_WIRELESS_PAPER)
+#if defined(ENABLE_GPS) || defined(ENABLE_RAK_GPS) || defined(WP_DISP)
 extern TinyGPSPlus gps;
 #endif
 
@@ -221,12 +221,12 @@ char msg_text[MAX_MSG_LEN_PHONE * 2] = {0};
 
 unsigned int _GW_ID = 0x12345678; // ID of our Node
 
-#if (defined(BOARD_E290) || defined(BOARD_WIRELESS_PAPER))
+#if (defined(BOARD_E290) || defined(WP_DISP) || defined(BOARD_E213))
 #include "heltec-eink-modules.h"
 
 #if defined(BOARD_E290)
 EInkDisplay_VisionMasterE290 epaper_display;
-#elif defined(BOARD_WIRELESS_PAPER)
+#elif (defined(WP_DISP) || defined(BOARD_E213))
 // Wireless Paper: Panel-Controller variiert je HW-Version (E0213A367 ab V1.1.1,
 // LCMEN2R13EFC1 bei V1.1). Welcher verbaut ist, wird zur Laufzeit per Chip-ID erkannt
 // (detectEinkChipId() in esp32_functions.cpp) und der passende Treiber dynamisch
@@ -256,13 +256,13 @@ const char*  g_wp_panel_name  = "?";
 // Strich satt schwarz erscheint, muss er aus MEHREREN Pixeln bestehen - genau das liefert die
 // fette FreeSansBold9pt (Striche ~2 Pixel breit). Gleiche Schriftgroesse (9pt), nur kraeftiger
 // -> auf E-Ink klar lesbar und richtig schwarz statt grau.
-#if defined(BOARD_WIRELESS_PAPER)
+#if defined(WP_DISP)
 #define WP_FONT9 (&FreeSansBold9pt7b)
 #else
 #define WP_FONT9 (&FreeSans9pt7b)
 #endif
 
-#if defined(BOARD_WIRELESS_PAPER)
+#if defined(WP_DISP)
 // Standard-Layout (Statusseiten wie Info/Position/Track: gross, ueber das ganze
 // Panel verteilt). Nur die Nachrichtenseite (iDisplayType 0) schaltet via
 // wpApplyLayout() auf ein kompaktes Layout (kleine Statuszeile, enge Zeilen) um,
@@ -274,11 +274,21 @@ bool bWpCompactLayout = false;
 // der 10-s-Statuszeilen-Refresh die Ziffer nicht wegloescht.
 int wpMsgIdx = 0;
 
-#if defined(BOARD_WIRELESS_PAPER)
+
+void wpApplyLayout(bool compact)
+{
+    bWpCompactLayout = compact;
+    // dzeile[0] = Statuszeilen-Baseline. Bewusst in BEIDEN Layouts 12, damit die 9pt-Schrift
+    // vollstaendig in das 16px-Refresh-Fenster passt (bei 16 wurde die unterste Pixelreihe der
+    // Statuszeile auf den Info-/Track-Seiten abgeschnitten). Body-Zeilen bleiben layout-abhaengig.
+    if(compact) { dzeile[0]=12; dzeile[1]=32; dzeile[2]=47; dzeile[3]=62; dzeile[4]=77; dzeile[5]=92; }
+    else        { dzeile[0]=12; dzeile[1]=41; dzeile[2]=61; dzeile[3]=81; dzeile[4]=101; dzeile[5]=121; }
+}
+
 // Nachrichtentext-Font: gleiche 9pt-fett-Glyphen wie WP_FONT9, aber enger Zeilenabstand
 // (yAdvance=15 statt ~22), damit eine volle Nachricht (bis ~160 Zeichen) auf das Panel passt.
 // Wird SOWOHL beim Live-Empfang (sendDisplayText) ALS AUCH beim Durchblaettern ("#N") genutzt
-// -> identischer Zeilenabstand in beiden Faellen (Browse == Live). Lazy-Init beim ersten Aufruf.
+// -> identischer Zeilenabstand in beiden Faellen. Lazy-Init beim ersten Aufruf.
 const GFXfont* wpMsgFont()
 {
     static GFXfont f;
@@ -290,17 +300,6 @@ const GFXfont* wpMsgFont()
         ready = true;
     }
     return &f;
-}
-#endif
-
-void wpApplyLayout(bool compact)
-{
-    bWpCompactLayout = compact;
-    // dzeile[0] = Statuszeilen-Baseline. Bewusst in BEIDEN Layouts 12, damit die 9pt-Schrift
-    // vollstaendig in das 16px-Refresh-Fenster passt (bei 16 wurde die unterste Pixelreihe der
-    // Statuszeile auf den Info-/Track-Seiten abgeschnitten). Body-Zeilen bleiben layout-abhaengig.
-    if(compact) { dzeile[0]=12; dzeile[1]=32; dzeile[2]=47; dzeile[3]=62; dzeile[4]=77; dzeile[5]=92; }
-    else        { dzeile[0]=12; dzeile[1]=41; dzeile[2]=61; dzeile[3]=81; dzeile[4]=101; dzeile[5]=121; }
 }
 #else
 int dzeile[maxdisplines] = {16, 41, 61, 81, 101, 121, 0};
@@ -341,7 +340,7 @@ int dzeile[maxdisplines] = {42, 52, 62, 0, 0, 0, 0};
 int dzeile[maxdisplines] = {8, 21, 31, 41, 51, 61, 0};
 #endif
 
-#if !defined(BOARD_E290) && !defined(BOARD_WIRELESS_PAPER) && !defined(BOARD_TRACKER) && !defined(BOARD_HELTEC_T114) && !defined(BOARD_T_ECHO) && !defined(BOARD_T_DECK) && !defined(BOARD_T_DECK_PLUS) && !defined(BOARD_T5_EPAPER) && !defined(BOARD_T_DECK_PRO) && !defined(BOARD_T_CONNECT_PRO)
+#if !defined(BOARD_E290) && !defined(WP_DISP) && !defined(BOARD_E213) && !defined(BOARD_TRACKER) && !defined(BOARD_HELTEC_T114) && !defined(BOARD_T_ECHO) && !defined(BOARD_T_DECK) && !defined(BOARD_T_DECK_PLUS) && !defined(BOARD_T5_EPAPER) && !defined(BOARD_T_DECK_PRO) && !defined(BOARD_T_CONNECT_PRO)
 
 #include <U8g2lib.h>
 
@@ -732,7 +731,7 @@ void insertOwnTx(unsigned int msg_id)
 #if defined(BOARD_T_ECHO)
 #define maxdisplines 11
 #define PAGE_MAX 6
-#elif defined(BOARD_WIRELESS_PAPER)
+#elif defined(WP_DISP)
 #define maxdisplines 7
 #define PAGE_MAX 10   // Wireless Paper: bis zu 9 gespeicherte Nachrichten in einer Loop durchblaettern
 #else
@@ -871,7 +870,7 @@ void sendDisplay1306(bool bClear, bool bTransfer, int x, int y, char *text)
 {
     #if !defined (BOARD_T_DECK)  && !defined (BOARD_T_DECK_PLUS)
 
-    #if !defined (BOARD_E290) && !defined(BOARD_WIRELESS_PAPER) && !defined (BOARD_TRACKER) && !defined(BOARD_HELTEC_T114) && !defined(BOARD_T_ECHO) && !defined(BOARD_T5_EPAPER) && !defined(BOARD_T_DECK_PRO) && !defined(BOARD_T_CONNECT_PRO)
+    #if !defined (BOARD_E290) && !defined(WP_DISP) && !defined(BOARD_E213) && !defined (BOARD_TRACKER) && !defined(BOARD_HELTEC_T114) && !defined(BOARD_T_ECHO) && !defined(BOARD_T5_EPAPER) && !defined(BOARD_T_DECK_PRO) && !defined(BOARD_T_CONNECT_PRO)
         if(u8g2 == NULL)
             return;
     #endif
@@ -893,7 +892,7 @@ void sendDisplay1306(bool bClear, bool bTransfer, int x, int y, char *text)
 
             epaper_display.fastmodeOn();
 
-            #if defined(BOARD_WIRELESS_PAPER)
+            #if defined(WP_DISP)
             // Nachrichtenseite: kleine Statuszeile (9pt) -> Platz fuer 160 Zeichen.
             // Statusseiten: gewohnte groessere Schrift (12pt).
             epaper_display.setFont(bWpCompactLayout ? WP_FONT9 : &FreeSans12pt7b);
@@ -970,7 +969,7 @@ void sendDisplay1306(bool bClear, bool bTransfer, int x, int y, char *text)
                             epaper_display.println(pageTextLong1);
 
                             epaper_display.setCursor(0, dzeile[2]);
-                            #if defined(BOARD_WIRELESS_PAPER)
+                            #if defined(WP_DISP)
                             epaper_display.setFont(wpMsgFont());   // enger Zeilenabstand (15) wie Live-Empfang -> Browse == Live
                             #endif
                             epaper_display.println(pageTextLong2);
@@ -979,8 +978,9 @@ void sendDisplay1306(bool bClear, bool bTransfer, int x, int y, char *text)
                     else
                     if(memcmp(pageText[its], "#L", 2) == 0)
                     {
-                        #if defined(BOARD_WIRELESS_PAPER)
-                        // Nachrichtenseite: Linie hoeher (kleine Statuszeile); Statusseiten: wie gewohnt bei 22
+                        #if defined(WP_DISP)
+                        // Nachrichtenseite (kompakt): Linie hoeher bei y=17; Statusseiten bei y=22.
+                        // Die Statusseite darf bewusst anders sein als die Nachrichten-/Blaetter-Ansicht.
                         epaper_display.drawLine(0, bWpCompactLayout ? 17 : 22, 250, bWpCompactLayout ? 17 : 22, GxEPD_BLACK);
                         #else
                         epaper_display.drawLine(0, 22, 320, 22, GxEPD_BLACK);
@@ -1002,7 +1002,18 @@ void sendDisplay1306(bool bClear, bool bTransfer, int x, int y, char *text)
                 }
 
             	if(memcmp(text, "#S", 2) != 0 && memcmp(text, "#F", 2) != 0)
+                {
+                    #if defined(WP_DISP)
+                    // Der "#N"-Render kommt AUSSCHLIESSLICH von wpShowStoredMessage (Nachrichten-
+                    // Blaettern) und schiebt UNMITTELBAR danach selbst einen fastmodeOff()+update()
+                    // = Voll-Refresh nach (zeigt denselben Framebuffer inkl. Browse-Ziffer). Dieses
+                    // erste "#N"-update() ist daher auf BEIDEN Panels redundant und erzeugt nur einen
+                    // zusaetzlichen Refresh/Blitzer pro Klick. Auf der ganzen Wireless Paper (V1.1 UND
+                    // V1.2) ueberspringen -> je Blaetter-Schritt nur EIN Voll-Refresh.
+                    if(memcmp(text, "#N", 2) != 0)
+                    #endif
                     epaper_display.update();
+                }
             }
             
         #elif defined(BOARD_TRACKER) || defined(BOARD_HELTEC_T114) || defined(BOARD_T_CONNECT_PRO)
@@ -1184,8 +1195,8 @@ void sendDisplayHead(bool bInit)
 
     bSetDisplay=true;
 
-    #if defined(BOARD_WIRELESS_PAPER)
-    wpMsgIdx = 0;   // Home/Info-Seite -> keine Nachrichten-Ziffer oben rechts
+    #if defined(WP_DISP)
+    wpMsgIdx = 0;       // Home/Info-Seite -> keine Nachrichten-Ziffer oben rechts
     #endif
 
     #ifdef BOARD_T5_EPAPER
@@ -1230,7 +1241,7 @@ void sendDisplayHead(bool bInit)
 
     sendDisplayMainline();
 
-    #if defined(BOARD_WIRELESS_PAPER)
+    #if defined(WP_DISP)
     // Info-Seite in EINEM Voll-Refresh aufbauen (fastmodeOff vor dem Zeichnen). Sonst
     // wuerde ein Fastmode-Partial-Update ueber ein zuvor gecleartes (weisses) Panel nichts
     // anzeigen -> die Seite bliebe leer (z.B. beim Zurueckschalten aus dem Track-Modus).
@@ -1320,7 +1331,7 @@ void sendDisplayTrack()
 
         sendDisplayMainline();
 
-        #if defined(BOARD_WIRELESS_PAPER)
+        #if defined(WP_DISP)
         // Direkt im Voll-Refresh aufbauen (fastmodeOff vor dem Zeichnen) - kein Fastmode-
         // Partial-Zwischenframe. Zusaetzlich die Track-Seite kleiner setzen (FreeSans 9pt
         // statt 12pt): die RATE-Zeile ("RATE: 1800 NEXT 1778") ist bei 12pt so breit, dass
@@ -1344,7 +1355,7 @@ void sendDisplayTrack()
         snprintf(msg_text, sizeof(msg_text), "NEXT:%5i", pos_seconds);
         sendDisplay1306(false, false, 3, dzeile[4], msg_text);
         #else
-        #if defined(BOARD_WIRELESS_PAPER)
+        #if defined(WP_DISP)
         // Kompaktere Beschriftung fuer die fette WP-Schrift (FreeSansBold ist breiter), damit die
         // Zeile nicht umbricht. E290 behaelt die ausfuehrliche Beschriftung.
         snprintf(msg_text, sizeof(msg_text), "RATE:%4i N:%4i", (int)posinfo_interval, pos_seconds);
@@ -1455,7 +1466,7 @@ void sendDisplayTime()
             pagePointer=PAGE_MAX-1;
     }
 
-    #if !defined (BOARD_E290) && !defined(BOARD_WIRELESS_PAPER) && !defined (BOARD_TRACKER) && !defined(BOARD_HELTEC_T114) && !defined(BOARD_T_ECHO) && !defined(BOARD_T_DECK)  && !defined(BOARD_T_DECK_PLUS) && !defined(BOARD_T5_EPAPER) && !defined(BOARD_T_DECK_PRO) && !defined(BOARD_T_CONNECT_PRO)
+    #if !defined (BOARD_E290) && !defined(WP_DISP) && !defined(BOARD_E213) && !defined (BOARD_TRACKER) && !defined(BOARD_HELTEC_T114) && !defined(BOARD_T_ECHO) && !defined(BOARD_T_DECK)  && !defined(BOARD_T_DECK_PLUS) && !defined(BOARD_T5_EPAPER) && !defined(BOARD_T_DECK_PRO) && !defined(BOARD_T_CONNECT_PRO)
         if(u8g2 == NULL)
             return;
     #endif
@@ -1537,7 +1548,7 @@ void sendDisplayTime()
 
 void sendDisplayMainline()
 {
-    #if defined(BOARD_WIRELESS_PAPER)
+    #if defined(WP_DISP)
     // Nachrichtenseite (0) und die zeilenreiche Positions-Anzeige (1) kompakt
     // darstellen; die Info-/Track-Seiten (9) im grossen Standardlayout. Wird hier
     // zentral umgeschaltet, da jede Seite sendDisplayMainline() nach dem Setzen
@@ -1593,7 +1604,7 @@ void sendDisplayMainline()
     sendDisplay1306(false, false, 3, dzeile[0]+3, (char*)"#L");
 }
 
-#if defined(BOARD_WIRELESS_PAPER)
+#if defined(WP_DISP)
 // Zeichnet die Nachrichten-Ziffer oben rechts (neueste=N..aelteste=1) in den Framebuffer.
 // Muss VOR jedem update() der obersten Zeile aufgerufen werden (wpShowStoredMessage UND
 // wpRefreshClock), sonst loescht der 10-s-Statuszeilen-Refresh die Ziffer weg.
@@ -1624,6 +1635,9 @@ void wpRefreshClock()
     // NUR alle 60 s (1x pro Minute) per Voll-Refresh aktualisiert - haeufigere Voll-Refreshes
     // wuerden die Display-Lebensdauer spuerbar verkuerzen. Auf V1.2 bleibt es beim schonenden
     // 10-s-Teil-Refresh.
+    // E213 hat das E0213A367 (= WP V1.2) -> partial-window/Teilrefresh moeglich (Uhr alle 10 s ohne
+    // Blitzen). bV11 nur fuer das LCMEN2R13EFC1-Panel (WP V1.1, kein partielles Fenster). Der
+    // wait()-Timeout in BaseDisplay sichert gegen ein etwaiges Haengen ab.
     const bool bV11 = (memcmp(g_wp_panel_name, "LCMEN", 5) == 0);
 
     // Wechsel der Batterieanzeige VOLT<->PROZ (bDisplayVolt, via --volt/--proz oder Web-Client)
@@ -1709,8 +1723,13 @@ void wpShowStoredMessage(int slot, int idx)
         pageLine[its][2] = pageLastLine[slot][its][2];
         memcpy(pageText[its], pageLastText[slot][its], 25);
     }
-    strncpy(pageTextLong1, pageLastTextLong1[slot], sizeof(pageTextLong1));
-    strncpy(pageTextLong2, pageLastTextLong2[slot], sizeof(pageTextLong2));
+    // Defensiv (analog sendDisplayText weiter unten): strncpy garantiert KEINE Terminierung,
+    // wenn die Quelle die volle Puffergroesse fuellt -> mit sizeof()-1 kopieren und das letzte
+    // Byte explizit auf '\0' setzen.
+    strncpy(pageTextLong1, pageLastTextLong1[slot], sizeof(pageTextLong1) - 1);
+    pageTextLong1[sizeof(pageTextLong1) - 1] = '\0';
+    strncpy(pageTextLong2, pageLastTextLong2[slot], sizeof(pageTextLong2) - 1);
+    pageTextLong2[sizeof(pageTextLong2) - 1] = '\0';
 
     sendDisplay1306(false, true, 0, 0, (char*)"#N");
 
@@ -1722,6 +1741,55 @@ void wpShowStoredMessage(int slot, int idx)
 
     epaper_display.fastmodeOff();   // Voll-Refresh nachschieben -> Status-Screen physisch weg
     epaper_display.update();
+}
+
+
+// E-Ink beim Deepsleep loeschen (Voll-Clear). Zwei Faelle:
+//  - LOW-VOLTAGE-Deepsleep (bWpAkkuLow): "AKKU LOW" + die letzten Spannungs-Rohwerte anzeigen
+//    (zur Beobachtung; E-Ink haelt das Bild auch im Schlaf -> bleibt ablesbar).
+//  - MANUELLER Button-Deepsleep: nur loeschen (kein Text - das Original kennt keinen).
+// Hintergrund: "Display off" ergibt auf E-Ink keinen Sinn (bistabil, zieht statisch keinen Strom);
+// ohne Clear bliebe das letzte Bild stehen und der Sleep waere nicht erkennbar. Aufwecken per RESET.
+void wpShowDeepSleep()
+{
+    iDisplayType = 0;
+    wpApplyLayout(true);
+    epaper_display.fastmodeOff();
+    // Nur den Framebuffer leeren (KEIN eigener Panel-Refresh). clear() wuerde intern activate()
+    // ausfuehren -> zusammen mit dem update() unten waeren das ZWEI Voll-Refreshes direkt
+    // hintereinander. Bei fast leerem Akku reicht die Boost-Spannung dann nicht fuer beide ->
+    // das zweite (mit "AKKU LOW" + Werten) wird grau/unvollstaendig. clearMemory() + EIN update()
+    // = nur ein Refresh -> halber Stromhunger, Werte bleiben sichtbar.
+    epaper_display.clearMemory();
+    #if defined(BOARD_WIRELESS_PAPER)
+    // WP-spezifische AKKU-LOW-Anzeige (Spannungs-History aus batt_functions). Der E213 nutzt den
+    // gemeinsamen Display-Pfad (WP_DISP) mit, hat aber eine andere Akku-Mess-Logik (ADC_CTRL=46) -
+    // daher hier kein bWpAkkuLow/wpBattHistory fuer E213.
+    if(bWpAkkuLow)
+    {
+        epaper_display.setFont(WP_FONT9);
+        epaper_display.setCursor(3, dzeile[0]);
+        epaper_display.print("AKKU LOW");
+        float h[WP_VHIST_MAX];
+        int n = wpBattHistory(h, WP_VHIST_MAX);   // letzte Werte, neueste zuerst
+        char ln[48];
+        int row = 1;
+        for(int i = 0; i < n && row <= 5; row++)
+        {
+            ln[0] = '\0';
+            for(int k = 0; k < 3 && i < n; k++, i++)
+            {
+                char one[14];
+                snprintf(one, sizeof(one), "%s%.2fV", (k ? "  " : ""), h[i]);
+                strncat(ln, one, sizeof(ln) - strlen(ln) - 1);
+            }
+            epaper_display.setCursor(3, dzeile[row]);
+            epaper_display.print(ln);
+        }
+        bWpAkkuLow = false;
+    }
+    #endif
+    epaper_display.update();                  // Voll-Refresh -> sichtbar (haelt im Schlaf)
 }
 #endif
 
@@ -1749,7 +1817,7 @@ void mainStartTimeLoop()
         {
             bDisplayIsOff = false;
 
-            #if !defined(BOARD_WIRELESS_PAPER)
+            #if !defined(WP_DISP)
             sendDisplayHead(true);
             #else
             // E-Ink (Wireless Paper): den ERSTEN von zwei Boot-Aufbauten ueberspringen.
@@ -1791,7 +1859,7 @@ void mainStartTimeLoop()
                         iDisplayChange=1;
                 }
 
-                #if defined(BOARD_WIRELESS_PAPER)
+                #if defined(WP_DISP)
                 // E-Ink: Beim Umschalten des Track-Modus den Bildschirm physisch loeschen
                 // und sofort die passende Seite neu aufbauen. Sonst (a) schreibt die
                 // Track-Seite beim Einschalten ueber den alten Inhalt und (b) bleibt beim
@@ -1834,7 +1902,7 @@ void mainStartTimeLoop()
 
                 if(bDisplayTrack)
                 {
-                    #if defined(BOARD_WIRELESS_PAPER)
+                    #if defined(WP_DISP)
                     // ============================================================================
                     // Konsequente Tracking-Anzeige-Logik fuer die GPS-LOSE Wireless Paper
                     // ----------------------------------------------------------------------------
@@ -1936,7 +2004,7 @@ void mainStartTimeLoop()
                 }
                 else
                 {
-                    #if defined(BOARD_WIRELESS_PAPER)
+                    #if defined(WP_DISP)
                     // E-Ink schonen: Uhrzeit nur alle 10 s aktualisieren (Teilbereich-Refresh
                     // der Statuszeile), statt sekuendlich. sendDisplayTime() ist fuer E-Paper
                     // ohnehin deaktiviert. Im aus-Zustand (--display off) NICHT refreshen.
@@ -2110,8 +2178,8 @@ void sendDisplayText(struct aprsMessage &aprsmsg, int16_t rssi, int8_t snr)
     DisplayOffWait = millis() + (30 * 1000); // 30 seconds
     bDisplayIsOff=false;
 
-    #if defined(BOARD_WIRELESS_PAPER)
-    wpMsgIdx = 0;   // frisch eintreffende Nachricht -> kein (alter) Browse-Index oben rechts
+    #if defined(WP_DISP)
+    wpMsgIdx = 0;       // frisch eintreffende Nachricht -> kein (alter) Browse-Index oben rechts
     #endif
     //
     ///////////////////////////////////////////////////////////
@@ -2222,7 +2290,7 @@ void sendDisplayText(struct aprsMessage &aprsmsg, int16_t rssi, int8_t snr)
 
     strAscii = utf8ascii(aprsmsg.msg_payload);
 
-    #if defined(BOARD_WIRELESS_PAPER)
+    #if defined(WP_DISP)
     // Nachrichtentext mit kompakter Schrift (enger Zeilenabstand 15 statt 22) -> bis zu 160
     // Zeichen passen auf das Panel. Gleicher Font wie beim Durchblaettern -> Browse == Live.
     epaper_display.setFont(wpMsgFont());
@@ -2235,7 +2303,7 @@ void sendDisplayText(struct aprsMessage &aprsmsg, int16_t rssi, int8_t snr)
     strncpy(pageLastTextLong2[pagePointer], strAscii.c_str(), sizeof(pageLastTextLong2[pagePointer]) - 1);
     pageLastTextLong2[pagePointer][sizeof(pageLastTextLong2[pagePointer]) - 1] = '\0';
 
-    #if defined(BOARD_WIRELESS_PAPER)
+    #if defined(WP_DISP)
     // Neue Nachricht per Voll-Refresh aufbauen -> gestochen scharf, tiefschwarz,
     // kein Ghosting. Die schnellen Partial-Updates (Uhrzeit) bleiben unberuehrt.
     epaper_display.fastmodeOff();
@@ -2768,7 +2836,7 @@ void sendDisplayPosition(struct aprsMessage &aprsmsg, int16_t rssi, int8_t snr)
     sendDisplay1306(false, true, 3, dzeile[izeile], msg_text);
     #endif
 
-    #if defined(BOARD_WIRELESS_PAPER)
+    #if defined(WP_DISP)
     // Nach dem partiellen Aufbau einen Voll-Refresh nachschieben: loescht die zuvor
     // angezeigte Nachricht physisch (kein Ueberlagern), die Position erscheint sauber.
     epaper_display.fastmodeOff();

--- a/src/loop_functions.h
+++ b/src/loop_functions.h
@@ -16,8 +16,9 @@ unsigned long getUnixClock();
 
 void sendDisplay1306(bool bClear, bool bTransfer, int x, int y, char *text);
 void sendDisplayHead(bool bInit);
-#if defined(BOARD_WIRELESS_PAPER)
+#if defined(WP_DISP)
 void wpShowStoredMessage(int slot, int idx);   // idx = Index oben rechts (neueste=N..aelteste=1, 0=keiner)
+void wpShowDeepSleep();                         // E-Ink nur loeschen (kein Text) vor dem Deepsleep -> Sleep sichtbar
 #endif
 void sendDisplayTrack();
 void sendDisplayWX();
@@ -77,7 +78,7 @@ double cround4abs(double dvar);
 int conv_fuss(int alt_meter);
 int conv_meter(int alt_fuss);
 
-#if defined(BOARD_E290) || defined(BOARD_WIRELESS_PAPER)
+#if defined(BOARD_E290) || defined(BOARD_WIRELESS_PAPER) || defined(BOARD_E213)
 void DrawDirection(float angle, int cx, int cy, int radius);
 void DrawRssi(int cx, int cy, int16_t rssi);
 double degreesToRadians(double degrees);

--- a/src/loop_functions_extern.h
+++ b/src/loop_functions_extern.h
@@ -336,9 +336,9 @@ extern int iDisplayType;
 #if defined(BOARD_T_ECHO)
 #define maxdisplines 11
 #define PAGE_MAX 6
-#elif defined(BOARD_WIRELESS_PAPER)
+#elif defined(BOARD_WIRELESS_PAPER) || defined(BOARD_E213)
 #define maxdisplines 7
-#define PAGE_MAX 10   // Wireless Paper: bis zu 9 gespeicherte Nachrichten in einer Loop durchblaettern
+#define PAGE_MAX 10   // Wireless Paper / Vision Master E213: bis zu 9 gespeicherte Nachrichten durchblaettern
 #else
 #define maxdisplines 7
 #define PAGE_MAX 6

--- a/src/lora_functions.cpp
+++ b/src/lora_functions.cpp
@@ -89,7 +89,7 @@ extern int mheardAlt[MAX_MHEARD];
 
 // TinyGPS
 // gps nur fuer Distanz-/Kursberechnung (distanceBetween) - auch ohne ENABLE_GPS sichtbar machen.
-#if defined(ENABLE_GPS) || defined(ENABLE_RAK_GPS) || defined(BOARD_WIRELESS_PAPER)
+#if defined(ENABLE_GPS) || defined(ENABLE_RAK_GPS) || defined(WP_DISP)
 extern TinyGPSPlus gps;
 #endif
 

--- a/src/mheard_functions.cpp
+++ b/src/mheard_functions.cpp
@@ -37,12 +37,12 @@ uint8_t mheardPathLen[MAX_MHPATH];
 uint8_t mheardWrite = 0;   // counter for ringbuffer
 uint8_t mheardPathWrite = 0;   // counter for ringbuffer
 
-#define max_hardware 32
+#define max_hardware 33
 
 #if defined(BOARD_T_DECK) || defined(BOARD_T_DECK_PLUS)
-    String HardWare[max_hardware] = {"no info", "TLO_V2", "TLO_V1", "TLV2_1p6", "TBEAM", "TB_1268", "TB_0p7", "TECHO", "TDECK", "RAK4631", "HELTV21", "HELTV1", "TB_2101", "EB_E22", "HELTV3", "HELT_E290", "TB_1262", "TDECK+", "TB_SUPR", "ES3_E22", "TRACKER_V3", "STICK_V3", "T5_EPAPER", "TPAGER", "TDECKpro", "TBEAM_1W", "HETLV4", "T_ETH_EL", "HETL_T114", "T3S3V13", "TCONPRO", "WLPAPER"};
+    String HardWare[max_hardware] = {"no info", "TLO_V2", "TLO_V1", "TLV2_1p6", "TBEAM", "TB_1268", "TB_0p7", "TECHO", "TDECK", "RAK4631", "HELTV21", "HELTV1", "TB_2101", "EB_E22", "HELTV3", "HELT_E290", "TB_1262", "TDECK+", "TB_SUPR", "ES3_E22", "TRACKER_V3", "STICK_V3", "T5_EPAPER", "TPAGER", "TDECKpro", "TBEAM_1W", "HETLV4", "T_ETH_EL", "HETL_T114", "T3S3V13", "TCONPRO", "WLPAPER", "HELT_E213"};
 #else
-    String HardWare[max_hardware] = {"no info", "TLORA_V2", "TLORA_V1", "TLORA_V2_1_1p6", "TBEAM", "TBEAM_1268", "TBEAM_0p7", "T_ECHO", "TDECK", "RAK4631", "HELTEC_V2_1", "HELTEC_V1", "TBEAM_AXP2101", "EBYTE_E22", "HELTEC_V3", "HELTEC_E290", "TBEAM_1262", "TDECK_PLUS", "TBEAM_SUPREME", "ESP_S3_E22", "TRACK_V3", "STICK_V3", "T5_EPAPER", "TPAGER", "TDECKpro", "TBEAM_1W", "HELTEC_V4", "T_ETH_ELITE", "HELTEC_T114", "T3_S3_V13", "T_CON_PRO", "WIRELESS_PAPER"};
+    String HardWare[max_hardware] = {"no info", "TLORA_V2", "TLORA_V1", "TLORA_V2_1_1p6", "TBEAM", "TBEAM_1268", "TBEAM_0p7", "T_ECHO", "TDECK", "RAK4631", "HELTEC_V2_1", "HELTEC_V1", "TBEAM_AXP2101", "EBYTE_E22", "HELTEC_V3", "HELTEC_E290", "TBEAM_1262", "TDECK_PLUS", "TBEAM_SUPREME", "ESP_S3_E22", "TRACK_V3", "STICK_V3", "T5_EPAPER", "TPAGER", "TDECKpro", "TBEAM_1W", "HELTEC_V4", "T_ETH_ELITE", "HELTEC_T114", "T3_S3_V13", "T_CON_PRO", "WIRELESS_PAPER", "HELTEC_E213"};
 #endif
 
 void initMheard()
@@ -743,6 +743,8 @@ String getHardwareLong(uint8_t hwid)
         ihw=30;
     if(ihw == 57)
         ihw=31;
+    if(ihw == 58)
+        ihw=32;   // HELTEC_E213 (Vision Master E213) -> Array-Index 32
     if(ihw < 0 || ihw >= max_hardware)
         ihw=0;
 

--- a/src/onebutton_functions.cpp
+++ b/src/onebutton_functions.cpp
@@ -21,6 +21,12 @@
 #include "nrf52_functions.h"
 #endif
 
+#if defined(WP_DISP)
+// Anzahl der per 1x-Klick durchblaetterbaren letzten Nachrichten (Wireless Paper + E213,
+// gemeinsamer 2.13"-Display-Pfad): die letzten 4 (original-kompatibel).
+#define WP_MSG_BROWSE_MAX 4
+#endif
+
 void singleClick()
 {
   if(bDisplayCont)
@@ -35,6 +41,76 @@ void singleClick()
   {
     if(bDisplayCont)
         Serial.printf("BUTTON single press last:%i pointer:%i lines:%i\n", pageLastPointer, pagePointer, pageLastLineAnz[pagePointer]);
+
+    #if defined(WP_DISP)
+    // ===== Wireless Paper + E213: die letzten WP_MSG_BROWSE_MAX Nachrichten + Status in einer LOOP =====
+    // Eigene Logik statt des Magic-Status-Slots: der konnte haengenbleiben, wenn die NEUESTE
+    // Nachricht zufaellig im Status-Slot landete (Original "verhaspelte" sich nach ~3). Die WP hat
+    // zudem keinen pageHold-Timeout (sendDisplayTime laeuft hier nicht), daher wird der Loop hier
+    // explizit geschlossen. Rotation: neueste -> ... -> Fensterrand -> Status -> neueste -> ...
+    // Das Browse-Fenster ist auf WP_MSG_BROWSE_MAX (=4, vorbereitet fuer 9) begrenzt - der Ring
+    // (PAGE_MAX=10) koennte mehr, aus Kompatibilitaet zeigen wir aber nur die letzten 4.
+    {
+      static bool wpStatusStep = false;                 // naechster Klick zeigt die Status-Seite
+      int wpNewest = pageLastPointer - 1;               // Slot der neuesten Nachricht
+      if(wpNewest < 0) wpNewest += PAGE_MAX;
+
+      // KEINE Nachricht im Ringpuffer: Original/PR -> Statusschirm; Preview -> "No Message".
+      if(pageLastLineAnz[wpNewest] == 0)
+      {
+        sendDisplayHead(true);
+        wpStatusStep = false;
+        pagePointer  = wpNewest;
+        return;
+      }
+
+      // Status-Schritt (nach dem Fensterrand/der aeltesten) -> Statusschirm, dann Loop
+      if(wpStatusStep)
+      {
+        sendDisplayHead(true);
+        wpStatusStep = false;
+        pagePointer  = wpNewest;
+        return;
+      }
+
+      if(pageLastLineAnz[pagePointer] == 0)             // Sicherheit: aktueller Slot leer -> neueste
+        pagePointer = wpNewest;
+
+      // Anzahl gespeicherter Nachrichten (zusammenhaengend ab der neuesten)
+      int wpN = 0;
+      {
+        int s = wpNewest;
+        for(int n = 0; n < PAGE_MAX; n++)
+        {
+          if(pageLastLineAnz[s] == 0) break;
+          wpN++;
+          s--; if(s < 0) s += PAGE_MAX;
+        }
+      }
+      // sichtbares Fenster = min(vorhanden, WP_MSG_BROWSE_MAX)
+      int wpShow  = (wpN < WP_MSG_BROWSE_MAX) ? wpN : WP_MSG_BROWSE_MAX;
+      // Schritte unterhalb der neuesten (0 = neueste); ausserhalb Fenster -> auf neueste zuruecksetzen
+      int wpSteps = (wpNewest - pagePointer + PAGE_MAX) % PAGE_MAX;
+      if(wpSteps >= wpShow) { pagePointer = wpNewest; wpSteps = 0; }
+
+      // Index oben rechts: neueste = wpShow (max 4) ... Fensterrand = 1; 0 = Home/Status.
+      int wpRank = wpShow - wpSteps;
+
+      // Nachricht anzeigen (Helper in loop_functions.cpp; kompaktes Layout + Voll-Refresh).
+      wpShowStoredMessage(pagePointer, wpRank);
+
+      // naechste (aeltere) bestimmen; am Fensterrand (wpSteps+1 >= wpShow) ODER aelteste erreicht
+      // (naechster Slot leer) -> naechster Klick zeigt Status, danach wieder bei der neuesten.
+      int wpNext = pagePointer - 1;
+      if(wpNext < 0) wpNext += PAGE_MAX;
+      if((wpSteps + 1) >= wpShow || pageLastLineAnz[wpNext] == 0)
+        wpStatusStep = true;
+      else
+        pagePointer = wpNext;
+
+      return;
+    }
+    #endif
 
     if(pagePointer == 5)
     {
@@ -161,7 +237,12 @@ void PressLong()
 
   bShowHead=false;
 
-  #if defined(BOARD_E290) || defined(BOARD_WIRELESS_PAPER)
+  #if defined(WP_DISP)
+      // Long Press auf Wireless Paper + E213 -> Deepsleep (Strom sparen im Akkubetrieb). #992
+      // "--display off" ist auf E-Ink SINNLOS (bistabiles Panel zieht statisch keinen Strom);
+      // der --deepsleep-Pfad loescht stattdessen das Panel sichtbar (wpShowDeepSleep).
+      commandAction((char*)"--deepsleep", isPhoneReady, false);
+  #elif defined(BOARD_E290)
       sendDisplayMainline();
       E290DisplayUpdate();
   #else
@@ -215,7 +296,7 @@ void init_onebutton()
 /* Initialize a new OneButton instance for a button connected to digital
 *  pin and GND, which is active low [2] and uses the internal pull-up resistor.
 */
-    #if (defined(BOARD_E290) || defined(BOARD_WIRELESS_PAPER))
+    #if (defined(BOARD_E290) || defined(BOARD_WIRELESS_PAPER) || defined(BOARD_E213))
       // btn.setup( /*GPIO=*/ iButtonPin, /*active LOW=*/ true, /*pull-up=*/ false);
       btn.setup( /*GPIO=*/ iButtonPin, INPUT, /*active LOW=*/ true);
     #else

--- a/tools/e213_monitor.py
+++ b/tools/e213_monitor.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""
+Robuster serieller Monitor fuer Heltec Vision Master E213 (ESP32-S3 USB-Serial/JTAG / HWCDC).
+
+Warum dieses Skript? Der USB-Serial/JTAG-Port des ESP32-S3 verschwindet auf macOS im Betrieb
+immer wieder kurz aus dem System (USB-Re-Enumeration OHNE Board-Reset). 'screen' stirbt beim
+ersten Aussetzer; dieses Skript verbindet automatisch neu und ueberbrueckt die Luecke.
+
+Nutzung:
+    python3 tools/e213_monitor.py            # Port automatisch suchen (usbmodem*)
+    python3 tools/e213_monitor.py /dev/cu.usbmodem1101 115200
+
+Eingabe: Tippe eine Zeile + ENTER -> wird mit \\n an das Board gesendet (z.B. "--info").
+Beenden: Ctrl-C.
+"""
+import sys, time, glob, threading
+
+try:
+    import serial
+except ImportError:
+    sys.exit("pyserial fehlt. Installiere: ~/.platformio/penv/bin/python -m pip install pyserial\n"
+             "oder starte dieses Skript mit ~/.platformio/penv/bin/python")
+
+BAUD = 115200
+PORT_ARG = None
+for a in sys.argv[1:]:
+    if a.isdigit():
+        BAUD = int(a)
+    else:
+        PORT_ARG = a
+
+
+def find_port(timeout=10.0):
+    t0 = time.time()
+    while time.time() - t0 < timeout:
+        if PORT_ARG:
+            import os
+            if os.path.exists(PORT_ARG):
+                return PORT_ARG
+        else:
+            ports = sorted(glob.glob("/dev/cu.usbmodem*"))
+            if ports:
+                return ports[0]
+        time.sleep(0.2)
+    return None
+
+
+_ser = None
+_stop = False
+
+
+def reader():
+    """Liest fortlaufend und gibt aus; bei Verbindungsverlust wird in main() neu verbunden."""
+    global _ser
+    while not _stop:
+        s = _ser
+        if s is None:
+            time.sleep(0.1)
+            continue
+        try:
+            data = s.readline()
+            if data:
+                sys.stdout.write(data.decode("utf-8", "replace"))
+                sys.stdout.flush()
+        except Exception:
+            time.sleep(0.1)  # Verbindung weg -> main() reconnectet
+
+
+def main():
+    global _ser, _stop
+    print("E213-Monitor (Auto-Reconnect). Ctrl-C zum Beenden.\n")
+    th = threading.Thread(target=reader, daemon=True)
+    th.start()
+    cur_port = None
+    try:
+        # Eingabe-Thread: Zeilen von stdin an das Board
+        def writer():
+            for line in sys.stdin:
+                s = _ser
+                if s is not None:
+                    try:
+                        s.write((line.rstrip("\n") + "\n").encode("utf-8", "replace"))
+                    except Exception:
+                        pass
+        wt = threading.Thread(target=writer, daemon=True)
+        wt.start()
+
+        while True:
+            if _ser is None:
+                port = find_port(15)
+                if not port:
+                    print("\n[monitor] kein usbmodem-Port gefunden, warte ...", flush=True)
+                    continue
+                try:
+                    _ser = serial.Serial(port, BAUD, timeout=0.3)
+                    if port != cur_port:
+                        print(f"\n[monitor] verbunden mit {port} @ {BAUD}\n", flush=True)
+                        cur_port = port
+                except Exception:
+                    _ser = None
+                    time.sleep(0.3)
+                    continue
+            # Verbindung pruefen (Port noch da?)
+            import os
+            if cur_port and not os.path.exists(cur_port):
+                try:
+                    _ser.close()
+                except Exception:
+                    pass
+                _ser = None  # -> reconnect oben
+            time.sleep(0.4)
+    except KeyboardInterrupt:
+        _stop = True
+        print("\n[monitor] beendet.")
+
+
+if __name__ == "__main__":
+    main()

--- a/variants/vision-master-e213/configuration.h
+++ b/variants/vision-master-e213/configuration.h
@@ -1,0 +1,115 @@
+/*
+definitions for HELTEC Vision Master E213 (V1.1.1)
+ESP32-S3R8 (16MB Flash, 8MB PSRAM) + SX1262 + 2.13" E-Ink 250x122.
+
+Abgeleitet von vision-master-e290 (Funkpfad, nativer USB) und wireless-paper (2.13"-Panel,
+keine Sensoren, kein GPS). Der Panel-Controller variiert je HW-Version und wird zur Laufzeit
+per Chip-ID erkannt (detectEinkChipId() in esp32_functions.cpp):
+  - E0213A367      -> V1.0 / V1.1.1 / V1.2
+  - LCMEN2R13EFC1  -> V1.1
+
+Pinbelegung verifiziert aus offiziellem Heltec-Schaltplan HT-VME213_V1.0:
+  E-Ink: BUSY=1 DC=2 RST=3 CLK=4 CS=5 SDI/MOSI=6  (in src/Platforms/VisionMasterE213/VisionMasterE213.h)
+  LoRa : NSS=8 SCK=9 MOSI=10 MISO=11 RST=12 BUSY=13 DIO1=14  (identisch zur E290)
+  Akku : VBAT_Read=7  ADC_Ctrl=46 ;  LED=45 ; VEXT/Ve_Ctrl=18 (active HIGH) ; PRG=0 USER=21
+*/
+
+#pragma once
+
+#include <Arduino.h>
+#include <configuration_global.h>
+
+// Vision Master E213 specific config
+#define MODUL_HARDWARE HELTEC_E213
+
+#define RF_FREQUENCY 433.175000          // Hz  (AT 70cm, wie E290)
+#define LORA_APRS_FREQUENCY 433.775000   // Hz
+
+// --- Keine Onboard-Sensoren auf dem E213 -> bewusst NICHT aktiviert ---
+// (kein ENABLE_GPS / BMX280 / BMP390 / AHT20 / SHT21 / BMX680 / MCP23017 / INA226 / MCU811 / RTC / SOFTSER)
+
+#define TX_POWER_MAX 22  // max 22 dBm
+#define TX_POWER_MIN 2
+
+// SX1262 mit identischer Pinbelegung wie E290 -> bewaehrten E290-Funkpfad mitnutzen
+// (radio-Objekt, RX-IRQ, Spektralscan, Kommando-/Web-Funktionen). Steuert KEIN Display.
+#define SX1262_E290
+
+// generischer E-Paper-Pfad (Display-Init, sendDisplay*, Update) wie E290/WP
+#define HAS_EPAPER
+
+#define LORA_PREAMBLE_LENGTH DEFAULT_PREAMPLE_LENGTH  // Same for Tx and Rx
+
+#define WAIT_TX 5         // ticks waiting after Lora TX in doTX()
+
+#define TX_OUTPUT_POWER 22  // SX1262 up to +22dBm
+#define CURRENT_LIMIT 140   // mA
+
+// RadioLib Modem-Parameter (wie E290)
+#define LORA_CR 6
+#define LORA_BANDWIDTH 250
+#define LORA_SF 11
+
+// =============================================
+// GPIOs
+// ===== Analog / Batterie =====
+#define ANALOG_PIN 0
+#define ANALOG_REFRESH_INTERVAL 30 // sec messure intervall
+
+// PRG-Taster (BUTTON_1) liegt auf GPIO0; USER-Taster (BUTTON_2) auf GPIO21.
+#define BUTTON_PIN 0
+
+// Onboard-LED des E213 auf GPIO45 (active HIGH). ACHTUNG: GPIO18 ist hier VEXT (NICHT LED
+// wie bei der Wireless Paper). MeshCom blinkt die LED ueber den BOARD_LED-Pfad; per Default
+// AUS (bUSER_BOARD_LED=false), per "--board led on" einschaltbar.
+#define BOARD_LED 45
+
+// I2C frei liegend (QL_SDA/QL_SCL der SH2.0-4P-Sensorports). esp32_main.cpp ruft beim Start
+// ungeschuetzt Wire.begin(I2C_SDA, I2C_SCL) auf; kollidiert nicht mit E-Ink 1-6 oder LoRa 8-14.
+#define I2C_SDA 39
+#define I2C_SCL 38
+
+// esp32_pmu.cpp legt ohne ENABLE_GPS ein SoftwareSerial gpsSerial(GPS_RX_PIN, GPS_TX_PIN) an.
+// E213 hat KEIN GPS -> Pins nur Platzhalter (UART-Header), das Objekt bleibt schlafend.
+#define GPS_RX_PIN 44  // ungenutzt (kein GPS) - U0RXD-Header
+#define GPS_TX_PIN 43  // ungenutzt (kein GPS) - U0TXD-Header
+
+#define OneWire_GPIO  99 // ungenutzt
+
+// Batteriemessung Heltec Vision Master E213 (laut offiziellem Schaltplan):
+//  - VBAT_Read auf GPIO7, interner Teiler 100k/100k (Faktor 2)
+//  - Mess-Freigabe ueber ADC_Ctrl GPIO46 (Polaritaet am Geraet verifizieren)
+#define ADC_CTRL_E213 46
+
+#define USE_NEW_BATT
+#define USE_BATT
+#ifdef USE_BATT
+  #define BATTERY_PIN             7
+  #define BAT_VOLT_PIN            BATTERY_PIN
+  // Teiler-Faktor AM GERAET ermittelt (2026-06-23): Pin misst ~840 mV bei vollem Akku -> Faktor
+  // ~4.92, IDENTISCH zur Vision Master E290 (ADC_MULTIPLIER 4.9245). Der im Schaltplan vermutete
+  // 100k/100k-Teiler (Faktor 2) war FALSCH (840 mV * 2 = 1.68 V; 840 mV * 4.9245 = 4.14 V = voll).
+  // analogReadMilliVolts() ist kalibriert -> der Faktor ist rein der Teiler. Feinabgleich via --batt factor.
+  #define BAT_MULTIPLIER          4.9245
+  #define ADC_MULTIPLIER          BAT_MULTIPLIER
+  #define BAT_MAX_VOLTAGE         4.1  // [--maxv 4.1] Volt => Proz Umrechnung, def. Akku
+  #define BAT_MIN_VOLTAGE         3.3  // fuer Volt => Proz Umrechnung, definiert durch LDO
+  #define BAT_VOLT_OFFSET         0    // offset
+  #define BAT_VOLT_FACTOR         1    //factor [--batt factor 1.000]
+  #define BAT_ATTEN               ADC_11db
+  #define BAT_WIDTH               12
+
+  #define ADC_CTRL_PIN            46
+#endif
+
+// E-Ink-Versorgung (VEXT=GPIO18, active HIGH) wird von der Plattform-Schicht
+// src/Platforms/VisionMasterE213/power_controls.cpp (#ifdef Vision_Master_E213) gehandhabt.
+
+// PCB Wiring - LoRa - nur fuer prepareToSleep() / Referenz (identisch zur E290)
+#define PIN_LORA_DIO_1          14
+#define PIN_LORA_NSS            8
+#define PIN_LORA_NRST           12
+#define PIN_LORA_BUSY           13
+#define PIN_LORA_SCK            9
+#define PIN_LORA_MISO           11
+#define PIN_LORA_MOSI           10

--- a/variants/vision-master-e213/platformio.ini
+++ b/variants/vision-master-e213/platformio.ini
@@ -1,0 +1,63 @@
+; ── Heltec Vision Master E213 (V1.1.1) ───────────────────────────────────────
+; ESP32-S3R8 (16MB Flash, 8MB PSRAM, nativer USB-Serial/JTAG) + SX1262 + 2.13" E-Ink
+; (250x122, E0213A367/LCMEN2R13EFC1, Laufzeit-Erkennung per Chip-ID).
+;
+; Abgeleitet von vision-master-e290 (gleicher Funkpfad SX1262_E290, nativer USB), aber
+; Display = 2.13"-Panel wie Wireless Paper (eigener BOARD_E213-Pfad, geteilte Guards mit
+; BOARD_WIRELESS_PAPER wo Code identisch ist).
+[env:vision-master-e213]
+platform = espressif32@^6.6.0
+board = heltec_wifi_lora_32_V3
+framework = arduino
+monitor_speed = 115200
+monitor_filters = esp32_exception_decoder
+board_upload.use_1200bps_touch = true
+board_build.partitions = partitions-4MB-safeboot.csv
+board_build.app_partition_name = app
+; PSRAM-AKTIVIERUNG VORERST DEAKTIVIERT (2026-06-23): Mit `board_build.arduino.memory_type =
+; qio_opi` wird das 8 MB Octal-PSRAM zwar erkannt ([PSRM]=8386295), aber das Geraet geht in eine
+; Boot-Loop: `assert failed: spinlock_acquire` in gpio_install_isr_service, ausgeloest beim
+; Installieren der LoRa-DIO1-Interrupt-Routine (RadioLib SX126x::setDio1Action -> attachInterrupt).
+; Bekanntes ESP32-S3 + Octal-PSRAM + Arduino-ISR-Problem; die PSRAM-sdkconfig steckt fest in den
+; vorkompilierten Arduino-Libs (per build_flag nicht aenderbar). Stabile PSRAM-Nutzung = eigenes
+; Vorhaben (IRAM-safe ISR / passende Core-Variante). Firmware laeuft ohne PSRAM stabil (Heap reicht).
+upload_protocol = custom
+upload_command = pio pkg exec -p "tool-esptoolpy" -- esptool -b 921600 write_flash 0x0000 ${platformio.build_dir}/${this.__env__}/bootloader.bin 0xE000 otadata.bin 0x8000 ${platformio.build_dir}/${this.__env__}/partitions.bin 0x10000 safeboot-s3.bin 0xC0000 ${platformio.build_dir}/${this.__env__}/firmware.bin
+build_src_filter =
+	+<*>
+	-<nrf52/*>
+	-<t-deck/*>
+	-<t-deck-pro/*>
+	-<t5-epaper/*>
+	-<safeboot/*>
+	-<lib/lvgl/*>
+	;use Displays, Fonts, GFX_Root, Platforms
+lib_ignore = AceButton, Adafruit TCA8418, epdiy, es7210, ESP32-audioI2S, lvgl, SensorLibTDECKPro, TFT_eSPI, TinyGSM, U8g2, XPowersLib
+lib_deps =
+	${libs.lib_deps}
+	${esp32libs.lib_deps}
+	ropg/Heltec_ESP32_LoRa_v3@^0.9.1
+	plerup/EspSoftwareSerial@^8.2.0
+build_flags =
+	${common.build_flags}
+	; E213 haengt ueber natives USB-Serial/JTAG (kein CP2102) am Rechner -> USB-CDC aktivieren.
+	; ARDUINO_USB_MODE=1 -> Hardware-USB-Serial/JTAG (HWCDC) statt TinyUSB. Stabiler (Port flackert
+	; nicht), und Crash-/Panic-Ausgaben kommen auch bei Hang/Crash noch durch (Debugging!).
+	-D ARDUINO_USB_CDC_ON_BOOT=1
+	-D ARDUINO_USB_MODE=1
+	-D MONITOR_SPEED=${upload_settings.monitor_speed}
+	-D BOARD_E213="Vision_Master_E213"
+	-D VISION_MASTER_E213
+	-I variants/vision-master-e213
+
+; ── Preview-Variante (erweiterter Stand, analog WP-Preview) ──────────────────
+[env:vision-master-e213-preview]
+extends = env:vision-master-e213
+build_flags =
+	${common.build_flags}
+	-D ARDUINO_USB_CDC_ON_BOOT=1
+	-D MONITOR_SPEED=${upload_settings.monitor_speed}
+	-D BOARD_E213="Vision_Master_E213"
+	-D VISION_MASTER_E213
+	-D E213_PREVIEW
+	-I variants/vision-master-e213


### PR DESCRIPTION
## Neues Board: Heltec Vision Master E213

Dieser PR fügt das **Heltec Vision Master E213** als neues MeshCom-Board hinzu
(ESP32-S3 + SX1262 + 2.13" E-Ink, 250x122). HW-ID **58** (`HELTEC_E213`).

### Hardware
- ESP32-S3 (16 MB Flash, 8 MB PSRAM*), SX1262 (HT-RA62-Modul, Funkpfad identisch zur Vision Master E290)
- 2.13" E-Ink, nativer USB-Serial/JTAG (HWCDC)
- *PSRAM derzeit **nicht** aktiviert: ESP32-S3-Octal-PSRAM führt zusammen mit dem RadioLib-DIO1-Interrupt zu einem `spinlock_acquire`-Crash (bekanntes Arduino-Core-Thema); wird nicht benötigt, interner Heap reicht.

### Getestet / Hardware-Versionen
- **Getestet auf HW V1.1.1** (Display E0213A367-BW / SSD1680): Boot, Display, LoRa 433 MHz, BLE, WLAN/NTP, Uhr, Tasten-Bedienung (Browse + Long-Press-Deepsleep), Akku-Messung + Low-Voltage-Deepsleep — alles am Gerät verifiziert.
- **Vorbereitet für V1.0 und V1.1**: Die Display-Panel-Erkennung läuft **zur Laufzeit, nicht-invasiv über die BUSY-Polarität** und wählt automatisch den passenden Treiber:
  - **E0213A367** (SSD1680) → V1.0 / V1.1.1 / V1.2
  - **LCMEN2R13EFC1** → V1.1

### Wesentliche Änderungen
- Neue Variante `variants/vision-master-e213/` (env `vision-master-e213` + `-preview`) und Plattform-Layer `src/Platforms/VisionMasterE213/` (inkl. `prepareToSleep()` für ~18 µA Deepsleep).
- **Gemeinsamer 2.13"-Display-Pfad mit der Wireless Paper** über das neue Makro `WP_DISP` (= `BOARD_WIRELESS_PAPER || BOARD_E213`). Die Wireless Paper bleibt dabei **byte-identisch** (reine Makro-Umstellung); andere Boards (E290 byte-verifiziert, RAK4631, T-Beam, …) unverändert.
- **Panel-Auto-Erkennung per BUSY-Polarität** in `esp32_functions.cpp` — löst die alte `0x2F`-Chip-ID-Probe ab (die brachte den SSD1680 in einen Dauer-BUSY-Zustand → Hang).
- HW-ID 58 (`HELTEC_E213`) inkl. Klartext-Anzeigename in `mheard_functions.cpp`.
- Akku: ADC_CTRL (GPIO46) active HIGH, Teiler-Faktor 4.9245 (identisch zur Vision Master E290), Low-Voltage-Deepsleep.

### Hinweis zur Hardware-ID
Die HW-ID **58** ist vorläufig gewählt (nächste freie nach `HELTEC_WIRELESS_PAPER = 57`). Bitte ggf. eine offizielle ID zuweisen, falls 58 serverseitig bereits anders belegt ist — ich passe sie dann gerne an.

### Builds
Grün: `vision-master-e213`, `vision-master-e213-preview`, `wireless-paper`, `vision-master-e290`.
