### PR TITLE
MH-JSON: Ursprungsrufzeichen und Gateway-Kennung mitsenden

### DIFF
--- a/src/mheard_functions.cpp
+++ b/src/mheard_functions.cpp
@@ -341,6 +341,12 @@ void updateMheard(struct mheardLine &mheardLine, uint8_t isPhoneReady)
     mhdoc["PL"] = mheardLine.mh_path_len;
     mhdoc["MESH"] = mheardLine.mh_mesh;
     mhdoc["NCNT"] = mheardLine.mh_ncount;
+    // Ursprung des Pakets: CALL ist der letzte Hop, SRC der Absender. Beides liegt hier
+    // bereits im Struct (lora_functions.cpp fuellt es aus aprsmsg.msg_source_call).
+    mhdoc["SRC"] = mheardLine.mh_sourcecallsign.c_str();
+    // HEY-Baken eines Gateways tragen "HG" statt "H" als Ziel - dieselbe Auskunft, die
+    // updateMheardPath() unten schon fuer die eigene Pfadtabelle auswertet (| 0x80).
+    mhdoc["GW"] = (mheardLine.mh_destinationpath == "HG") ? 1 : 0;
 
     // send to Phone
     uint8_t bleBuffer[MAX_MSG_LEN_PHONE] = {0};


### PR DESCRIPTION
Beide Werte liegen an dieser Stelle bereits im mheardLine-Struct und werden nur nicht serialisiert:

- mh_sourcecallsign wird in lora_functions.cpp aus aprsmsg.msg_source_call gefuellt. Das MH-JSON kennt bisher nur CALL, den LETZTEN HOP. Bei einem weitergeleiteten Paket fehlt damit die Angabe, von wem es urspruenglich kam.
- mh_destinationpath traegt bei einer HEY-Bake "H" bzw. "HG". Die Firmware wertet das bereits aus: updateMheardPath() merkt sich das Gateway-Bit fuer die eigene Pfadtabelle (mheardPathLen[ipos] = mh_path_len | 0x80). An die App geht die Auskunft aber nicht.

Nutzen aus Anwendungssicht: eine App kann heute nicht sagen, WER eine weitergeleitete Bake urspruenglich gesendet hat, und muss aus dem gw-Bit RATEN, ob ein Knoten ein Gateway ist. Das gw-Bit wird naemlich auch gesetzt, wenn ein Gateway ein Paket bloss ueber HF weiterreicht — es trennt also nicht zwischen "eingespeist" und "weitergereicht". Mit SRC und GW ist beides entschieden statt geschaetzt, ohne jede Aenderung am RF Protokoll.

Gemessen an einem Standort mit einem einzigen direkten Nachbarn: in rund 75 Minuten 16 HEY-Beobachtungen, davon 5 zuordenbar (die eigenen Baken des Nachbarn) und 11 nicht — weitergeleitete Baken fremder Knoten, deren Ursprung die Firmware kennt. Zwei Drittel der Information verfallen ungenutzt.

Bewusst NUR im Live-Pfad (updateMheard), nicht in sendMheard: dort wird mheardLine aus dem gespeicherten |-String mheardBuffer[iset] rekonstruiert, und der enthaelt weder Ursprungsrufzeichen noch Ziel-Pfad. Die beiden Felder waeren dort leer bzw. immer 0 — eine falsche Aussage ist schlechter als eine fehlende. Wer sie auch in der gespeicherten Liste haben moechte, muesste das Speicher- format erweitern; das waere eine eigene Entscheidung und gehoert nicht in diesen Patch.

Laengenwirkung gering: rund 26 Zeichen, der Puffer ist MAX_MSG_LEN_PHONE (300) und ein Datensatz liegt bei etwa 150.

Gebaut mit pio run -e ttgo_tbeam (espressif32 6.13.0, ArduinoJson 7.4.3): erfolgreich, keine neuen Warnungen.