### PR TITLE
Fix marker color assignment, orphaned map markers, and own-position r…

### DIFF
--- a/src/esp32/esp32_main.cpp
+++ b/src/esp32/esp32_main.cpp
@@ -65,6 +65,8 @@ Timeout timerSerial;
     extern GPSData gpsData;
 #endif
 
+#include <t-deck/tdeck_sdmap.h>
+
 #if defined(HAS_TFT_CONNECT)
 #include "tft_display_functions.h"
 
@@ -3051,12 +3053,32 @@ void esp32loop()
         }
 
 
-        #if defined(BOARD_T_DECK) || defined(BOARD_T_DECK_PLUS) || defined(BOARD_T_DECK_PRO)
+                    #if defined(BOARD_T_DECK) || defined(BOARD_T_DECK_PLUS) || defined(BOARD_T_DECK_PRO)
             gps_refresh_track++;
             if(gps_refresh_track > 4)
             {
                 tdeck_refresh_track_view();
                 gps_refresh_track=0;
+            }
+
+            // SD-Kartenmodus: alle 30 Sekunden pruefen, ob die eigene Position die
+            // aktuell geladene Kachel verlassen hat, und bei Bedarf nachladen -
+            // nur solange der Kartenbildschirm auch tatsaechlich sichtbar ist.
+            static unsigned long sdmap_boundary_timer = 0;
+            if ((sdmap_boundary_timer + 30000UL) < millis())
+            {
+                sdmap_boundary_timer = millis();
+
+                if (lv_tabview_get_tab_act(tv) == 3 && (gpsData.latitude != 0.0 || gpsData.longitude != 0.0))
+                {
+                    if (!sdmap_in_current_tile(gpsData.latitude, gpsData.longitude))
+                    {
+                        sdmap_lastKnownLat = gpsData.latitude;
+                        sdmap_lastKnownLon = gpsData.longitude;
+                        sdmap_refresh(map_ta, sdmap_lastKnownLat, sdmap_lastKnownLon);
+                        refresh_map(meshcom_settings.node_map);
+                    }
+                }
             }
         #endif
 

--- a/src/t-deck/event_functions.cpp
+++ b/src/t-deck/event_functions.cpp
@@ -885,7 +885,14 @@ void tabview_event_cb(lv_event_t * e)
                 break;
             case 2: // POS
                 break;
-            case 3: // MAP
+                        case 3: // MAP
+                if (gpsData.latitude != 0.0 || gpsData.longitude != 0.0)
+                {
+                    sdmap_lastKnownLat = gpsData.latitude;
+                    sdmap_lastKnownLon = gpsData.longitude;
+                }
+                sdmap_refresh(map_ta, sdmap_lastKnownLat, sdmap_lastKnownLon);
+                refresh_map(meshcom_settings.node_map);
                 break;
             case 4: // GPS
                 tdeck_refresh_track_view();

--- a/src/t-deck/event_functions.cpp
+++ b/src/t-deck/event_functions.cpp
@@ -843,6 +843,7 @@ void btn_event_handler_zoomin(lv_event_t * e)
 
         sdmap_zoom_in();
         sdmap_refresh(map_ta, sdmap_lastKnownLat, sdmap_lastKnownLon);
+        refresh_map(meshcom_settings.node_map);
         add_map_point(meshcom_settings.node_call, sdmap_lastKnownLat, sdmap_lastKnownLon, true);
     }
 }
@@ -862,6 +863,7 @@ void btn_event_handler_zoomout(lv_event_t * e)
 
         sdmap_zoom_out();
         sdmap_refresh(map_ta, sdmap_lastKnownLat, sdmap_lastKnownLon);
+        refresh_map(meshcom_settings.node_map);
         add_map_point(meshcom_settings.node_call, sdmap_lastKnownLat, sdmap_lastKnownLon, true);
     }
 }

--- a/src/t-deck/lv_obj_functions.cpp
+++ b/src/t-deck/lv_obj_functions.cpp
@@ -102,7 +102,8 @@ lv_obj_t    *btn_batt_label2;
 lv_obj_t    *btn_batt_label4;
 lv_obj_t    *text_input;
 lv_obj_t    *position_ta;
-lv_obj_t    *map_ta;
+lv_obj_t    *map_ta; 
+lv_obj_t    * map_no_data_label = NULL;
 lv_obj_t    *mheard_ta;
 lv_obj_t    *path_ta;
 lv_obj_t    *tv;
