### PR TITLE
WLAN: Sentinel "none" zusätzlich zu "empty" für offene APs akzeptieren

### DIFF
--- a/src/udp_functions.cpp
+++ b/src/udp_functions.cpp
@@ -611,7 +611,8 @@ void sendMeshComUDP()
     else
       WiFi.setTxPower(WIFI_POWER_8_5dBm);
 
-    if(strcmp(meshcom_settings.node_pwd, "empty") == 0)
+    // offenes WLAN: "empty" (neu) ODER "none" (Bestand, Flash-Default und Hilfetext) akzeptieren
+    if(strcmp(meshcom_settings.node_pwd, "empty") == 0 || strcmp(meshcom_settings.node_pwd, "none") == 0)
       WiFi.begin(meshcom_settings.node_ssid, NULL);
     else
       WiFi.begin(meshcom_settings.node_ssid, meshcom_settings.node_pwd);  
@@ -635,7 +636,8 @@ void sendMeshComUDP()
     else
       WiFi.setTxPower(WIFI_POWER_8_5dBm);
 
-    if(strcmp(meshcom_settings.node_pwd, "empty") == 0)
+    // offenes WLAN: "empty" (neu) ODER "none" (Bestand, Flash-Default und Hilfetext) akzeptieren
+    if(strcmp(meshcom_settings.node_pwd, "empty") == 0 || strcmp(meshcom_settings.node_pwd, "none") == 0)
       WiFi.begin(meshcom_settings.node_ssid, NULL, WiFi.channel(best_idx), WiFi.BSSID(best_idx),true);
     else
       WiFi.begin(meshcom_settings.node_ssid, meshcom_settings.node_pwd, WiFi.channel(best_idx), WiFi.BSSID(best_idx),true);


### PR DESCRIPTION
# WLAN-Verbindung zu offenen APs: Sentinel "none" zusätzlich zu "empty" akzeptieren

## Kurzfassung

Commit `5cae7e2` ("Change password check from 'none' to 'empty'") hat den Sentinel-Wert für „offenes WLAN" im Feld `node_pwd` von `"none"` auf `"empty"` umgestellt — allerdings **nur an den beiden Prüfstellen** in `sendMeshComUDP()`. Alle Stellen, die diesen Wert **erzeugen** (Flash-Default, Werksreset, Hilfetext), liefern weiterhin `"none"`.

Dadurch verbinden sich Nodes, die an einem **offenen WLAN** betrieben werden, nach dem Update nicht mehr — still und über Reboots hinweg persistent.

Dieser PR macht die Prüfung **abwärtskompatibel**: Es werden **beide** Werte (`"empty"` und `"none"`) als „offenes WLAN" akzeptiert. Die mit `5cae7e2` eingeführte Absicht (`"empty"` soll funktionieren) bleibt vollständig erhalten.

## Geänderter Code

Datei: `src/udp_functions.cpp` — zwei Stellen in `sendMeshComUDP()` (Zeilen ~614 und ~638), jeweils die `if`-Bedingung vor `WiFi.begin(...)`:

```c
// vorher
if(strcmp(meshcom_settings.node_pwd, "empty") == 0)

// nachher
// offenes WLAN: "empty" (neu) ODER "none" (Bestand, Flash-Default und Hilfetext) akzeptieren
if(strcmp(meshcom_settings.node_pwd, "empty") == 0 || strcmp(meshcom_settings.node_pwd, "none") == 0)
```

Umfang: **1 Datei, 4 Zeilen eingefügt, 2 entfernt** (davon 2 Kommentarzeilen). Keine weiteren Änderungen, keine Umbenennungen, keine Formatierungsänderungen.

## Warum ist das nötig? (Analyse)

### 1. Der Wert `"empty"` wird nirgends im Code erzeugt

Eine Suche über den gesamten Quellbaum zeigt: Der String `"empty"` kommt **ausschließlich** in den beiden mit `5cae7e2` geänderten Vergleichszeilen vor. Es gibt keine Stelle, die `"empty"` jemals nach `node_pwd` schreibt:

- **kein** Flash-Default,
- **keine** Normalisierung in `--setpwd`,
- **kein** BLE-/Web-Setzweg,
- **keine** Dokumentation.

Der `NULL`-Zweig ist damit praktisch nur noch erreichbar, wenn ein Nutzer das (undokumentierte) `--setpwd empty` eintippt.

### 2. Der Bestandswert ist `"none"` — inklusive Flash-Default

