### PR TITLE
Feature: Terminalkommando --rotate 0/90/180/270 (E-Ink Display drehen)

### DIFF
--- a/src/command_functions.cpp
+++ b/src/command_functions.cpp
@@ -273,6 +273,41 @@ void commandAction(char *umsg_text, bool ble)
         return;
     }
     else
+#if defined(WP_DISP)
+    if(commandCheck(msg_text+2, (char*)"rotate ") == 0)
+    {
+        // --rotate 0/90/180/270 : persistenter Display-Dreh-Offset (Grad), board-uebergreifend
+        // ADDITIV auf die Werks-Basisrotation. "--rotate " = 9 Zeichen -> Wert ab msg_text+9.
+        // Nur Wireless Paper + Vision Master E213. Hinweis: 0/180 = Querformat, 90/270 = Hochformat.
+        int iRot = -1;
+        sscanf(msg_text+9, "%d", &iRot);
+
+        if(iRot == 0 || iRot == 90 || iRot == 180 || iRot == 270)
+        {
+            meshcom_settings.node_disp_rot = iRot;   // -> NVS via save_settings()
+            g_dispRotOffset = iRot;                  // sofort im laufenden Betrieb wirksam
+
+            save_settings();
+
+            if(bBLEDEBUG)
+                printfdeb("[COMMAND]rotate: display offset -> %i deg\n", iRot);
+
+            // Neue Rotation SOFORT anwenden (gleiche Quelle wie beim Boot), DANN Voll-Refresh:
+            // sendDisplayHead(true) ruft fastmodeOff() -> voller Panel-Refresh (V1.1 LCMEN kann
+            // kein Partial-Update). Reihenfolge zwingend: erst drehen, dann zeichnen.
+            applyDisplayRotation();
+            sendDisplayHead(true);
+        }
+        else
+        {
+            if(bBLEDEBUG)
+                printfdeb("[COMMAND]rotate: ungueltiger Wert %i (erlaubt: 0/90/180/270)\n", iRot);
+        }
+
+        return;
+    }
+    else
+#endif
     if(commandCheck(msg_text+2, (char*)"settime") == 0)
     {
         // 2025.02.27 13:18:24
@@ -619,6 +654,10 @@ void commandAction(char *umsg_text, bool ble)
             delay(100);
             printlndeb("--debug    on/off\n--bledebug on/off\n--loradebug on/off\n--gpsdebug  on/off\n--softserdebug  on/off\n--wxdebug   on/off\n--display   on/off\n--setinfo   on/off\n--volt on/off   show battery voltage\n--proz on/off    show battery proz.\n");
             delay(100);
+#if defined(WP_DISP)
+            printlndeb("--rotate 0/90/180/270  E-Ink Display drehen (persistent, board-uebergreifend)\n");
+            delay(100);
+#endif
             printfdeb("--setgrc 9;..9;  set groups\n--nomsgall on/off  '*'-msg on display\n");
             delay(100);
             printlndeb("--maxv    100%% battery voltage\n--track   on/off SmartBeaconing\n--gps on/off use GPS-CHIP\n--utcoff +/-99.9 set UTC-Offset\n−−settime yyyy.mm.dd hh:mm:ss\n");

--- a/src/configuration_global.h
+++ b/src/configuration_global.h
@@ -208,3 +208,12 @@
 
 // OLED
 #define SSD1306_ADDRESS 0x3C
+
+// --- Persistenter Display-Dreh-Offset (Terminalkommando --rotate 0/90/180/270) --------------
+// g_dispRotOffset (Grad) wird board-uebergreifend ADDITIV auf die Werks-Basisrotation
+// aufaddiert: setRotation((basis + g_dispRotOffset) % 360). 0 = Werksausrichtung. Persistiert
+// als meshcom_settings.node_disp_rot (NVS "node_disrot"), beim Boot in initDisplay() gespiegelt.
+// Definition in esp32_functions.cpp. Nur Wireless Paper + Vision Master E213 (WP_DISP).
+#if defined(WP_DISP)
+extern int g_dispRotOffset;
+#endif

--- a/src/esp32/esp32_flash.cpp
+++ b/src/esp32/esp32_flash.cpp
@@ -63,6 +63,7 @@ void init_flash(void)
     snprintf(meshcom_settings.node_atxt, sizeof(meshcom_settings.node_atxt), "%s", strVar.c_str());
 
     meshcom_settings.node_sset2 = preferences.getInt("node_sset2", 0x0000);
+    meshcom_settings.node_disp_rot = preferences.getInt("node_disrot", 0);   // Display-Dreh-Offset (--rotate); Default 0 = Werksausrichtung
     meshcom_settings.node_owgpio = preferences.getInt("node_owgpio", 0);
 
     meshcom_settings.node_temp2 = preferences.getFloat("node_temp2", 0.0);
@@ -329,6 +330,7 @@ void save_settings(void)
     preferences.putString("node_atxt", strVar); 
 
     preferences.putInt("node_sset2", meshcom_settings.node_sset2);
+    preferences.putInt("node_disrot", meshcom_settings.node_disp_rot);   // Display-Dreh-Offset (--rotate)
     preferences.putInt("node_owgpio", meshcom_settings.node_owgpio);
 
     preferences.putFloat("node_temp2", meshcom_settings.node_temp2);

--- a/src/esp32/esp32_flash.h
+++ b/src/esp32/esp32_flash.h
@@ -63,6 +63,12 @@ struct s_meshcom_settings
 	char node_atxt[40] = {0};
 
 	int node_sset2 = 0x0000;
+
+	// Display-Dreh-Offset fuer das Kommando --rotate 0/90/180/270 (Grad).
+	// Board-uebergreifend ADDITIV auf die Werks-Basisrotation (siehe applyDisplayRotation()).
+	// 0 = Werksausrichtung. Persistiert in NVS (Key "node_disrot").
+	int node_disp_rot = 0;
+
 	int node_owgpio = 36;
 
 	float node_temp2 = 0;

--- a/src/esp32/esp32_functions.cpp
+++ b/src/esp32/esp32_functions.cpp
@@ -136,9 +136,32 @@ static bool detectEinkPanelIsE0213()
 }
 #endif
 