@@ -1450,11 +1451,19 @@ void setDisplayLayout(lv_obj_t *parent)
     ////////////////////////////////////////////////////////////////////////////
     // MAP
     map_ta = lv_img_create(t7);
+
+    map_no_data_label = lv_label_create(t7);
+    lv_label_set_text(map_no_data_label, "Keine Karte ausgewaehlt\noder vorhanden!");
+    lv_obj_set_style_text_color(map_no_data_label, lv_color_white(), 0);
+    lv_obj_set_style_text_align(map_no_data_label, LV_TEXT_ALIGN_CENTER, 0);
+    lv_label_set_long_mode(map_no_data_label, LV_LABEL_LONG_WRAP);
+    lv_obj_set_width(map_no_data_label, 200);
+    lv_obj_align(map_no_data_label, LV_ALIGN_CENTER, 0, 0);
+    lv_obj_add_flag(map_no_data_label, LV_OBJ_FLAG_HIDDEN);
     // Kontrast erhöhen
     lv_obj_set_style_img_recolor(map_ta, lv_color_black(), 0);
     lv_obj_set_style_img_recolor_opa(map_ta, LV_OPA_40, 0);   // 0 = kein Effekt, 255 = komplett schwarz
     
-    lv_obj_align(map_ta, LV_ALIGN_CENTER, 0, 0);
     lv_obj_align(map_ta, LV_ALIGN_CENTER, 0, 0);
     lv_obj_set_size(map_ta, 300, LV_VER_RES * 0.74);
     

--- a/src/t-deck/lv_obj_functions.cpp
+++ b/src/t-deck/lv_obj_functions.cpp
@@ -401,7 +401,7 @@ int map_y[MAX_MAP] = {0};
 
 //////////////////////////////////////////////
 // MAP points
-lv_obj_t * map_point[MAX_POINTS];
+lv_obj_t * map_point[MAX_POINTS];lv_obj_t * map_point_label[MAX_POINTS];
 
 String map_point_call[MAX_POINTS];
 double map_point_lat[MAX_POINTS];
@@ -1450,6 +1450,9 @@ void setDisplayLayout(lv_obj_t *parent)
     ////////////////////////////////////////////////////////////////////////////
     // MAP
     map_ta = lv_img_create(t7);
+    // Kontrast erhöhen
+    lv_obj_set_style_img_recolor(map_ta, lv_color_black(), 0);
+    lv_obj_set_style_img_recolor_opa(map_ta, LV_OPA_40, 0);   // 0 = kein Effekt, 255 = komplett schwarz
     
     lv_obj_align(map_ta, LV_ALIGN_CENTER, 0, 0);
     lv_obj_align(map_ta, LV_ALIGN_CENTER, 0, 0);
@@ -1744,6 +1747,11 @@ void add_map_point(String callsign, double dlat, double dlon, bool bHome)
                 delay(19);
             }
 
+            if(map_point_label[ip] != NULL)
+            {
+                lv_obj_del(map_point_label[ip]);
+            }
+
             ipoint = ip;
 
             bFound = true;
@@ -1787,8 +1795,14 @@ void add_map_point(String callsign, double dlat, double dlon, bool bHome)
             delay(10);
         }
 
+        if(map_point_label[map_point_count] != NULL)
+        {
+            lv_obj_del(map_point_label[map_point_count]);
+        }
+
         map_point_call[map_point_count] = ""; // wieder frei machen;
         map_point[map_point_count] = NULL;
+        map_point_label[map_point_count] = NULL;
         map_point_lat[map_point_count] = 0.0;
         map_point_lon[map_point_count] = 0.0;
     }
@@ -1807,6 +1821,13 @@ void add_map_point(String callsign, double dlat, double dlon, bool bHome)
 
     lv_obj_set_style_radius(map_point[ipoint] , LV_RADIUS_CIRCLE, 0);
 
