### PR TITLE
Wireless Paper: Deepsleep-Pfad an Vision Master E213 angleichen (Wakeup + Sleep-Strom + Grau-Fix)

### DIFF
--- a/src/Platforms/WirelessPaper/power_controls.cpp
+++ b/src/Platforms/WirelessPaper/power_controls.cpp
@@ -36,10 +36,13 @@ namespace Platform {
         digitalWrite(PIN_DISPLAY_RST, HIGH);
     }
 
-    void prepareToSleep() {
-
-        // Set SX1262 to SLEEP mode - Software SPI so we can "trample" stuff
-        // -----------------------------------------------------------------
+    // Set SX1262 to SLEEP mode - Software SPI so we can "trample" stuff.
+    // Bewusst SEPARAT von prepareToSleep(): erlaubt, den LoRa-RX-Strom (~mehrere mA)
+    // schon VOR dem E-Ink-Voll-Refresh zu entfernen, OHNE die Display-Versorgung (VEXT)
+    // zu kappen. Bei fast leerem Akku bekommt der energiehungrige OTP-Refresh dadurch das
+    // volle Energie-Budget (sonst graut er aus). Die Sequenz ist idempotent -> prepareToSleep()
+    // ruft sie unten erneut auf, das schadet nicht.
+    void loraToSleep() {
 
         // Default pin states
         digitalWrite(PIN_LORA_NSS, HIGH);
@@ -52,7 +55,7 @@ namespace Platform {
         pinMode(PIN_LORA_MOSI, OUTPUT);
 
         // CS LOW
-        digitalWrite(PIN_LORA_NSS, LOW); 
+        digitalWrite(PIN_LORA_NSS, LOW);
 
         // TX data and params
         shiftOut(PIN_LORA_MOSI, PIN_LORA_SCK, MSBFIRST, 0x84);  // Command: Enter SLEEP mode
@@ -60,6 +63,13 @@ namespace Platform {
 
         // CS HIGH - all done
         digitalWrite(PIN_LORA_NSS, HIGH);
+    }
+
+    void prepareToSleep() {
+
+        // Set SX1262 to SLEEP mode - Software SPI so we can "trample" stuff
+        // -----------------------------------------------------------------
+        loraToSleep();
 
 
         // Set the GPIOs for sleep

--- a/src/command_functions.cpp
+++ b/src/command_functions.cpp
@@ -52,10 +52,10 @@
 #include "bme680.h"
 #endif
 
-#if defined(BOARD_E213)
-// prepareToSleep()/loraToSleep() sind im E213-Platform-Layer (Namespace Platform) definiert
-// (VisionMasterE213/power_controls.cpp). Forward-Deklaration statt schwergewichtigem
-// Platform-Header-Include. prepareToSleep(): voller Deepsleep-Strom-Spar-Pfad (E213-Long-Press).
+#if defined(WP_DISP)
+// prepareToSleep()/loraToSleep() sind im jeweiligen Platform-Layer (Namespace Platform) definiert
+// (WirelessPaper/ bzw. VisionMasterE213/power_controls.cpp). Forward-Deklaration statt
+// schwergewichtigem Platform-Header-Include. prepareToSleep(): voller Deepsleep-Strom-Spar-Pfad.
 namespace Platform { void prepareToSleep(); void loraToSleep(); }
 #endif
 
@@ -851,10 +851,16 @@ void commandAction(char *umsg_text, bool ble)
             }
         #else
             #if defined(WP_DISP)
+            // GRAU-FIX (v.a. Akku-leer-Pfad): Bei fast leerem Akku konkurriert der energiehungrige
+            // E-Ink-Voll-Refresh (OTP-Waveform) mit dem noch laufenden SX1262-RX (~mehrere mA) um die
+            // schwache Akkuspannung -> der interne Display-Boost schwingt nicht an, der Refresh wird
+            // grau. Daher den LoRa-Chip ZUERST schlafen legen und der Akkuspannung kurz Zeit zum
+            // Erholen geben (beim manuellen Deepsleep mit voller Spannung schadet der Vorlauf nicht).
+            Platform::loraToSleep();
+            delay(200);   // LiPo erholt sich nach Lastwegnahme
             // E-Ink vor dem Schlafen sichtbar loeschen (sonst bleibt das letzte Bild stehen und
             // der Deepsleep ist am bistabilen Panel nicht erkennbar). #992.
             wpShowDeepSleep();
-            #if defined(BOARD_E213)
             // PRG-Button (GPIO0, active LOW) als Aufweckquelle armieren. Ohne Wakeup-Quelle
             // schlaeft der ESP32-S3 nach dem Deepsleep bis zum Power-Cycle/RESET - das bistabile
             // E-Ink bliebe scheinbar fuer immer eingefroren. Mit ext1 weckt ein Tastendruck.
@@ -869,10 +875,9 @@ void commandAction(char *umsg_text, bool ble)
             // Schlafstrom senken. Kurzes Settle, damit der E-Ink-Voll-Refresh aus wpShowDeepSleep()
             // sicher fertig ist, dann prepareToSleep(): SX1262 -> SLEEP (sonst Dauer-RX ~5 mA),
             // VEXT (Display-/LoRa-Versorgung) aus, LoRa-Pins hochohmig -> Ziel ~18 uA. Ohne das
-            // entlaedt der "Deepsleep" den Akku weiter. E213 nutzt dieselbe Sequenz (gleiche Pins).
+            // entlaedt der "Deepsleep" den Akku weiter. WP und E213 nutzen dieselbe Sequenz.
             delay(100);
             Platform::prepareToSleep();
-            #endif
             #endif
             #if not defined(BOARD_RAK4630)
             esp_deep_sleep_start();


### PR DESCRIPTION
## Wireless Paper: Deepsleep-Pfad an Vision Master E213 angleichen (Wakeup + Sleep-Strom + Grau-Fix)

Der `--deepsleep`-Pfad ist auf dem **Vision Master E213** bereits vollständig (Wakeup-Quelle + Strom-Spar-Sequenz), auf dem **Wireless Paper** im committfähigen Default-Build aber unvollständig. Dieser PR gleicht die WP an das E213 an — beide teilen denselben 2,13"-Display-/LoRa-Pfad (`WP_DISP`).

### Motivation (2 zusammenhängende Befunde)

**1. WP-Default: `--deepsleep` armiert keine Wakeup-Quelle und senkt den Strom nicht.**
Im Default-Build `env:wireless-paper` lief der Deepsleep-Block bisher nur unter `#if defined(BOARD_E213)` — der WP-Zweig fiel also durch. Folgen auf der WP (Long-Press-Deepsleep **und** Low-Voltage-Auto-Deepsleep):
- **Keine Aufweckquelle** → das Gerät war nur per RESET/Power-Cycle weckbar. Das bistabile E-Ink behält sein Bild → das Modul wirkt dauerhaft „eingefroren".
- **`prepareToSleep()` wurde nicht aufgerufen** → der SX1262 blieb im Dauer-RX (~mehrere mA), VEXT blieb an. Der „Deepsleep" senkte den Strom nicht, der (oft ohnehin leere) LiPo entlud sich weiter.

**2. Grau-Fix fehlt (WP-Default + E213):** Bei fast leerem Akku konkurriert der energiehungrige E-Ink-Voll-Refresh (OTP-Waveform) mit dem noch laufenden SX1262-RX um die schwache Akkuspannung → der interne Display-Boost schwingt nicht an, die „AKKU LOW"-Anzeige wird **grau/unlesbar** — genau wenn sie den User informieren soll.

### Änderung

**`src/command_functions.cpp`**
- Forward-Deklaration `namespace Platform { prepareToSleep(); loraToSleep(); }`: Guard `#if defined(BOARD_E213)` → **`#if defined(WP_DISP)`** (jetzt für WP **und** E213 verfügbar).
- `--deepsleep`-Handler: Der Wakeup-/`prepareToSleep()`-Block stand unter `#if defined(BOARD_E213)` und lag bereits im äußeren `#if defined(WP_DISP)`. Der innere `BOARD_E213`-Guard entfällt → der Block läuft nun für **alle** `WP_DISP`-Boards (WP + E213). Die Wakeup-Logik ist board-agnostisch (GPIO0/PRG immer + `iButtonPin`: WP=GPIO0, E213=GPIO21).
- **Grau-Fix eingefügt:** `Platform::loraToSleep()` + `delay(200)` **vor** `wpShowDeepSleep()` — der LoRa-RX-Strom wird entfernt, bevor der E-Ink-Refresh läuft, **ohne** die Display-Versorgung (VEXT) zu kappen. Beim manuellen Deepsleep (volle Spannung) schadet der Vorlauf nicht.

**`src/Platforms/WirelessPaper/power_controls.cpp`**
- Die SX1262-SLEEP-Sequenz (SW-SPI, Befehl `0x84`) wird aus `prepareToSleep()` in eine eigene Funktion **`loraToSleep()`** herausgezogen; `prepareToSleep()` ruft sie nun auf. Damit ist der reine LoRa-Sleep separat verfügbar (für den Grau-Fix), ohne Verhaltensänderung von `prepareToSleep()`. Das **E213 hatte `loraToSleep()` bereits** separat — die WP wird hier nur nachgezogen.

### Wirkung

| Build | Vorher | Nachher |
|---|---|---|
| `env:wireless-paper` (Default) | kein Wakeup (nur RESET), Dauer-RX im „Schlaf", AKKU-LOW grau | PRG/Button weckt, ~µA statt mA, AKKU-LOW lesbar |
| `env:vision-master-e213` | Wakeup + `prepareToSleep` ✓, aber AKKU-LOW grau | zusätzlich Grau-Fix → AKKU-LOW lesbar |
| E290 & alle Nicht-`WP_DISP` | — | **unberührt** |

### Umfang / Risiko

- **2 Dateien, +27/−12 Zeilen.** Nur `WP_DISP` (Wireless Paper + Vision Master E213) betroffen — E290 und alle anderen Boards unverändert.
- `prepareToSleep()` verhält sich unverändert (nur intern in `loraToSleep()` + Rest aufgeteilt).
- Die exakte `prepareToSleep()`-Sequenz läuft seit Wochen erprobt in der craith-WP-Preview; der **WP-Default-PRG-Wakeup wurde am Gerät bestätigt** (Long-Press → Deepsleep → PRG weckt).
- Alle Default-Envs bauen: `wireless-paper`, `vision-master-e213`, `vision-master-e290`.

---
*Eingereicht von OE3LCR. Grundlage: Audit-Befunde zum WP/E213-Deepsleep-Pfad.*