+#if defined(WP_DISP)
+// Persistenter Display-Dreh-Offset (Terminalkommando --rotate 0/90/180/270), in Grad.
+// Wird in initDisplay() aus meshcom_settings.node_disp_rot geladen und von applyDisplayRotation()
+// ADDITIV auf die Werks-Basisrotation aufaddiert. 0 = Werksausrichtung.
+int g_dispRotOffset = 0;
+
+// EINZIGE Stelle, die die Betriebs-Rotation des E-Ink setzt: Board-Werks-Basis + --rotate-Offset.
+// Wird beim Boot (startDisplay) UND live vom --rotate-Handler aufgerufen -> Boot und Live nutzen
+// GARANTIERT dieselbe Ausrichtung. setRotation() rechnet intern die Fenster-Bounds (setWindow) neu.
+void applyDisplayRotation()
+{
+    #if defined(BOARD_E213)
+    epaper_display.setRotation((90 + g_dispRotOffset) % 360);    // E213-Basis 90° (OE1KBC, ef998aa)
+    #else  // BOARD_WIRELESS_PAPER  (WP_DISP = WP || E213)
+    epaper_display.setRotation((270 + g_dispRotOffset) % 360);   // WP-Basis 270°
+    #endif
+}
+#endif
+
 void initDisplay()
 {
 #if defined(WP_DISP)
+    // Persistenten Display-Dreh-Offset (--rotate) aus den bereits geladenen Settings uebernehmen
+    // (init_flash() lief in esp32setup() VOR initDisplay()). Greift in startDisplay() + Live-Handler.
+    g_dispRotOffset = meshcom_settings.node_disp_rot;
+
     // Gemeinsame Panel-Auto-Erkennung fuer Wireless Paper (V1.1 LCMEN / V1.1.1+V1.2 E0213) UND
     // Vision Master E213. Nicht-invasiv ueber die invertierte BUSY-Polaritaet (siehe
     // detectEinkPanelIsE0213()). Loest die alte 0x2F-Chip-ID-Probe ab: die war auf dem E213
@@ -203,7 +226,14 @@ void startDisplay(char line1[20], char line2[20], char line3[20])
 
     epaper_display.landscape();
 
+    // Betriebs-Rotation (Werks-Basis + --rotate-Offset) setzen. Bei WP_DISP ueber die gemeinsame
+    // applyDisplayRotation(): Wireless Paper 270°, E213 90° (OE1KBC, ef998aa). Das setzt das global
+    // gesetztes setRotation(90) fuer WP wieder auf die korrekte 270°-Basis; E290 bleibt unveraendert.
+    #if defined(WP_DISP)
+    applyDisplayRotation();
+    #else
     epaper_display.setRotation(90); // top/down (270);
+    #endif
 
     // Start-Screen im Original-E290-Layout - nur der Board-Name ist board-spezifisch.
     // Der erkannte Panel-Controller wird zusaetzlich als DEBUG-Zeile am Terminal

--- a/src/esp32/esp32_functions.h
+++ b/src/esp32/esp32_functions.h
@@ -3,5 +3,6 @@
 
 void initDisplay();
 void startDisplay(char line1[20], char line2[20], char line3[20]);
+void applyDisplayRotation();   // Werks-Basis + --rotate-Offset aufs E-Ink anwenden (Boot + Live); nur unter WP_DISP definiert
 
 #endif


### PR DESCRIPTION
## Feature: Terminalkommando `--rotate 0/90/180/270` (E-Ink Display drehen)

Persistentes Kommando zum Drehen des E-Ink-Displays für **Heltec Wireless Paper** und **Vision Master E213**. Idee: OE1KBC (Terminalkommando statt Tastengeste).

### Nutzung
```
--rotate 0      → Werksausrichtung (Standard)
--rotate 180    → auf dem Kopf (Antenne unten statt oben)
--rotate 90     → Hochformat, 90°
--rotate 270    → Hochformat, 270°
```
Verfügbar über **USB-Serial, BLE (MeshCom-App), Telnet/NetConsole**. Persistent (überlebt Reboot).

> **Hinweis:** Praktisch sinnvoll sind nur **0** und **180** (Querformat, Antenne oben/unten). **90/270 kippen ins Hochformat** — das Textlayout ist für Querformat ausgelegt. 90/270 bleiben aber zugelassen (für eine physische 90°-Montage).

### Konzept — additiver Offset
`--rotate` setzt **keinen absoluten** Panel-Wert, sondern einen **additiven Offset** auf die board-spezifische Werks-Basisrotation:

```
effektive_rotation = (Werks-Basis + node_disp_rot) % 360      // WP-Basis 270°, E213-Basis 90°
```

Da die beiden Panels physisch um 180° zueinander verbaut sind, ergäbe ein absoluter Wert (`--rotate 90` = `setRotation(90)`) auf WP und E213 **verschiedene** physische Ausrichtungen. Der additive Offset macht die **Wirkung** von `--rotate` auf beiden Boards **identisch** (board-übergreifend konsistent).

### Architektur
`applyDisplayRotation()` (in `esp32_functions.cpp`) ist die **einzige** Stelle, die die Betriebsrotation setzt — sie wird **beim Boot** (`startDisplay()`) **und live** vom `--rotate`-Handler aufgerufen. Damit nutzen Boot und Live garantiert dieselbe Ausrichtung (keine Divergenz). Der Live-Refresh läuft über `sendDisplayHead(true)` (Voll-Refresh — die V1.1-Panels/LCMEN können kein Partial-Update).

### Nebeneffekt-Korrektur
Der bisherige **globale** `setRotation(90)` in `startDisplay()` (aus „E213 180° gedreht") drehte auch den **WP-** und **E290-Startscreen** mit. Dieser PR macht es board-spezifisch: **WP zurück auf 270°**, **E213 bleibt 90°**, **E290 unverändert**.

### Umfang / Risiko
- **6 Dateien, +87 Zeilen**, alle additiv.
- Nur unter `WP_DISP` (Wireless Paper + E213) aktiv — **alle anderen Boards unberührt**.
- `--rotate 0` = **bit-identisches Verhalten** zu vorher.
- **Am Gerät verifiziert** (WP + E213: dreht live, board-übergreifend konsistent, überlebt Reboot). Alle Board-Varianten bauen.

### Persistenz
Neues Settings-Feld `node_disp_rot` (NVS-Key `"node_disrot"`), Default `0`. NVS-Migration unkritisch (fehlender Key → Default 0).

### Geänderte Dateien
| Datei | Änderung |
|---|---|
| `esp32/esp32_flash.h` / `.cpp` | Feld `node_disp_rot` + NVS Load/Save |
| `configuration_global.h` | `extern g_dispRotOffset` (unter `WP_DISP`) |
| `esp32/esp32_functions.cpp` / `.h` | `g_dispRotOffset` + `applyDisplayRotation()` + Boot-Sync + `startDisplay()` |
| `command_functions.cpp` | `--rotate`-Handler + `--help`-Eintrag |

---
*Eingereicht von OE3LCR. Idee/Vorschlag: OE1KBC.*