+    // Rufzeichen als kleine Beschriftung unter dem Punkt
+    map_point_label[ipoint] = lv_label_create(map_ta);
+    lv_label_set_text(map_point_label[ipoint], callsign.c_str());
+    lv_obj_set_style_text_font(map_point_label[ipoint], &lv_font_montserrat_12, 0);
+    lv_obj_set_style_text_color(map_point_label[ipoint], lv_color_black(), 0);
+    lv_obj_set_pos(map_point_label[ipoint], x - 5, y + 11);
+
     // MAP screen
     /*
     lv_tabview_set_act(tv, 3, LV_ANIM_OFF);
@@ -1823,7 +1844,8 @@ void init_map()
 {
     for(int im=0; im<MAX_POINTS; im++)
     {
-        map_point[im] = NULL;
+        map_point[im] = NULL; map_point_label[im] = NULL;
+        
         map_point_call[im] = "";
         
         map_pos_call[im] = "";
@@ -1841,7 +1863,6 @@ void refresh_map(int iMap)
     if(bDEBUG)
         Serial.printf("[ MAP ]...set to %i - %s\n", iMap, getMap(iMap).c_str());
 
-    // pos update
     for(int im = 0; im < MAX_POINTS; im++)
     {
         if(map_pos_call[im].length() > 0)
@@ -1850,7 +1871,14 @@ void refresh_map(int iMap)
             if(map_pos_call[im].compareTo(meshcom_settings.node_call) == 0)
                 bHome=true;
 
-            add_map_point(map_pos_call[im], map_pos_lat[im], map_pos_lon[im], bHome);
+            if (bHome)
+            {
+                add_map_point(map_pos_call[im], sdmap_lastKnownLat, sdmap_lastKnownLon, bHome);
+            }
+            else
+            {
+                add_map_point(map_pos_call[im], map_pos_lat[im], map_pos_lon[im], bHome);
+            }
         }
     }
 }
@@ -1891,17 +1919,12 @@ void set_map(int iMap)
     lv_obj_align(map_ta, LV_ALIGN_CENTER, 0, 0);
     lv_obj_set_size(map_ta, map_x[iMap], map_y[iMap]);
     lv_obj_align(map_ta, LV_ALIGN_CENTER, 0, 0);
-
+    lv_obj_clean(map_ta);   // entfernt WIRKLICH alle Kind-Objekte (Punkte + Labels), auch verwaiste
     for(int im = 0; im < MAX_POINTS; im++)
     {
-        if(map_point[im] != NULL && lv_obj_is_valid(map_point[im]))
-        {
-            lv_obj_del(map_point[im]);
-
-            delay(10);
-        }
-
-        map_point[im]=NULL;
+        map_point[im] = NULL;
+        map_point_label[im] = NULL;
+        map_point_call[im] = "";
     }
 
     refresh_map(iMap);
@@ -3542,22 +3565,22 @@ void tdeck_add_pos_point(String callsign, double u_dlat, char lat_c, double u_dl
 
     for(int ip = 0; ip < MAX_POINTS; ip++)
     {
-        if(map_pos_call[ip] == callsign)
-        {
-            if(map_pos_lat[ip] == dlat && map_pos_lon[ip] == dlon)
-                return;
+        if (map_pos_call[ip] == callsign)
+{
+    if(map_pos_lat[ip] == dlat && map_pos_lon[ip] == dlon)
+        return;
 
-            map_pos_lat[ip] = dlat;
-            map_pos_lon[ip] = dlon;
+    map_pos_lat[ip] = dlat;
+    map_pos_lon[ip] = dlon;
 
-            bool bHome=false;
-            if (map_pos_call[map_pos_count].compareTo(meshcom_settings.node_call) == 0)
-                bHome=true;
+    bool bHome=false;
+    if (callsign.compareTo(meshcom_settings.node_call) == 0)
+        bHome=true;
 
-            add_map_point(callsign, dlat, dlon, bHome);
+    add_map_point(callsign, dlat, dlon, bHome);
 
-            return;
-        }
+    return;
+}
     }
 
     map_pos_call[map_pos_count] = callsign;

--- a/src/t-deck/lv_obj_functions_extern.h
+++ b/src/t-deck/lv_obj_functions_extern.h
@@ -64,6 +64,7 @@ extern lv_obj_t    *btn_batt_label4;
 extern lv_obj_t    *text_input;
 extern lv_obj_t    *position_ta;
 extern lv_obj_t    *map_ta;
+extern lv_obj_t    *map_no_data_label;
 extern double       sdmap_lastKnownLat;
 extern double       sdmap_lastKnownLon;
 extern lv_obj_t    *mheard_ta;

--- a/src/t-deck/tdeck_main.cpp
+++ b/src/t-deck/tdeck_main.cpp
@@ -23,6 +23,7 @@
 #include <Wire.h>
 #include <SD.h>
 #include "tdeck_sdmap.h"
+#include <gps_functions.h>
 
 #include <AceButton.h>
 using namespace ace_button;
@@ -239,7 +240,12 @@ bool setupSD()
                 else
                     strMaps[i] = "-";
             }
-
+            
+            if (meshcom_settings.node_map >= sdmap_get_set_count())
+            {
+                Serial.printf("[ SDMAP ]...Gespeicherte Kartenauswahl (%d) nicht gefunden, falle zurueck auf Set 0\n", meshcom_settings.node_map);
+                meshcom_settings.node_map = 0;
+            }
             lv_dropdown_set_options(dropdown_mapselect, getMapDropbox().c_str());
             return true;
         }
@@ -577,22 +583,34 @@ static void keypad_read(lv_indev_drv_t *indev_drv, lv_indev_data_t *data)
                 bSPEC=true;
             }
 
-            if(act_key == 0x2b) // SYM + O
+                       if(act_key == 0x2b) // SYM + O -> Zoom raus (wie Touch-Button)
             {
-                if (meshcom_settings.node_map > 0)
-                    meshcom_settings.node_map--;
-                
-                set_map(meshcom_settings.node_map);
+                if (gpsData.latitude != 0.0 || gpsData.longitude != 0.0)
+                {
+                    sdmap_lastKnownLat = gpsData.latitude;
+                    sdmap_lastKnownLon = gpsData.longitude;
+                }
+
+                sdmap_zoom_out();
+                sdmap_refresh(map_ta, sdmap_lastKnownLat, sdmap_lastKnownLon);
+                refresh_map(meshcom_settings.node_map);
+                add_map_point(meshcom_settings.node_call, sdmap_lastKnownLat, sdmap_lastKnownLon, true);
 
                 bSPEC=true;
             }
 
-            if(act_key == 0x2d) // SYM + I
+            if(act_key == 0x2d) // SYM + I -> Zoom rein (wie Touch-Button)
             {
-                if (meshcom_settings.node_map < MAX_MAP-1)
-                    meshcom_settings.node_map++;
+                if (gpsData.latitude != 0.0 || gpsData.longitude != 0.0)
+                {
+                    sdmap_lastKnownLat = gpsData.latitude;
+                    sdmap_lastKnownLon = gpsData.longitude;
+                }
 
-                set_map(meshcom_settings.node_map);
+                sdmap_zoom_in();
+                sdmap_refresh(map_ta, sdmap_lastKnownLat, sdmap_lastKnownLon);
+                refresh_map(meshcom_settings.node_map);
+                add_map_point(meshcom_settings.node_call, sdmap_lastKnownLat, sdmap_lastKnownLon, true);
 
                 bSPEC=true;
             }

--- a/src/t-deck/tdeck_sdmap.cpp
+++ b/src/t-deck/tdeck_sdmap.cpp
@@ -3,6 +3,7 @@
 #include <SD.h>
 #include <math.h>
 #include <loop_functions_extern.h>   // fuer bDEBUG
+#include "lv_obj_functions_extern.h"
 // lodepng-Funktionen direkt deklarieren statt lodepng.h einzubinden
 // (das spart uns fragile verschachtelte Include-Pfade tief in der LVGL-Bibliothek -
 // die eigentlichen Funktionen sind laengst mitkompiliert, LVGL nutzt sie ja selbst)
@@ -124,23 +125,51 @@ bool sdmap_refresh(lv_obj_t * img, double lat, double lon)
     sdmap_lastLat = lat;
     sdmap_lastLon = lon;
 
-    int xtile = (int)sdmap_lon2xf(lon, sdmap_zoom);
-    int ytile = (int)sdmap_lat2yf(lat, sdmap_zoom);
-    sdmap_currentTileX = xtile;
-    sdmap_currentTileY = ytile;
-
+    int useZoom = sdmap_zoom;
+    int xtile = 0, ytile = 0;
     char path[64];
-    snprintf(path, sizeof(path), "%s/%d/%d/%d.png", sdmap_dirs[sdmap_activeSet], sdmap_zoom, xtile, ytile);
-    if (!SD.exists(path))
+    bool bTileFound = false;
+
+    while (useZoom >= SDMAP_MIN_ZOOM)
     {
-        Serial.printf("[ SDMAP ]...Kachel fehlt: %s\n", path);
+        xtile = (int)sdmap_lon2xf(lon, useZoom);
+        ytile = (int)sdmap_lat2yf(lat, useZoom);
+
+        snprintf(path, sizeof(path), "%s/%d/%d/%d.png", sdmap_dirs[sdmap_activeSet], useZoom, xtile, ytile);
+
+        if (SD.exists(path))
+        {
+            bTileFound = true;
+            break;
+        }
+
+        useZoom--;
+    }
+
+    if (!bTileFound)
+    {
+        Serial.printf("[ SDMAP ]...Keine Kachel fuer diese Position in %s gefunden (Zoom %d bis %d geprueft)\n",
+                      sdmap_dirs[sdmap_activeSet], sdmap_zoom, SDMAP_MIN_ZOOM);
+        if (map_no_data_label != NULL)
+            lv_obj_clear_flag(map_no_data_label, LV_OBJ_FLAG_HIDDEN);
         return false;
     }
+
+    if (useZoom != sdmap_zoom)
+    {
+        Serial.printf("[ SDMAP ]...Zoom automatisch angepasst: %d -> %d (Originalzoom hatte keine Kachel)\n", sdmap_zoom, useZoom);
+        sdmap_zoom = useZoom;
+    }
+
+    sdmap_currentTileX = xtile;
+    sdmap_currentTileY = ytile;
 
     File f = SD.open(path, FILE_READ);
     if (!f)
     {
         Serial.printf("[ SDMAP ]...Kachel konnte nicht geoeffnet werden: %s\n", path);
+        if (map_no_data_label != NULL)
+            lv_obj_clear_flag(map_no_data_label, LV_OBJ_FLAG_HIDDEN);
         return false;
     }
 
@@ -150,6 +179,8 @@ bool sdmap_refresh(lv_obj_t * img, double lat, double lon)
     {
         Serial.println("[ SDMAP ]...malloc fuer PNG-Rohdaten fehlgeschlagen");
         f.close();
+        if (map_no_data_label != NULL)
+            lv_obj_clear_flag(map_no_data_label, LV_OBJ_FLAG_HIDDEN);
         return false;
     }
 
@@ -160,10 +191,11 @@ bool sdmap_refresh(lv_obj_t * img, double lat, double lon)
     {
         Serial.println("[ SDMAP ]...Lesefehler beim Kachel-Import");
         free(pngRaw);
+        if (map_no_data_label != NULL)
+            lv_obj_clear_flag(map_no_data_label, LV_OBJ_FLAG_HIDDEN);
         return false;
     }
 
-        // PNG SELBST dekodieren (RGBA, lodepng_decode32 ist bereits im Projekt gelinkt)
     unsigned char * rgba32 = nullptr;
     unsigned pngW = 0, pngH = 0;
     unsigned err = lodepng_decode32(&rgba32, &pngW, &pngH, pngRaw, fsize);
@@ -174,10 +206,11 @@ bool sdmap_refresh(lv_obj_t * img, double lat, double lon)
         Serial.printf("[ SDMAP ]...PNG-Dekodierfehler %u: %s\n", err, lodepng_error_text(err));
         if (rgba32 != nullptr)
             free(rgba32);
+        if (map_no_data_label != NULL)
+            lv_obj_clear_flag(map_no_data_label, LV_OBJ_FLAG_HIDDEN);
         return false;
     }
 
-    // In LVGLs natives Farbformat konvertieren (RGB565 bei LV_COLOR_DEPTH=16)
     size_t pixelCount = (size_t)pngW * pngH;
     size_t nativeSize = pixelCount * sizeof(lv_color_t);
 
@@ -186,13 +219,14 @@ bool sdmap_refresh(lv_obj_t * img, double lat, double lon)
     {
         Serial.println("[ SDMAP ]...ps_malloc fuer Kachel fehlgeschlagen");
         free(rgba32);
+        if (map_no_data_label != NULL)
+            lv_obj_clear_flag(map_no_data_label, LV_OBJ_FLAG_HIDDEN);
         return false;
     }
 
     lv_color_t * dst = (lv_color_t *)newbuf;
     for (size_t i = 0; i < pixelCount; i++)
     {
-        // rgba32 liegt als R,G,B,A pro Pixel vor (4 Bytes) - Alpha ignorieren, Kacheln sind deckend
         dst[i] = lv_color_make(rgba32[i * 4 + 0], rgba32[i * 4 + 1], rgba32[i * 4 + 2]);
     }
 
@@ -206,13 +240,16 @@ bool sdmap_refresh(lv_obj_t * img, double lat, double lon)
     sdmap_buf    = newbuf;
     sdmap_bufLen = nativeSize;
 
-    sdmap_dsc.header.cf = LV_IMG_CF_TRUE_COLOR;   // schon fertig dekodiert!
+    sdmap_dsc.header.cf = LV_IMG_CF_TRUE_COLOR;
     sdmap_dsc.header.w  = (lv_coord_t)pngW;
     sdmap_dsc.header.h  = (lv_coord_t)pngH;
     sdmap_dsc.data      = sdmap_buf;
     sdmap_dsc.data_size = sdmap_bufLen;
 
     lv_img_set_src(img, &sdmap_dsc);
+
+    if (map_no_data_label != NULL)
+        lv_obj_add_flag(map_no_data_label, LV_OBJ_FLAG_HIDDEN);
 
     Serial.printf("[ SDMAP ]...Kachel geladen & dekodiert: %s (%ux%u, %u Bytes)\n",
                   path, pngW, pngH, (unsigned)nativeSize);

--- a/src/t-deck/tdeck_sdmap.cpp
+++ b/src/t-deck/tdeck_sdmap.cpp
@@ -98,7 +98,6 @@ void sdmap_init()
 
             snprintf(sdmap_dirs[sdmap_setCount], sizeof(sdmap_dirs[sdmap_setCount]), "/maps/%s", base);
 
-            // Vorhandene Zoomstufen dieses Sets ermitteln (Ordnernamen 0,1,2,... darunter)
             int minZ = 999, maxZ = -1;
             File zoomRoot = SD.open(sdmap_dirs[sdmap_setCount]);
             if (zoomRoot && zoomRoot.isDirectory())
@@ -287,21 +286,3 @@ bool sdmap_refresh(lv_obj_t * img, double lat, double lon)
     sdmap_dsc.data_size = sdmap_bufLen;
 
     lv_img_set_src(img, &sdmap_dsc);
-
-    if (map_no_data_label != NULL)
-        lv_obj_add_flag(map_no_data_label, LV_OBJ_FLAG_HIDDEN);
-
-    Serial.printf("[ SDMAP ]...Kachel geladen & dekodiert: %s (%ux%u, %u Bytes)\n",
-                  path, pngW, pngH, (unsigned)nativeSize);
-
-    return true;
-}
-
-void sdmap_project(double lat, double lon, int16_t * x, int16_t * y)
-{
-    double xf = sdmap_lon2xf(lon, sdmap_zoom);
-    double yf = sdmap_lat2yf(lat, sdmap_zoom);
-
-    *x = (int16_t)((xf - floor(xf)) * SDMAP_TILE_PX);
-    *y = (int16_t)((yf - floor(yf)) * SDMAP_TILE_PX);
-}

--- a/src/t-deck/tdeck_sdmap.cpp
+++ b/src/t-deck/tdeck_sdmap.cpp
@@ -3,10 +3,9 @@
 #include <SD.h>
 #include <math.h>
 #include <loop_functions_extern.h>   // fuer bDEBUG
-#include "lv_obj_functions_extern.h"
+#include "lv_obj_functions_extern.h" // fuer map_no_data_label
+
 // lodepng-Funktionen direkt deklarieren statt lodepng.h einzubinden
-// (das spart uns fragile verschachtelte Include-Pfade tief in der LVGL-Bibliothek -
-// die eigentlichen Funktionen sind laengst mitkompiliert, LVGL nutzt sie ja selbst)
 extern "C" {
     unsigned lodepng_decode32(unsigned char** out, unsigned* w, unsigned* h,
                                const unsigned char* in, size_t insize);
@@ -17,28 +16,10 @@ static char sdmap_dirs[SDMAP_SET_COUNT][40];
 static char sdmap_names[SDMAP_SET_COUNT][SDMAP_NAME_LEN];
 static int  sdmap_setCount  = 0;
 static int  sdmap_activeSet = 0;
-static int sdmap_currentTileX = -1;
-static int sdmap_currentTileY = -1;
-
-
-
-void sdmap_set_active_set(int idx)
-{
-    if (idx < 0) idx = 0;
-    if (idx >= SDMAP_SET_COUNT) idx = SDMAP_SET_COUNT - 1;
-    sdmap_activeSet = idx;
-}
-
-int sdmap_get_set_count()
-{
-    return sdmap_setCount;
-}
-
-const char * sdmap_get_set_name(int idx)
-{
-    if (idx < 0 || idx >= sdmap_setCount) return "";
-    return sdmap_names[idx];
-}
+static int  sdmap_currentTileX = -1;
+static int  sdmap_currentTileY = -1;
+static int  sdmap_setMinZoom[SDMAP_SET_COUNT];
+static int  sdmap_setMaxZoom[SDMAP_SET_COUNT];
 
 static int      sdmap_zoom   = 8;
 static uint8_t *sdmap_buf    = nullptr;
@@ -65,6 +46,29 @@ bool sdmap_in_current_tile(double lat, double lon)
     int xt = (int)sdmap_lon2xf(lon, sdmap_zoom);
     int yt = (int)sdmap_lat2yf(lat, sdmap_zoom);
     return (xt == sdmap_currentTileX && yt == sdmap_currentTileY);
+}
+
+void sdmap_set_active_set(int idx)
+{
+    if (idx < 0) idx = 0;
+    if (idx >= SDMAP_SET_COUNT) idx = SDMAP_SET_COUNT - 1;
+    sdmap_activeSet = idx;
+
+    if (sdmap_zoom < sdmap_setMinZoom[idx])
+        sdmap_zoom = sdmap_setMinZoom[idx];
+    if (sdmap_zoom > sdmap_setMaxZoom[idx])
+        sdmap_zoom = sdmap_setMaxZoom[idx];
+}
+
+int sdmap_get_set_count()
+{
+    return sdmap_setCount;
+}
+
+const char * sdmap_get_set_name(int idx)
+{
+    if (idx < 0 || idx >= sdmap_setCount) return "";
+    return sdmap_names[idx];
 }
 
 void sdmap_init()
@@ -94,7 +98,43 @@ void sdmap_init()
 
             snprintf(sdmap_dirs[sdmap_setCount], sizeof(sdmap_dirs[sdmap_setCount]), "/maps/%s", base);
 
-            Serial.printf("[ SDMAP ]...Kartenset %d gefunden: %s\n", sdmap_setCount + 1, sdmap_dirs[sdmap_setCount]);
+            // Vorhandene Zoomstufen dieses Sets ermitteln (Ordnernamen 0,1,2,... darunter)
+            int minZ = 999, maxZ = -1;
+            File zoomRoot = SD.open(sdmap_dirs[sdmap_setCount]);
+            if (zoomRoot && zoomRoot.isDirectory())
+            {
+                File zoomEntry = zoomRoot.openNextFile();
+                while (zoomEntry)
+                {
+                    if (zoomEntry.isDirectory())
+                    {
+                        const char * zn = zoomEntry.name();
+                        const char * zbase = strrchr(zn, '/');
+                        zbase = zbase ? zbase + 1 : zn;
+
+                        int z = atoi(zbase);
+                        if (z >= 0 && z <= SDMAP_MAX_ZOOM)
+                        {
+                            if (z < minZ) minZ = z;
+                            if (z > maxZ) maxZ = z;
+                        }
+                    }
+                    zoomEntry = zoomRoot.openNextFile();
+                }
+                zoomRoot.close();
+            }
+
+            if (maxZ < 0)
+            {
+                minZ = SDMAP_MIN_ZOOM;
+                maxZ = SDMAP_MAX_ZOOM;
+            }
+
+            sdmap_setMinZoom[sdmap_setCount] = minZ;
+            sdmap_setMaxZoom[sdmap_setCount] = maxZ;
+
+            Serial.printf("[ SDMAP ]...Kartenset %d gefunden: %s (Zoom %d-%d)\n",
+                          sdmap_setCount + 1, sdmap_dirs[sdmap_setCount], minZ, maxZ);
 
             sdmap_setCount++;
         }
@@ -110,13 +150,13 @@ int sdmap_get_zoom()
 
 void sdmap_zoom_in()
 {
-    if (sdmap_zoom < SDMAP_MAX_ZOOM)
+    if (sdmap_zoom < sdmap_setMaxZoom[sdmap_activeSet])
         sdmap_zoom++;
 }
 
 void sdmap_zoom_out()
 {
-    if (sdmap_zoom > SDMAP_MIN_ZOOM)
+    if (sdmap_zoom > sdmap_setMinZoom[sdmap_activeSet])
         sdmap_zoom--;
 }
 

--- a/src/t-deck/tdeck_sdmap.h
+++ b/src/t-deck/tdeck_sdmap.h
@@ -4,30 +4,32 @@
 #include <Arduino.h>
 #include <lvgl.h>
 
-#define SDMAP_MIN_ZOOM 0
-#define SDMAP_MAX_ZOOM 13
-#define SDMAP_TILE_PX  256
 #define SDMAP_SET_COUNT 5
 #define SDMAP_NAME_LEN  24
+#define SDMAP_MIN_ZOOM  0
+#define SDMAP_MAX_ZOOM  20   // grobe Obergrenze zur Absicherung, echte Grenze wird pro Set ermittelt
+#define SDMAP_TILE_PX   256
 
-void sdmap_set_active_set(int idx);
-int  sdmap_get_set_count();
-const char * sdmap_get_set_name(int idx);
-
-// Einmalig aufrufen, nachdem SD.begin() erfolgreich war
+// Muss einmalig aufgerufen werden, nachdem SD.begin() erfolgreich war
 void sdmap_init();
 
-// Aktuellen Zoomlevel abfragen / veraendern (0..12, geklemmt)
+// Aktuellen Zoomlevel abfragen / veraendern (innerhalb der Grenzen des aktiven Sets)
 int  sdmap_get_zoom();
 void sdmap_zoom_in();
 void sdmap_zoom_out();
 
+// Waehlt eines von mehreren Kartensets auf der SD-Karte aus (0..SDMAP_SET_COUNT-1)
+void sdmap_set_active_set(int idx);
+int  sdmap_get_set_count();
+const char * sdmap_get_set_name(int idx);
+
 // Laedt die passende Kachel fuer lat/lon beim aktuellen Zoom und zeigt sie in img an.
-// Rueckgabe true, wenn die Kachel erfolgreich geladen wurde.
 bool sdmap_refresh(lv_obj_t * img, double lat, double lon);
-bool sdmap_in_current_tile(double lat, double lon);
 
 // Liefert die Pixelposition (0..255) von lat/lon innerhalb der zuletzt geladenen Kachel.
 void sdmap_project(double lat, double lon, int16_t * x, int16_t * y);
+
+// Prueft, ob lat/lon in der aktuell geladenen Kachel liegt.
+bool sdmap_in_current_tile(double lat, double lon);
 
 #endif


### PR DESCRIPTION
## Zusammenfassung

Folge-Verbesserungen zum SD-Karten-Feature aus PR #1087: mehrere Bugfixes bei der Positions-Markierung, automatisches Kartenverhalten (kein schwarzer Bildschirm mehr in gängigen Fällen) sowie ein Absturz-Fix beim Booten.

## Positions-Marker & Farbe

- Bugfix: Die eigene Station wurde teils fälschlich rot statt blau angezeigt — falscher Array-Index bei der "Zuhause"-Erkennung in `tdeck_add_pos_point()`, jetzt korrekt anhand des tatsächlichen Rufzeichens geprüft.
- Rufzeichen wird als kleine schwarze Beschriftung unter jedem Positions-Punkt angezeigt.
- "Verwaiste" Marker aus vorherigen Kartenständen werden beim Kartenwechsel jetzt zuverlässig entfernt (`lv_obj_clean()` statt Einzel-Nachverfolgung über Arrays).
- Die eigene Position nutzt beim Neuzeichnen (z. B. bei jedem Zoom) konsequent die zuverlässigste bekannte GPS-Position (`sdmap_lastKnownLat`/`sdmap_lastKnownLon`), statt sich auf möglicherweise veraltete Beacon-Daten zu verlassen.

## Automatisches Karten-Verhalten

- Die Karte wird jetzt sofort aktualisiert, sobald der Kartenbildschirm angezeigt wird (vorher oft schwarz, bis einmal gezoomt wurde).
- Automatisches Nachladen der passenden Kachel alle 30 Sekunden, falls die eigene Position die aktuell geladene Kachel verlassen hat — nur solange der Kartenbildschirm sichtbar ist.
- Fehlt für die aktuelle Zoomstufe eine Kachel, wird automatisch eine gröbere Zoomstufe probiert, statt einen leeren Bildschirm zu zeigen.
- Die gespeicherte Kartenauswahl wird beim Booten validiert und automatisch auf ein gültiges Set zurückgesetzt, falls sie auf einen leeren/nicht mehr existierenden Slot verweist.

## Bedienung & Rückmeldung

- Sichtbarer Hinweistext ("Keine Karte ausgewählt oder vorhanden!") statt schwarzem Bildschirm, falls trotz Fallback keine Kachel geladen werden kann.
- Tastatur-Shortcuts (SYM+I / SYM+O) zoomen jetzt konsistent zu den Touch-Buttons innerhalb des aktuellen Kartensets (vorher: Wechsel zwischen den inzwischen entfernten alten Bitmap-Karten).
- Leichte Kontrastanhebung der Kartenkacheln über LVGLs `img_recolor`-Stil (Richtung Schwarz eingefärbt), da viele OSM-Kachel-Sets recht hell/blass sind.

## Stabilität

- Absturz beim Booten behoben (Guru Meditation Error / LoadProhibited): Der `map_ta`-Bildobjekt wurde beim letzten Umbau versehentlich nicht mehr initialisiert, wodurch ein Nullpointer-Zugriff beim Setzen des Kontrast-Stils entstand.

## Getestet

T-Deck Plus, mehrtägiger Betrieb inkl. Standortwechsel und variierendem GPS-Empfang.