### PR TITLE
URGENT FIX: Restore missing code in tdeck_sdmap.cpp (broke dev build)

### DIFF
--- a/src/t-deck/tdeck_sdmap.cpp
+++ b/src/t-deck/tdeck_sdmap.cpp
@@ -164,25 +164,45 @@ bool sdmap_refresh(lv_obj_t * img, double lat, double lon)
     sdmap_lastLat = lat;
     sdmap_lastLon = lon;
 
-    int xtile = (int)sdmap_lon2xf(lon, sdmap_zoom);
-    int ytile = (int)sdmap_lat2yf(lat, sdmap_zoom);
+    int useZoom = sdmap_zoom;
+    int xtile = 0, ytile = 0;
+    char path[64];
+    bool bTileFound = false;
+
+    while (useZoom >= SDMAP_MIN_ZOOM)
+    {
+        xtile = (int)sdmap_lon2xf(lon, useZoom);
+        ytile = (int)sdmap_lat2yf(lat, useZoom);
+
+        snprintf(path, sizeof(path), "%s/%d/%d/%d.png", sdmap_dirs[sdmap_activeSet], useZoom, xtile, ytile);
+
+        if (SD.exists(path))
+        {
+            bTileFound = true;
+            break;
+        }
+
+        useZoom--;
+    }
+
+    if (!bTileFound)
+    {
+        Serial.printf("[ SDMAP ]...Keine Kachel fuer diese Position in %s gefunden (Zoom %d bis %d geprueft)\n",
+                      sdmap_dirs[sdmap_activeSet], sdmap_zoom, SDMAP_MIN_ZOOM);
+        if (map_no_data_label != NULL)
+            lv_obj_clear_flag(map_no_data_label, LV_OBJ_FLAG_HIDDEN);
+        return false;
+    }
+
+    if (useZoom != sdmap_zoom)
+    {
+        Serial.printf("[ SDMAP ]...Zoom automatisch angepasst: %d -> %d (Originalzoom hatte keine Kachel)\n", sdmap_zoom, useZoom);
+        sdmap_zoom = useZoom;
+    }
 
     sdmap_currentTileX = xtile;
     sdmap_currentTileY = ytile;
 
-    char path[64];
-    snprintf(path, sizeof(path), "%s/%d/%d/%d.png", sdmap_dirs[sdmap_activeSet], sdmap_zoom, xtile, ytile);
-
-    if (!SD.exists(path))
-    {
-        Serial.printf("[ SDMAP ]...Kachel fehlt: %s\n", path);
-
-        snprintf(path, sizeof(path), "%s/1/1/1.png", sdmap_dirs[sdmap_activeSet]);
-        if (!SD.exists(path))
-            return false;
-    }
-
-    
     File f = SD.open(path, FILE_READ);
     if (!f)
     {
@@ -266,3 +286,21 @@ bool sdmap_refresh(lv_obj_t * img, double lat, double lon)
     sdmap_dsc.data_size = sdmap_bufLen;
 
     lv_img_set_src(img, &sdmap_dsc);
+
+    if (map_no_data_label != NULL)
+        lv_obj_add_flag(map_no_data_label, LV_OBJ_FLAG_HIDDEN);
+
+    Serial.printf("[ SDMAP ]...Kachel geladen & dekodiert: %s (%ux%u, %u Bytes)\n",
+                  path, pngW, pngH, (unsigned)nativeSize);
+
+    return true;
+}
+
+void sdmap_project(double lat, double lon, int16_t * x, int16_t * y)
+{
+    double xf = sdmap_lon2xf(lon, sdmap_zoom);
+    double yf = sdmap_lat2yf(lat, sdmap_zoom);
+
+    *x = (int16_t)((xf - floor(xf)) * SDMAP_TILE_PX);
+    *y = (int16_t)((yf - floor(yf)) * SDMAP_TILE_PX);
+}


### PR DESCRIPTION
## Problem

Beim Zusammenführen von PR #1095 über den GitHub-Web-Editor ist ein Teil von `src/t-deck/tdeck_sdmap.cpp` verloren gegangen. Die Funktion `sdmap_refresh()` bricht seitdem mitten im Code ab (fehlende schließende Klammer, fehlendes `return true;`), und die komplette Funktion `sdmap_project()` fehlt am Dateiende.

**Dadurch kompiliert `dev` aktuell nicht.**

## Fix

Stellt den vollständigen, korrekten Inhalt von `sdmap_refresh()` und `sdmap_project()` wieder her — inhaltlich identisch zu dem, was ursprünglich in PR #1095 vorgesehen war (Auto-Zoom-Fallback bei fehlender Kachel, "keine Karte"-Hinweistext, korrekter Abschluss der PNG-Dekodierung).

Getestet: lokaler Build läuft wieder fehlerfrei durch (`pio run --environment t_deck_plus`).

Bitte möglichst zeitnah mergen, da `dev` aktuell nicht baubar ist.