### PR TITLE
Info-JSON: Build-Datum (FLASH_VERSION) mitsenden

### DIFF
--- a/src/command_functions.cpp
+++ b/src/command_functions.cpp
@@ -4866,6 +4866,10 @@ void commandAction(char *umsg_text, bool ble)
 
             idoc["TYP"] = "I";
             idoc["FWVER"] = fwver;
+            // Build-Datum als eigener Schluessel: FWVER traegt nur "4.35 p", damit sind
+            // Sub-Releases fuer die App nicht unterscheidbar. FWVER selbst bleibt
+            // unveraendert, damit bestehende Apps weiter damit rechnen koennen.
+            idoc["FWDATE"] = FLASH_VERSION;
             idoc["CALL"] = meshcom_settings.node_call;
             idoc["ID"] = _GW_ID;
             idoc["HWID"] = BOARD_HARDWARE;


### PR DESCRIPTION
Die App bekommt heute nur FWVER, zusammengesetzt aus SOURCE_VERSION und SOURCE_VERSION_SUB, also z. B. "4.35 p". Damit lassen sich SUB-RELEASES nicht unterscheiden: zwei Staende mit demselben Buchstaben sehen fuer die App identisch aus, obwohl sie es nicht sind. Fuer Fehlersuche und Support ist genau das der Unterschied, auf den es ankommt — ein Nutzer kann nicht sagen, welchen Stand er geflasht hat.

Der Wert ist bereits vorhanden: configuration_global.h definiert FLASH_VERSION (derzeit 20260724). Er wird nur nicht gemeldet.

Bewusst ein NEUER Schluessel statt einer Aenderung an FWVER: bestehende Apps parsen dieses Feld, ein geaendertes Format wuerde sie brechen. FWDATE ist additiv und stoert niemanden, der es nicht kennt.

Laenge: das Info-JSON liegt damit bei grob 260 Zeichen. Die vorhandene Begrenzung greift bei MAX_MSG_LEN_PHONE - 2 = 298, es bleibt also Reserve. Der Hinweis ist hier wichtiger als beim Mheard-Pfad, weil eine Ueberschreitung an dieser Stelle das JSON abschneiden und damit unbrauchbar machen wuerde.

Ein kurzer git-Hash waere zusaetzlich denkbar, erfordert aber ein PlatformIO-Build-Flag und damit einen Eingriff in den Build — nicht Teil dieses Patches.

Gebaut mit pio run -e ttgo_tbeam (espressif32 6.13.0, ArduinoJson 7.4.3): erfolgreich, keine neuen Warnungen.