### PR TITLE
fix: prevent NUL bytes from wedging the shared console command buffer

### DIFF
--- a/src/esp32/esp32_main.cpp
+++ b/src/esp32/esp32_main.cpp
@@ -3863,11 +3863,16 @@ void checkSerialCommand(void)
         if(Serial.available() > 0)
         {
             char rd = (char)Serial.read();
-            printdeb(rd);   // echo to USB + net console via MSerial
-            strText[iTxtPos] = rd;
-            if(iTxtPos < (int)sizeof(strText) - 1)
+            // Drop NUL bytes: UART RX noise (e.g. unpowered USB-UART bridge on battery
+            // supply) delivers 0x00 which strlen() cannot see and wedges the parser.
+            if(rd != 0x00)
             {
-                iTxtPos++;
+                printdeb(rd);   // echo to USB + net console via MSerial
+                strText[iTxtPos] = rd;
+                if(iTxtPos < (int)sizeof(strText) - 1)
+                {
+                    iTxtPos++;
+                }
             }
         }
     }
@@ -3883,7 +3888,7 @@ void checkSerialCommand(void)
             if(netConsoleAvailable()) netConsoleRead();
             if(netConsoleAvailable()) netConsoleRead();
         }
-        else if(rd != '\r')         // strip CR, keep LF
+        else if(rd != '\r' && rd != 0x00)   // strip CR, keep LF; drop NUL (see above)
         {
             printdeb(rd);       // echo back via MSerial (server-side echo)
             strText[iTxtPos] = rd;
@@ -3896,6 +3901,17 @@ void checkSerialCommand(void)
     #endif
 
     iTxtLen = strlen(strText);
+
+    // Self-healing: normally every stored byte is non-NUL, so strlen == iTxtPos.
+    // A stray NUL in the buffer breaks that invariant and would block command
+    // processing forever (early return below never reaches the memset). Discard.
+    if(iTxtLen != iTxtPos)
+    {
+        memset(strText, 0x00, sizeof(strText));
+        iTxtPos = 0;
+        return;
+    }
+
     if(iTxtLen == 0)
         return;
 


### PR DESCRIPTION
## Problem

A node on battery supply stops responding to console commands on **both** the USB serial console and the net console: every command is echoed back, periodic output such as `[HEAP]` keeps arriving, but no command is ever executed (not even the unconditional `...wrong command` reply). Rebooting or re-flashing does not help — the node goes deaf again within seconds. Observed on a Heltec V3; a TTGO LoRa32 V2.1 on the same network/firmware is unaffected.

## Root cause

`checkSerialCommand()` (src/esp32/esp32_main.cpp) accumulates bytes from USB serial and the net console into the shared buffer `strText[]` via `iTxtPos`, but evaluates the buffer with `strlen()`:

- A single **0x00 byte as the first byte** makes `strlen()` return 0, so the function early-returns forever and never reaches the `memset` that clears the buffer. Everything received afterwards is stored *behind* the NUL and stays invisible to the parser.
- A 0x00 byte **inside** a started `--command` wedges the same way: the trailing-newline check can never succeed, so the reset is unreachable.

On battery supply the board's USB-UART bridge is unpowered and the ESP32's UART0 RX line floats/clamps low, which the UART decodes as noise bytes including 0x00 (break). Since Heltec V3 builds run with `ARDUINO_USB_CDC_ON_BOOT` disabled (`Serial` = UART0), the parser wedges seconds after every boot. The echo path (`printdeb`) is unaffected, which makes the node look "half alive".

Verified live against a wedged Heltec V3 over the net console: spontaneous noise bytes were echoed right after authentication, and neither `--help` nor an invalid command produced any reply, while a healthy TTGO answered both. With this fix flashed (OTA), the same Heltec responds normally on battery.

## Fix

- Drop 0x00 bytes on both input paths (USB serial and net console) before echo/store.
- Self-healing guard: for every valid buffer content `strlen(strText) == iTxtPos` holds, because only non-NUL bytes are stored. On mismatch, discard the buffer instead of blocking until reboot.

Note: `src/nrf52/nrf52_main.cpp` contains the same pattern and could receive the same guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)