### PR TITLE
Fix: Buffer-Overflow-Grenze im {MCP}-Handler (sizeof(clfd) statt sizeof(cset))

### DIFF
--- a/src/loop_functions.cpp
+++ b/src/loop_functions.cpp
@@ -2050,7 +2050,7 @@ void sendDisplayText(struct aprsMessage &aprsmsg, int16_t rssi, int8_t snr)
 
         char clfd[10];
         memset(clfd, 0x00, sizeof(clfd));
-        snprintf(clfd, sizeof(cset), "%03i", (int)(aprsmsg.msg_id & 0x3FF));
+        snprintf(clfd, sizeof(clfd), "%03i", (int)(aprsmsg.msg_id & 0x3FF));   // fix: was sizeof(cset)=30 written into clfd[10] (cppcheck bufferAccessOutOfBounds)
 
         // check pwd
         bool bpass=true;


### PR DESCRIPTION
## Fix: Buffer-Overflow-Grenze im `{MCP}`-Kommando-Handler

### Änderung
Eine Zeile in `src/loop_functions.cpp` (im `{MCP}`-Handler):

```diff
- snprintf(clfd, sizeof(cset), "%03i", (int)(aprsmsg.msg_id & 0x3FF));
+ snprintf(clfd, sizeof(clfd), "%03i", (int)(aprsmsg.msg_id & 0x3FF));
```

### Warum
Die laufende Nummer wird in den **10-Byte-Puffer `clfd`** geschrieben, die Größengrenze war aber fälschlich `sizeof(cset)` = **30** — ein Copy-Paste-Fehler von der `cset`-Zeile direkt darüber. `snprintf` durfte damit bis zu 30 Byte in einen 10-Byte-Stack-Puffer schreiben → **potenzieller Stack-Overflow**.

**In der Praxis latent:** Der Format-String `"%03i"` mit `(msg_id & 0x3FF)` (max. 1023) erzeugt nur max. 4 Zeichen — der Overflow löst also aktuell nie aus. `cppcheck` meldet es dennoch korrekt als `bufferAccessOutOfBounds`.

### Auswirkung
- **Kein Verhaltensunterschied** — der geschriebene Text ist identisch, nur die Puffergrenze stimmt jetzt.
- Betrifft alle Boards (geteilter Code in `loop_functions.cpp`).
- Alle Board-Varianten bauen unverändert.

Gefunden per statischer Analyse (cppcheck).

---
*Eingereicht von OE3LCR.*
