### PR TITLE
Mheard-JSON: Puffergroesse an serializeJson uebergeben statt gemessener Laenge

### DIFF
--- a/src/mheard_functions.cpp
+++ b/src/mheard_functions.cpp
@@ -345,10 +345,13 @@ void updateMheard(struct mheardLine &mheardLine, uint8_t isPhoneReady)
     // send to Phone
     uint8_t bleBuffer[MAX_MSG_LEN_PHONE] = {0};
     bleBuffer[0] = 0x44;
-    serializeJson(mhdoc, bleBuffer+1, measureJson(mhdoc)+1);
+    // Puffergroesse begrenzen, nicht die gemessene JSON-Laenge: serializeJson schreibt
+    // hoechstens so viele Bytes wie erlaubt und liefert die tatsaechlich geschriebene
+    // Anzahl zurueck. 1 Byte Header + Null-Terminator bleiben reserviert.
+    size_t json_len = serializeJson(mhdoc, bleBuffer+1, sizeof(bleBuffer)-1);
 
     if(isPhoneReady == 1)
-        addBLEOutBuffer(bleBuffer, measureJson(mhdoc)+1);
+        addBLEOutBuffer(bleBuffer, json_len+1);
 
     #if defined(BOARD_T_DECK) || defined(BOARD_T_DECK_PLUS)
 
@@ -648,9 +651,10 @@ void sendMheard()
                 // send to Phone
                 uint8_t bleBuffer[MAX_MSG_LEN_PHONE] = {0};
                 bleBuffer[0] = 0x44;
-                serializeJson(mhdoc, bleBuffer+1, measureJson(mhdoc)+1);
+                // wie oben: Puffergroesse begrenzen statt der gemessenen JSON-Laenge
+                size_t json_len = serializeJson(mhdoc, bleBuffer+1, sizeof(bleBuffer)-1);
 
-                addBLEComToOutBuffer(bleBuffer, measureJson(mhdoc)+1);
+                addBLEComToOutBuffer(bleBuffer, json_len+1);
             }
         }
     }


### PR DESCRIPTION

serializeJson(doc, buffer, size) versteht size als KAPAZITAET des Puffers und schreibt hoechstens so viele Bytes. Uebergeben wurde bisher measureJson()+1, also die benoetigte Laenge — damit ist die Grenze wirkungslos: waechst das JSON ueber MAX_MSG_LEN_PHONE (300), schreibt serializeJson ueber bleBuffer hinaus. Das ist ein Stack-Puffer in updateMheard(), und die Funktion laeuft bei jedem empfangenen Paket.

Heute passt es (ein MH-Datensatz liegt bei rund 150 Zeichen), die Reserve ist aber nicht zugesichert: ein langes Rufzeichen, ein DIST-Wert mit vielen Nachkommastellen oder ein spaeter ergaenztes Feld verschieben sie. Der Fehler waere dann kein abgeschnittener Datensatz, sondern ein Speicherueberschreiber an der haeufigsten Stelle des Empfangspfads.

Die Info-Ausgabe in command_functions.cpp behandelt denselben Fall bereits richtig (Begrenzung auf MAX_MSG_LEN_PHONE - 2 nach dem Serialisieren). Dieser Patch bringt den Mheard-Pfad auf dasselbe Verhalten, hier direkt ueber sizeof(bleBuffer), sodass die Laenge nicht zweimal gemessen werden muss.

Geaendert sind nur die Argumente eines bestehenden Aufrufs und die Verwendung seines Rueckgabewerts, an beiden Fundstellen gleich (Live-Pfad und Ausgabe der gespeicherten Liste). Verhalten bleibt unveraendert, solange das JSON in den Puffer passt; passt es nicht, wird es abgeschnitten statt darueber hinaus geschrieben.