### PR TITLE
Fix BME280 support on LilyGo T-Echo

### DIFF
--- a/src/bmx280.cpp
+++ b/src/bmx280.cpp
@@ -123,7 +123,7 @@ void setupBMX280(bool bNewStart)
 		bBMPON=false;
 		bBMEON=false;
 		bmx_found=false;
-		return; 
+		return;
 	}
 
   	if(bBMPON)
@@ -135,7 +135,11 @@ void setupBMX280(bool bNewStart)
 			Wire.endTransmission(true);
 		#endif
 
-		bmx_i2c_address = I2C_ADDRESS_BMP;
+		#ifdef BMP280_I2C_ADDRESS
+			bmx_i2c_address = BMP280_I2C_ADDRESS;
+		#else
+			bmx_i2c_address = I2C_ADDRESS_BMP;
+		#endif
 	}
   	else
     	if(bBMEON)
@@ -147,7 +151,11 @@ void setupBMX280(bool bNewStart)
 				Wire.endTransmission(true);
 			#endif
 
-			bmx_i2c_address = I2C_ADDRESS_BME;
+			#ifdef BME280_I2C_ADDRESS
+				bmx_i2c_address = BME280_I2C_ADDRESS;
+			#else
+				bmx_i2c_address = I2C_ADDRESS_BME;
+			#endif
 		}
     	else
       		return;
@@ -163,9 +171,9 @@ void setupBMX280(bool bNewStart)
 	bmx_found = false;
 
 	fTemp = 0.0;
-	fPress = 0.0;	
+	fPress = 0.0;
 	fHum = 0.0;
-		
+
 	#if defined(BOARD_TBEAM_V3) || (BOARD_E22_S3)
 		Wire.end();
 		Wire.begin(I2C_SDA, I2C_SCL);
@@ -184,7 +192,7 @@ void setupBMX280(bool bNewStart)
 
 	//by default sensing is disabled and must be enabled by setting a non-zero
 	//oversampling setting.
-	//set an oversampling setting for pressure and temperature measurements. 
+	//set an oversampling setting for pressure and temperature measurements.
 	bmx280.writeOversamplingPressure(BMx280MI::OSRS_P_x16);
 	bmx280.writeOversamplingTemperature(BMx280MI::OSRS_T_x16);
 
@@ -192,12 +200,10 @@ void setupBMX280(bool bNewStart)
 	if (bmx280.isBME280())
 		bmx280.writeOversamplingHumidity(BMx280MI::OSRS_H_x16);
 
-	
-	if(bBMEON)
-    	Serial.printf("[INIT]...BME280 startet\n");
-
-	if(bBMPON)
-    	Serial.printf("[INIT]...BMP280 startet\n");
+	if(bmx280.isBME280())
+		Serial.printf("[INIT]...BME280 started\n");
+	else
+		Serial.printf("[INIT]...BMP280 started\n");
 
 	bmx_found = true;
 }

--- a/variants/t_echo/configuration.h
+++ b/variants/t_echo/configuration.h
@@ -18,6 +18,7 @@ definitions for RAK4631
 #define ENABLE_RTC
 
 #define ENABLE_BMX280
+#define BME280_I2C_ADDRESS 0x77
 
 //#define ENABLE_BMP390
 //#define ENABLE_AHT20

--- a/variants/t_echo/variant.h
+++ b/variants/t_echo/variant.h
@@ -140,8 +140,8 @@ extern "C"
  */
 #define WIRE_INTERFACES_COUNT 2
 
-#define PIN_WIRE_SDA (13)
-#define PIN_WIRE_SCL (14)
+#define PIN_WIRE_SDA (26)
+#define PIN_WIRE_SCL (27)
 #define PIN_WIRE1_SDA (24)
 #define PIN_WIRE1_SCL (25)
 

--- a/variants/t_echo/variant.h
+++ b/variants/t_echo/variant.h
@@ -138,12 +138,10 @@ extern "C"
 /*
  * Wire Interfaces
  */
-#define WIRE_INTERFACES_COUNT 2
+#define WIRE_INTERFACES_COUNT 1
 
 #define PIN_WIRE_SDA (26)
 #define PIN_WIRE_SCL (27)
-#define PIN_WIRE1_SDA (24)
-#define PIN_WIRE1_SCL (25)
 
 // QSPI Pins
 #define PIN_QSPI_SCK 3	// 19


### PR DESCRIPTION
## Problem

On the LilyGo T-Echo with BME280, the sensor is not detected:

```text
[INIT]...setupBMX280 - I2C:76
[INIT]...begin() failed. check your BMx280 Interface and I2C Address.

[INIT]...setupBMX280 - I2C:77
[INIT]...begin() failed. check your BMx280 Interface and I2C Address.
```

The I²C scanner also reports no devices:

```text
[I2C ]...Scanner started


[I2C-0]...start
[I2C-X]...no devices found
```

The `t_echo` variant was using the RAK4630 I²C pin definitions (`PIN_WIRE_SDA 13` and `PIN_WIRE_SCL 14`), which do not match the T-Echo hardware.

According to the [LilyGo T-Echo reference documentation](https://github.com/xinyuan-lilygo/t-echo#t-echo-pinout), the I²C bus is wired with SDA on `P0.26` and SCL on `P0.27`.

There is also an address mismatch. `bmx280.cpp` uses `0x76` for the BME280, while the T-Echo's onboard BME280 has SDO tied high and therefore uses I²C address `0x77`.

## Fix

The T-Echo variant now declares the correct I²C SDA and SCL pins (`P0.26` and `P0.27`), uses I²C address `0x77` for the onboard BME280, and removes the unused second Wire interface.

The changes are limited to the T-Echo variant.

## Verified on hardware

After the fix, the I²C scanner detects both the onboard RTC and BME280:

```text
[I2C ]...Scanner started


[I2C-0]...start
[I2C-0]...0x51 RTC PCF8563
[I2C-0]...0x77 BME280/BMP280/BME680/BMP390

[INIT]...setupBMX280 - I2C:77
[INIT]...BME280 started
```

Temperature, pressure, and humidity are also correctly displayed and included in the position beacon.

<img width="768" height="1020" alt="PXL_20260821_101113310~2" src="https://github.com/user-attachments/assets/913529c9-5a24-4e47-aa07-d692fa78e847" />