`node_pwd` wird beim Start mit dem Default `"none"` aus dem NVS geladen:

```c
// src/esp32/esp32_flash.cpp:161-162
strVar = preferences.getString("node_lpwd", "none");
snprintf(meshcom_settings.node_pwd, sizeof(meshcom_settings.node_pwd), "%s", strVar.c_str());
```

Auch der Werksreset setzt beide Felder gemeinsam auf `"none"`:

```c
// src/esp32/esp32_main.cpp:1108-1112
if(memcmp(meshcom_settings.node_ssid, "XX0XXX", 6) == 0)
{
    snprintf(meshcom_settings.node_ssid, sizeof(meshcom_settings.node_ssid), (char*)"none");
    snprintf(meshcom_settings.node_pwd,  sizeof(meshcom_settings.node_pwd),  (char*)"none");
}
```

Und der eingebaute Hilfetext nennt weiterhin `none`:

```c
// src/command_functions.cpp:643
--setpwd  WLAN PASSWORD/none
```

### 3. Warum die Verbindung dadurch tatsächlich fehlschlägt

Im Arduino-ESP32-Core (geprüft in 2.0.17 — der von den ESP32-Umgebungen genutzten Version — sowie in 3.3.7) gilt in `WiFiSTA.cpp` bzw. `STA.cpp`:

```c
if(passphrase != NULL && passphrase[0] != 0)
{
    ...
    wifi_config.sta.threshold.authmode = _minSecurity;   // Default: WIFI_AUTH_WPA2_PSK
}
```

Daraus folgt:

| Aufruf | Ergebnis |
|---|---|
| `WiFi.begin(ssid, NULL)` | `authmode` bleibt `WIFI_AUTH_OPEN` → offener AP wird verbunden |
| `WiFi.begin(ssid, "")` | identisch zu `NULL` (Leerstring wird abgefangen) → offener AP wird verbunden |
| `WiFi.begin(ssid, "none")` | `authmode` = `WIFI_AUTH_WPA2_PSK` → **offener AP wird vom Scan-Filter verworfen, es kommt keine Verbindung zustande** |

Mit `node_pwd == "none"` landet die Verbindung seit `5cae7e2` im `else`-Zweig und damit im letzten Fall.

### 4. Betroffene Konstellation

Betroffen ist jeder Node mit **echter SSID** und `node_pwd == "none"` — also insbesondere Nutzer, die ein offenes WLAN verwenden und das Passwortfeld nie gesetzt haben (Flash-Default) oder bewusst `none` gesetzt und persistiert haben. `save_settings()` schreibt diesen Wert zurück, der Zustand ist also dauerhaft.

**Nicht betroffen:**

- Nodes mit einem echten WLAN-Passwort (beide Zweige verhalten sich unverändert).
- Der reine Werkszustand: dort ist `node_ssid == "none"`, und `sendMeshComUDP()` steigt bereits vorher aus:

  ```c
  // src/udp_functions.cpp:522
  if(meshcom_settings.node_ssid[0] == 0x00 || is_equ(meshcom_settings.node_ssid, "none"))
      return false;
  ```

- Nodes, bei denen `--setpwd none` auf einer neueren Firmware getippt wurde: dort greift die Normalisierung in `src/command_functions.cpp:3450`, die das Feld leert (`memset`), und ein Leerstring verhält sich wie `NULL`.

## Warum dieser Lösungsweg

Es wurden zwei Varianten erwogen:

1. **Alle erzeugenden Stellen auf `"empty"` umstellen** (Flash-Default, Werksreset, Hilfetext) — würde eine Migration bestehender Konfigurationen und eine Doku-Anpassung erfordern und bestehende Nodes bis zum manuellen Nachziehen offline lassen.
2. **Beide Sentinels akzeptieren** (dieser PR) — minimal-invasiv, sofort abwärtskompatibel, ohne Migration, ohne Änderung an Doku oder Hilfetext.

Variante 2 wurde gewählt, weil sie mit zwei Zeilen auskommt und keine bestehende Installation bricht. Falls langfristig ausschließlich `"empty"` gelten soll, kann `"none"` später entfernt werden, sobald Flash-Default, Werksreset und Hilfetext umgestellt und eine Migration vorhanden ist.

## Test

- Kompiliert (`pio run -e wireless-paper`) ohne Fehler oder neue Warnungen.
- Der Codepfad ist board-unabhängig (`sendMeshComUDP()` gilt für alle ESP32-Varianten); es wurden keine boardspezifischen Zweige angefasst.
