### PR TITLE
Stabilitaets- und Speichersicherheits-Fixes aus dem Feldbetrieb (82 Aenderungen)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -86,6 +86,45 @@ lib_deps =
 	adafruit/Adafruit SHTC3 Library@^1.0.1
 	adafruit/Adafruit LPS2X@^2.0.6
 
+; Frueher stand dieser Block als eigene, gleichnamige "nrf52"-Section in
+; jeder der drei nRF52-Variantendateien (wiscore_rak4631, heltec_t114,
+; t_echo). PlatformIO mergt gleichnamige Sections ueber alle extra_configs
+; hinweg, wodurch die drei Kopien im Glob-Reihenfolge-Zufall zu einer
+; einzigen wurden -- ein
+; stiller Kollisionsfehler (CFG-01). Hier ist das Teilen jetzt explizit und
+; unabhaengig von der Glob-Reihenfolge.
+;
+; -D BOARD_RAK4630 und der Quellfilter +<../variants/wiscore_rak4631/*>
+; werden von heltec_t114 und t_echo ABSICHTLICH mitgeerbt (das war auch
+; vorher schon der faktische Effekt des Merges): BOARD_RAK4630 schaltet ueber
+; 60 nRF52-Codestellen frei, und t_echo kompiliert dadurch wiscore_rak4631s
+; variant.cpp statt der eigenen (die einen bislang nie gebauten
+; PIN_LED3-Init enthaelt). Das zu aendern braucht Hardware-Verifikation auf
+; diesen Boards, nicht nur eine Config-Aufraeumung.
+[nrf52_base]
+platform = nordicnrf52@10.12.0
+framework = arduino
+extends = upload_settings
+build_src_filter =
+	+<*>
+	-<esp32/*>
+	-<Displays/*>
+	-<Fonts/*>
+	-<GFX_Root/*>
+	-<Platforms/*>
+	-<safeboot/*>
+	-<t-deck/*>
+	-<t-deck-pro/*>
+	-<t5-epaper/*>
+	-<tinyxml_function.cpp>
+	+<../variants/wiscore_rak4631/*>
+build_flags =
+	${common.build_flags}
+	-D BOARD_RAK4630="RAK4630"
+	-D MONITOR_SPEED=${upload_settings.monitor_speed}
+	-D SERIAL_BUFFER_SIZE=250
+	-Isrc/nrf52
+
 [common]
 build_flags = 
 	-DRADIOLIB_EXCLUDE_CC1101=1

--- a/src/Regexp.cpp
+++ b/src/Regexp.cpp
@@ -35,6 +35,7 @@ int capture_to_close (MatchState *ms) {
 
 //static const
 char *classend (MatchState *ms, /*const*/ char *p) {
+  (void)ms;
   switch (*p++) {
     case REGEXP_ESC: {
       if (*p == '\0')
@@ -294,7 +295,14 @@ init: /* using goto's to optimize tail recursion */
 
 // functions below written by Nick Gammon ...
 
-char MatchState::Match (/*const*/ char * pattern, unsigned int index)
+// pattern/index werden nach dem setjmp() noch veraendert (index-Klemmung,
+// pattern++ bei '^'). Nicht-volatile lokale Variablen haben nach einem longjmp()
+// einen unbestimmten Wert -> -Wclobbered. Hier ist das folgenlos, weil der
+// Fehlerpfad direkt ueber rtn zurueckkehrt und beide nicht mehr liest; volatile
+// macht die Garantie aber explizit statt sie vom Codefluss abhaengig zu lassen.
+// Top-Level-volatile an Parametern aendert die Funktionssignatur nicht, die
+// Deklaration in Regexp.h bleibt unveraendert gueltig.
+char MatchState::Match (/*const*/ char * volatile pattern, volatile unsigned int index)
 {
   // set up for throwing errors
   char rtn = setjmp (regexp_error_return);

--- a/src/ack_functions.h
+++ b/src/ack_functions.h
@@ -1,0 +1,82 @@
+#pragma once
+
+// Plausibilitaetspruefung fuer empfangene ACK-Frames (msg_type 0x41).
+//
+// Warum das noetig ist:
+// handleACK() akzeptierte einen Frame allein aufgrund von payload[0] == 0x41
+// und size >= 12. 0x41 ist als ASCII schlicht der Buchstabe 'A' — jedes
+// Bruchstueck eines Text- oder Positionspakets, das mit 'A' beginnt und lang
+// genug ist, lief damit durch die ACK-Verarbeitung: Bytes 1..4 galten als
+// seine msg_id, es landete im Dedup-Ring und wurde mit Prioritaet 1 ins Mesh
+// weitergesendet — wobei es je einen Heartbeat aus der vollen Sendequeue warf.
+//
+// Aufbau eines gueltigen ACK-Frames (12 Byte), siehe lora_functions.cpp:
+//   [0]      0x41                       MSG_TYPE_ACK
+//   [1..4]   msg_counter                eigene msg_id des ACK (little endian)
+//   [5]      0x80 | max_hop             Bit 7 = Server-Flag, Bit 0..6 = Resthops
+//   [6..9]   msg_id                     die quittierte Nachricht (little endian)
+//   [10]     0x01                       ACK von GW / Node
+//   [11]     0x00
+//
+// Byte 5 ist der belastbare Diskriminator: Funk-ACKs entstehen ausschliesslich
+// als (0x80 | meshcom_settings.max_hop_text) und werden auf dem Weiterleitungs-
+// pfad nur dekrementiert. Bit 7 ist also immer gesetzt, und der Hop-Zaehler
+// bleibt klein.
+//
+// Feldmessung (DG0OPK-11/-12/-13, 24./25.08.2026, 32,7 h, 8741 Frames im
+// ACK-Pfad) — drei unabhaengige Kriterien trennen deckungsgleich:
+//
+//   Byte 5          Anzahl          Byte 10/11 == 01 00   Feld 6..9 real gehoert
+//   0x80..0x84      8235 (94,2 %)   99,6 %                58,9 %
+//   0x80|Hops 5..116 221 ( 2,5 %)    0,0 %                 0,0 %
+//   Bit 7 = 0        285 ( 3,3 %)    0,0 %                 0,0 %
+//
+// Kein einziger der 506 unplausiblen Frames quittierte eine Nachricht, die der
+// Knoten tatsaechlich gehoert hatte. Byte 10/11 wird bewusst NICHT geprueft:
+// 0,4 % der gueltigen Frames tragen dort abweichende Werte (vermutlich aeltere
+// Firmwarestaende), das waere ein zu scharfes Kriterium.
+//
+// Ein Frame mit Byte 5 = 0xF4 fuehrt 116 Resthops — der Weiterleitungspfad
+// prueft nur (byte5 & 0x7F) > 0 und dekrementiert, nach oben war nichts
+// begrenzt. Dass das bisher nicht eskalierte, verdankte sich allein dem
+// Dedup-Ring, nicht dem Entwurf.
+
+#include <stdint.h>
+
+#include "configuration.h"
+
+/**
+ * @brief Prueft, ob ein empfangener Frame als ACK verarbeitet werden darf.
+ *
+ * Reine Funktion ohne Seiteneffekte und ohne globale Abhaengigkeiten, damit
+ * sie isoliert pruefbar ist.
+ *
+ * @param payload  Empfangspuffer, darf NULL sein.
+ * @param size     Laenge des Empfangspuffers in Byte.
+ * @param maxHop   Obere Schranke fuer den Hop-Zaehler in Byte 5,
+ *                 ueblicherweise MAX_HOP_LIMIT.
+ * @return true, wenn der Frame als ACK plausibel ist.
+ */
+static inline bool isPlausibleAckFrame(const uint8_t *payload, uint16_t size, uint8_t maxHop)
+{
+    if(payload == NULL)
+        return false;
+
+    if(size < 12)
+        return false;
+
+    if(payload[0] != MSG_TYPE_ACK)
+        return false;
+
+    // Bit 7 (Server-Flag) ist bei jedem ueber Funk erzeugten ACK gesetzt.
+    if((payload[5] & 0x80) != 0x80)
+        return false;
+
+    // Bit 0..6 tragen die verbleibenden Hops. Werte oberhalb der Schranke
+    // koennen nicht aus (0x80 | max_hop) mit anschliessendem Dekrementieren
+    // entstanden sein.
+    if((payload[5] & 0x7F) > maxHop)
+        return false;
+
+    return true;
+}

--- a/src/adc_functions.cpp
+++ b/src/adc_functions.cpp
@@ -1,6 +1,14 @@
 #include "configuration.h"
 
-#ifndef BOARD_RAK4630
+// ESP-IDF ADC calibration API (esp_adc_cal.h) and analogReadMilliVolts() are
+// ESP32-Arduino-core-only. The previous `#ifndef BOARD_RAK4630` guard only
+// worked for wiscore_rak4631 by coincidence of a platformio.ini section-name
+// collision (see Wave 0.2 notes) that leaked BOARD_RAK4630 into every other
+// nRF52 variant's build; on a correctly isolated build it left heltec_t114
+// and t_echo trying to compile ESP-IDF headers. loop_ADCFunctions() is only
+// ever called from src/esp32/esp32_main.cpp, so gating on ESP32 directly
+// keeps every board's compiled behavior identical to before.
+#if defined(ESP32)
 
 #include "loop_functions_extern.h"
 
@@ -67,7 +75,7 @@ void loop_ADCFunctions()
             if (ADCalpha == 0.0) { ADCalpha = 0.001; }
 
             int ADCintervall = (int)meshcom_settings.node_analog_alpha % 100;
-            if ((analog_oversample_timer + std::max(2,ADCintervall)) < millis())  //min. 2ms, max. 99ms
+            if ((uint32_t)(millis() - analog_oversample_timer) >= (uint32_t)std::max(2,ADCintervall))  //min. 2ms, max. 99ms
             {
                 //digitalWrite(BOARD_LED, LOW);  // OE3WAS für TEST Timing
                 //digitalWrite(BOARD_LED, HIGH);  // OE3WAS für TEST
@@ -94,7 +102,7 @@ void loop_ADCFunctions()
             }
 
             int ADCshowtime = (int)meshcom_settings.node_analog_alpha / 100;
-            if ((analog_show_timer + (1000 * std::max(1,ADCshowtime))) < millis())  // 1 .. 99s
+            if ((uint32_t)(millis() - analog_show_timer) >= (uint32_t)(1000 * std::max(1,ADCshowtime)))  // 1 .. 99s
             {
                 Serial.printf("[ADC1]; GPIO%d; %s; %u; %.3f; %u; %u; %.1f; %.1f; %.1f\n",
                     meshcom_settings.node_analog_pin, getTimeString().c_str(),

--- a/src/aht20.cpp
+++ b/src/aht20.cpp
@@ -37,12 +37,13 @@ float fAHT20Hum = 0.0;
 
 void setupAHT20(bool bInit)
 {
+    (void)bInit;
     aht20_found = false;
 
     if(!bAHT20ON)
 		return;
 		
-    #if defined(BOARD_TBEAM_V3) || (BOARD_E22_S3)
+    #if MC_I2C_NEEDS_BUS_RESET
         Wire.end();
         Wire.begin(I2C_SDA, I2C_SCL);
     #endif
@@ -67,7 +68,7 @@ bool loopAHT20()
 	if(!aht20_found)
 		return false;
 
-    #if defined(BOARD_TBEAM_V3) || (BOARD_E22_S3)
+    #if MC_I2C_NEEDS_BUS_RESET
         Wire.end();
         Wire.begin(I2C_SDA, I2C_SCL);
     #endif
@@ -81,7 +82,7 @@ bool loopAHT20()
 
     if(bWXDEBUG)
     {	
-        Serial.printf("Temperature (AHT20): %.1f °C\n", fAHT20Temp);        
+        Serial.printf("Temperature (AHT20): %.1f ï¿½C\n", fAHT20Temp);        
         Serial.printf("Humidity (AHT20): %.1f %%rH\n", fAHT20Hum);
     }
 

--- a/src/aprs_functions.cpp
+++ b/src/aprs_functions.cpp
@@ -6,6 +6,8 @@
 #include <debugconf.h>
 #include <configuration.h>
 
+#define MAX_APRS_FRAME_SIZE 340
+
 char shortSUBVERSION()
 {
     char csfw[2]={0};
@@ -143,6 +145,9 @@ uint16_t decodeAPRS(uint8_t RcvBuffer[UDP_TX_BUF_SIZE], uint16_t rsize, struct a
 
         return 0x00;
     }
+
+    if(rsize > MAX_APRS_FRAME_SIZE)
+        return 0x00;
 
     aprsmsg.payload_type = RcvBuffer[0];
 
@@ -379,6 +384,20 @@ uint16_t decodeAPRS(uint8_t RcvBuffer[UDP_TX_BUF_SIZE], uint16_t rsize, struct a
             if(bLORADEBUG)
             {
                 Serial.printf("APRS decode - Packet discarded, wrong APRS-protocol - PayloadEnd (0x00) missing!\n");
+
+                if(rsize < 255)
+                    printAsciiBuffer(RcvBuffer, rsize);
+            }
+
+            return 0x00;
+        }
+
+        // Trailer (hw + mod + 2-byte FCS = 4 bytes) must fully fit within rsize
+        if((inext + 4) > rsize)
+        {
+            if(bLORADEBUG)
+            {
+                Serial.printf("APRS decode - Packet discarded, wrong APRS-protocol - Trailer (HW/MOD/FCS) truncated!\n");
 
                 if(rsize < 255)
                     printAsciiBuffer(RcvBuffer, rsize);
@@ -1102,9 +1121,23 @@ uint16_t encodeAPRS(uint8_t msg_buffer[UDP_TX_BUF_SIZE], struct aprsMessage &apr
     return inext;
 }
 
+// Append the per-hop HEY signal report "NCT,RSSI,SNR;" to a '@' payload.
+// NCT = mheard neighbour count, RSSI as positive number, SNR in dB.
+// Used by the mesh relay path and the gateway UDP upload (same wire format).
+void appendHeySignalReport(struct aprsMessage &aprsmsg, int16_t rssi, int8_t snr, int mheard_count)
+{
+    aprsmsg.msg_payload.concat(String(mheard_count));
+    aprsmsg.msg_payload.concat(',');
+    aprsmsg.msg_payload.concat(String(rssi*-1.0, 0));
+    aprsmsg.msg_payload.concat(',');
+    aprsmsg.msg_payload.concat(String(snr));
+    aprsmsg.msg_payload.concat(';');
+}
+
 // OE1KBC-17>APLT00-1,WIDE1-1,qAS,OE3CGG-10:!4807.01N/01619.20E[(T-ECHO by F4AVI)
 uint16_t encodeLoRaAPRS(uint8_t msg_buffer[UDP_TX_BUF_SIZE], char cSourceCall[10], double lat, char lat_c, double lon, char lon_c, int alt)
 {
+    (void)alt;
     char msg_start[UDP_TX_BUF_SIZE];
 
     uint16_t ilng = 0;
@@ -1154,6 +1187,7 @@ uint16_t encodeLoRaAPRS(uint8_t msg_buffer[UDP_TX_BUF_SIZE], char cSourceCall[10
 
 uint16_t encodeLoRaAPRScompressed(uint8_t msg_buffer[UDP_TX_BUF_SIZE], char cSourceCall[10], double lat, char lat_c, double lon, char lon_c, int alt)
 {
+    (void)alt;
     if(lat == 0.0 or lon == 0.0)
     {
         if(bDisplayCont)

--- a/src/aprs_functions.h
+++ b/src/aprs_functions.h
@@ -10,6 +10,7 @@ uint16_t decodeAPRS(uint8_t RcvBuffer[UDP_TX_BUF_SIZE], uint16_t size, struct ap
 uint16_t encodeAPRS(uint8_t RcvBuffer[UDP_TX_BUF_SIZE], struct aprsMessage &aprsMessage);
 uint16_t encodeStartAPRS(uint8_t msg_buffer[MAX_MSG_LEN_PHONE], struct aprsMessage &aprsmsg);
 uint16_t encodePayloadAPRS(uint8_t msg_buffer[MAX_MSG_LEN_PHONE], struct aprsMessage &aprsmsg);
+void appendHeySignalReport(struct aprsMessage &aprsMessage, int16_t rssi, int8_t snr, int mheard_count);
 void initAPRSPOS(struct aprsPosition &aprsPosition);
 uint16_t decodeAPRSPOS(String PayloadBuffer, struct aprsPosition &aprsPosition);
 

--- a/src/batt_function_old.cpp
+++ b/src/batt_function_old.cpp
@@ -1,13 +1,14 @@
 #include <Arduino.h>
 #include <configuration.h>
 #include "printfdeb_functions.h"
+#include "batt_functions.h"
 
 #ifndef USE_NEW_BATT
 
 #include <loop_functions.h>
 #include <loop_functions_extern.h>
 
-#if not defined(BOARD_RAK4630)
+#if !defined(NRF52_SERIES)
 #include <esp_adc_cal.h>
 #endif
 
@@ -16,6 +17,15 @@ int global_proz = 0;
 
 unsigned long BattTimeWait = 0;
 unsigned long BattTimeAPP = 0;
+
+// Compile-Zeit-Fallback: bisheriges hartcodiertes Verhalten dieses Pfads (HIGH=Teiler ein,
+// LOW=Teiler aus). Siehe batt_functions.h fuer die Begruendung der Probe.
+batt_probe_t battProbeState = BATT_PROBE_ACTIVE_HIGH;
+
+bool battHardwarePresent(void)
+{
+	return battProbeState != BATT_PROBE_NONE;   // fail-safe: nur bei positiv erkanntem "kein Teiler" false
+}
 
 #if defined(NRF52_SERIES)
 
@@ -66,7 +76,7 @@ uint32_t vbat_pin = ADC_PIN;
 uint32_t vbat_pin = ADC_PIN;
 #endif
 
-#if defined(BOARD_RAK4630) || defined(BOARD_T_ECHO)
+#if defined(NRF52_SERIES)
 //nothing
 #else
 
@@ -204,6 +214,51 @@ void VextOFF(void)  // Vext default OFF
 }
 #endif
 
+#if defined(BOARD_HELTEC_V3) || defined(BOARD_STICK_V3) || defined(BOARD_HELTEC_V4)
+// battProbeState startet bewusst NICHT auf BATT_PROBE_UNKNOWN (Compile-Zeit-Fallback oben),
+// daher braucht das "einmalig ausfuehren"-Gating ein eigenes Flag statt eines Vergleichs
+// gegen battProbeState.
+static bool battProbeDone = false;
+
+// Einmalige ADC_CTRL_PIN-Polaritaets-Probe (siehe Begruendung in batt_functions.h). Wird aus
+// init_batt() aufgerufen, das battProbeDone-Flag sorgt dafuer, dass sie trotz mehrfachem
+// init_batt()-Aufruf (z.B. nach --batt factor Befehl) nur einmal laeuft.
+static void battProbeADCPolarity(uint32_t ctrlPin, uint32_t vbatPin)
+{
+	int countsHigh = 0;
+	int countsLow  = 0;
+
+	digitalWrite(ctrlPin, HIGH);
+	delay(100);   // Teiler braucht ~100ms zum Einschwingen (wie im Heltec-Zweig von read_batt())
+	for (int i = 0; i < 8; i++) { countsHigh += analogRead(vbatPin); }
+	countsHigh /= 8;
+
+	digitalWrite(ctrlPin, LOW);
+	delay(100);
+	for (int i = 0; i < 8; i++) { countsLow += analogRead(vbatPin); }
+	countsLow /= 8;
+
+	if (countsHigh >= BATT_PROBE_MIN_COUNTS && countsHigh > countsLow)
+	{
+		battProbeState = BATT_PROBE_ACTIVE_HIGH;
+		digitalWrite(ctrlPin, LOW);    // Ruhezustand: Teiler getrennt (Strom sparen)
+	}
+	else if (countsLow >= BATT_PROBE_MIN_COUNTS && countsLow > countsHigh)
+	{
+		battProbeState = BATT_PROBE_ACTIVE_LOW;
+		digitalWrite(ctrlPin, HIGH);   // Ruhezustand: Teiler getrennt (Strom sparen)
+	}
+	else
+	{
+		battProbeState = BATT_PROBE_NONE;   // kein Teiler bestueckt -> keine Batteriehardware
+	}
+
+	printfdeb("[INIT]...ADC_CTRL_PIN probe: high=%d;low=%d;-> %s\n", countsHigh, countsLow,
+		(battProbeState == BATT_PROBE_ACTIVE_HIGH) ? "active HIGH" :
+		(battProbeState == BATT_PROBE_ACTIVE_LOW)  ? "active LOW"  : "keine Batteriehardware (kein Teiler)");
+}
+#endif
+
 /**
  * @brief Initialize the battery analog input
  *
@@ -218,19 +273,23 @@ void init_batt(void)
 	digitalWrite(36, LOW);
 
 	#define ADC_CTRL_PIN 37
-	#define BATTERY_SAMPLES 20
 
 	pinMode(vbat_pin, INPUT);
 	pinMode(ADC_CTRL_PIN, OUTPUT);
 
 	analogReadResolution(12);
+
+	if (!battProbeDone)
+	{
+		battProbeADCPolarity(ADC_CTRL_PIN, vbat_pin);
+		battProbeDone = true;
+	}
 #endif
 
 // geht für HELTEC V3/V4 und für V3.2  wichtig für Display
 #if defined(BOARD_HELTEC_T114)
 
 	#define ADC_CTRL_PIN 6
-	#define BATTERY_SAMPLES 20
 
 	pinMode(vbat_pin, INPUT);
 	pinMode(ADC_CTRL_PIN, OUTPUT);
@@ -487,31 +546,59 @@ float read_batt(void)
 		*/
 		const float factor = ADC_MULTIPLIER;
 		/**/
-		
-		//V3.1
-		//digitalWrite(ADC_CTRL_PIN, LOW);
-		digitalWrite(ADC_CTRL_PIN, HIGH);
 
-		delay(100);
-		int analogValue = analogRead(vbat_pin);
-		
-		//V3.1 digitalWrite(ADC_CTRL_PIN, HIGH);
-		digitalWrite(ADC_CTRL_PIN, LOW);
+		// Divider needs ~100 ms to settle after being enabled. Das bisherige
+		// blockierende delay(100) haelt dabei die komplette Hauptschleife an --
+		// alle ~500 ms (die BattTimeWait-Kadenz), gemessen ~100,6 ms pro Aufruf.
+		// Spread the settle across two read_batt() calls instead of blocking:
+		// arm+enable on one call (return the previous cached value), read+disable
+		// on the next call once >=100 ms has actually elapsed.
+		static bool dividerArmed = false;
+		static uint32_t dividerArmedAt = 0;
+		static float cachedRaw = 0.0;
 
-		float floatVoltage = factor * analogValue;
-		uint16_t voltage = (int)(floatVoltage);
-
-		if(bDEBUG && bDisplayCont)
+		if (!dividerArmed)
 		{
-			printdeb("[readBatteryVoltage] ADC : ");
-			printlndeb(analogValue);
-			printdeb("[readBatteryVoltage] Float : ");
-			printfdeb("%.3f\n", floatVoltage);
-			printdeb("[readBatteryVoltage] milliVolts : ");
-			printlndeb(voltage);
+			// Polaritaet kommt aus der einmaligen Probe in init_batt() (battProbeState);
+			// Fallback (Probe noch nicht gelaufen / nichts gefunden) = active HIGH, bisheriges Verhalten.
+			if (battProbeState == BATT_PROBE_ACTIVE_LOW)
+				digitalWrite(ADC_CTRL_PIN, LOW);
+			else
+				digitalWrite(ADC_CTRL_PIN, HIGH);
+			dividerArmedAt = millis();
+			dividerArmed = true;
+			raw = cachedRaw;
 		}
+		else if ((uint32_t)(millis() - dividerArmedAt) >= 100)
+		{
+			int analogValue = analogRead(vbat_pin);
 
-		raw = floatVoltage;
+			if (battProbeState == BATT_PROBE_ACTIVE_LOW)
+				digitalWrite(ADC_CTRL_PIN, HIGH);   // Teiler wieder trennen (Strom sparen)
+			else
+				digitalWrite(ADC_CTRL_PIN, LOW);    // Teiler wieder trennen (Strom sparen)
+			dividerArmed = false;
+
+			float floatVoltage = factor * analogValue;
+			uint16_t voltage = (int)(floatVoltage);
+
+			if(bDEBUG && bDisplayCont)
+			{
+				printdeb("[readBatteryVoltage] ADC : ");
+				printlndeb(analogValue);
+				printdeb("[readBatteryVoltage] Float : ");
+				printfdeb("%.3f\n", floatVoltage);
+				printdeb("[readBatteryVoltage] milliVolts : ");
+				printlndeb(voltage);
+			}
+
+			raw = floatVoltage;
+			cachedRaw = floatVoltage;
+		}
+		else
+		{
+			raw = cachedRaw;
+		}
 
 		#elif defined(BOARD_TBEAM_1W)
 

--- a/src/batt_functions.cpp
+++ b/src/batt_functions.cpp
@@ -46,6 +46,66 @@ void check_efuse(void)
 }
 
 
+// Compile-Zeit-Fallback, bis die Probe (falls ADC_CTRL_PIN vorhanden) gelaufen ist bzw. auf
+// Boards ohne ADC_CTRL_PIN dauerhaft: Wireless Paper ist als active LOW dokumentiert, alle
+// anderen (E213/E290) als active HIGH ("am Geraet verifiziert").
+#if defined(BOARD_WIRELESS_PAPER)
+batt_probe_t battProbeState = BATT_PROBE_ACTIVE_LOW;
+#else
+batt_probe_t battProbeState = BATT_PROBE_ACTIVE_HIGH;
+#endif
+
+bool battHardwarePresent(void)
+{
+	return battProbeState != BATT_PROBE_NONE;   // fail-safe: nur bei positiv erkanntem "kein Teiler" false
+}
+
+
+#if defined(ADC_CTRL_PIN)
+// battProbeState startet bewusst NICHT auf BATT_PROBE_UNKNOWN (siehe oben), daher braucht das
+// "einmalig ausfuehren"-Gating ein eigenes Flag statt eines Vergleichs gegen battProbeState.
+// Nur hier deklariert: ohne ADC_CTRL_PIN gibt es keine Probe und das Flag waere ungenutzt.
+static bool battProbeDone = false;
+
+// Einmalige Polaritaets-Probe (siehe Begruendung in batt_functions.h). Wird lazy beim ersten
+// ADC_BATT_ON() aufgerufen (also beim Boot, aus init_batt()) und danach nie wieder (battProbeDone).
+static void battProbeADCPolarity(void)
+{
+	int countsHigh = 0;
+	int countsLow  = 0;
+
+	digitalWrite(ADC_CTRL_PIN, HIGH);
+	delay(100);   // Teiler braucht ~100ms zum Einschwingen (wie an anderer Stelle bereits verwendet)
+	for (int i = 0; i < 8; i++) { countsHigh += analogRead(BAT_VOLT_PIN); }
+	countsHigh /= 8;
+
+	digitalWrite(ADC_CTRL_PIN, LOW);
+	delay(100);
+	for (int i = 0; i < 8; i++) { countsLow += analogRead(BAT_VOLT_PIN); }
+	countsLow /= 8;
+
+	if (countsHigh >= BATT_PROBE_MIN_COUNTS && countsHigh > countsLow)
+	{
+		battProbeState = BATT_PROBE_ACTIVE_HIGH;
+		digitalWrite(ADC_CTRL_PIN, LOW);    // Ruhezustand: Teiler getrennt (Strom sparen)
+	}
+	else if (countsLow >= BATT_PROBE_MIN_COUNTS && countsLow > countsHigh)
+	{
+		battProbeState = BATT_PROBE_ACTIVE_LOW;
+		digitalWrite(ADC_CTRL_PIN, HIGH);   // Ruhezustand: Teiler getrennt (Strom sparen)
+	}
+	else
+	{
+		battProbeState = BATT_PROBE_NONE;   // kein Teiler bestueckt -> keine Batteriehardware
+	}
+
+	printfdeb("[INIT]...ADC_CTRL_PIN probe: high=%d;low=%d;-> %s\n", countsHigh, countsLow,
+		(battProbeState == BATT_PROBE_ACTIVE_HIGH) ? "active HIGH" :
+		(battProbeState == BATT_PROBE_ACTIVE_LOW)  ? "active LOW"  : "keine Batteriehardware (kein Teiler)");
+}
+#endif
+
+
 void VextON(void)
 {
 	#if defined(BOARD_WIRELESS_PAPER)
@@ -78,12 +138,17 @@ void ADC_BATT_ON(void)
 {
 	#if defined(ADC_CTRL_PIN)
 		pinMode(ADC_CTRL_PIN, OUTPUT);
-		//Heltec V3.1 --- hat keine eigene variants !?!?
-		#if defined(BOARD_HELTEC_V31) || defined(BOARD_WIRELESS_PAPER)
-			digitalWrite(ADC_CTRL_PIN,LOW);   // active LOW: LOW = Teiler durchgeschaltet/messen
-		#else
-			digitalWrite(ADC_CTRL_PIN, HIGH);   // E213/E290: active HIGH (am Geraet verifiziert: LOW->0mV, HIGH->840mV)
-		#endif
+
+		if (!battProbeDone)
+		{
+			battProbeADCPolarity();   // einmalig: Polaritaet des Teiler-Schalters ermitteln
+			battProbeDone = true;
+		}
+
+		if (battProbeState == BATT_PROBE_ACTIVE_LOW)
+			digitalWrite(ADC_CTRL_PIN, LOW);    // active LOW: LOW = Teiler durchgeschaltet/messen (z.B. Wireless Paper)
+		else
+			digitalWrite(ADC_CTRL_PIN, HIGH);   // active HIGH (Default/Fallback): E213/E290 am Geraet verifiziert
 	#endif
 }
 
@@ -91,12 +156,11 @@ void ADC_BATT_OFF(void)
 {
 	#if defined(ADC_CTRL_PIN)
 		pinMode(ADC_CTRL_PIN, OUTPUT);
-		//Heltec V3.1 --- hat keine eigene variants !?!?
-		#if defined(BOARD_HELTEC_V31) || defined(BOARD_WIRELESS_PAPER)
-			digitalWrite(ADC_CTRL_PIN,HIGH);
-		#else
-			digitalWrite(ADC_CTRL_PIN, LOW);   // E213/E290: active HIGH -> OFF = LOW
-		#endif
+
+		if (battProbeState == BATT_PROBE_ACTIVE_LOW)
+			digitalWrite(ADC_CTRL_PIN, HIGH);   // active LOW -> OFF = HIGH
+		else
+			digitalWrite(ADC_CTRL_PIN, LOW);    // active HIGH (Default/Fallback) -> OFF = LOW
 	#endif
 }
 
@@ -219,7 +283,7 @@ float read_batt(void)
 		wpPushVolt(rawVoltage);   // 2x/s -> letzte 10 Rohwerte fuer die "AKKU LOW"-Anzeige
 		#endif
 
-		if ((batt_show_timer + (1000 * std::max(1,BATTshowtime))) < millis())  // 1 .. 99s
+		if ((uint32_t)(millis() - batt_show_timer) >= (uint32_t)(1000 * std::max(1,BATTshowtime)))  // 1 .. 99s
 		{
 			batt_show_timer = millis();
 

--- a/src/batt_functions.h
+++ b/src/batt_functions.h
@@ -8,6 +8,28 @@
 #include "command_functions.h"
 #include "printfdeb_functions.h"
 
+// ----- ADC_CTRL_PIN Polaritaets-Probe -----
+// Manche Boards schalten den Spannungsteiler aktiv HIGH durch (E213/E290, am Geraet
+// verifiziert), manche aktiv LOW (Wireless Paper). Der bisherige Compile-Zeit-Test auf
+// BOARD_HELTEC_V31 war toter Code (dieses Define existiert nirgends im Baum) und hat auf
+// keinem realen Board je die active-LOW-Variante ausgewaehlt. Statt weiter zu raten, wird
+// die Polaritaet einmalig beim Boot per ADC-Probe gemessen: Teiler HIGH schalten, einschwingen
+// lassen, Rohwert lesen; danach LOW, einschwingen, lesen. Am Geraet gemessen liefert ein
+// durchgeschalteter Teiler ~902-906 Rohwerte (12-bit ADC), ein getrennter/offener Pin nur
+// 1-4 Rohwerte - drei Groessenordnungen Abstand. BATT_PROBE_MIN_COUNTS=50 (~200 mV bei
+// 12-bit/3.3V) liegt sicher dazwischen und toleriert ADC-Rauschen auf der "aus"-Seite.
+#define BATT_PROBE_MIN_COUNTS 50
+
+typedef enum {
+    BATT_PROBE_UNKNOWN = 0,   // Probe noch nicht gelaufen
+    BATT_PROBE_NONE,          // kein Teiler bestueckt -> keine Batteriehardware
+    BATT_PROBE_ACTIVE_HIGH,   // Teiler durchgeschaltet, wenn ADC_CTRL_PIN HIGH
+    BATT_PROBE_ACTIVE_LOW     // Teiler durchgeschaltet, wenn ADC_CTRL_PIN LOW
+} batt_probe_t;
+
+extern batt_probe_t battProbeState;
+bool battHardwarePresent(void);   // false NUR bei BATT_PROBE_NONE
+
 #if defined(USE_NEW_BATT)
 
 // Battery
@@ -37,7 +59,7 @@ int wpBattHistory(float* out, int maxn);   // letzte Spannungs-Rohwerte, neueste
 	#include "nrf52/t_echo_utilities.h"
 #endif
 
-#if not defined(BOARD_RAK4630)
+#if !defined(NRF52_SERIES)
 	#include <esp_adc_cal.h>
 #endif
 

--- a/src/bme680.cpp
+++ b/src/bme680.cpp
@@ -83,22 +83,43 @@ void setupBME680()
     Serial.println("[INIT]...Could not find BME680 sensor or Address conflict!");
     return;
   }
-  else
-  {
-    bme680_found = true;
-  }
 
-  // Initialize the BME680
+  // N-27: Ein ACK auf die Adresse beweist nur, dass dort UEBERHAUPT jemand
+  // antwortet -- nicht, dass es ein BME680 ist. 0x76 und 0x77 teilen sich
+  // BME280, BMP280 und BME680, wie der Kommentar oben selbst festhaelt.
+  // Erst begin() liest die Chip-ID und ist damit die einzige Stelle, die die
+  // drei auseinanderhaelt. Der Rueckgabewert wurde bisher verworfen und
+  // bme680_found allein aus dem ACK gesetzt: auf einem Board mit BME280 an
+  // 0x76 meldete der Node dann "BME680 sensor found", "--wx" zeigte
+  // "BME680: on (found)", und jeder Lesezyklus druckte dauerhaft
+  // "Failed to complete reading :(", ohne dass irgendetwas den Zustand
+  // zuruecksetzte.
+  bool bme680_begin_ok = false;
+
   switch (foundAddr)
   {
     case 1:
-      bme.begin(I2C_ADDRESS_BME680_1);
+      bme680_begin_ok = bme.begin(I2C_ADDRESS_BME680_1);
       break;
     case 2:
-      bme.begin(I2C_ADDRESS_BME680_2);
+      bme680_begin_ok = bme.begin(I2C_ADDRESS_BME680_2);
       break;
   }
-  
+
+  if(!bme680_begin_ok)
+  {
+    Serial.printf("[INIT]...BME680 an 0x%02X antwortet, ist aber keiner (Chip-ID passt nicht) - BME680 aus\n",
+                  (foundAddr == 1) ? I2C_ADDRESS_BME680_1 : I2C_ADDRESS_BME680_2);
+    Serial.println("[INIT]...Vermutlich ein BME280/BMP280 - mit --bme on bzw. --bmp on aktivieren");
+
+    bme680_found = false;
+    bBME680ON = false;   // wie im Konflikt-Zweig oben: nur Laufzeit, nicht gespeichert
+
+    return;
+  }
+
+  bme680_found = true;
+
   // Set up oversampling and filter initialization
   bme.setTemperatureOversampling(BME680_OS_8X);
   bme.setHumidityOversampling(BME680_OS_2X);

--- a/src/bmp390.cpp
+++ b/src/bmp390.cpp
@@ -46,12 +46,13 @@ float fAltidude = 0;
 
 void setupBMP390(bool bInit)
 {
+    (void)bInit;
     bmp3_found = false;
 
     if(!bBMP3ON)
 		return;
 		
-    #if defined(BOARD_TBEAM_V3) || (BOARD_E22_S3)
+    #if MC_I2C_NEEDS_BUS_RESET
         Wire.end();
         Wire.begin(I2C_SDA, I2C_SCL);
     #endif
@@ -81,7 +82,7 @@ bool loopBMP390()
 	if(!bmp3_found)
 		return false;
 
-    #if defined(BOARD_TBEAM_V3) || (BOARD_E22_S3)
+    #if MC_I2C_NEEDS_BUS_RESET
         Wire.end();
         Wire.begin(I2C_SDA, I2C_SCL);
     #endif

--- a/src/bmx280.cpp
+++ b/src/bmx280.cpp
@@ -128,7 +128,7 @@ void setupBMX280(bool bNewStart)
 
   	if(bBMPON)
 	{
-		#ifdef BOARD_TBEAM_V3
+		#if MC_I2C_NEEDS_BUS_RESET
 			Wire.end();
 			Wire.begin(I2C_SDA, I2C_SCL);
 		#else
@@ -144,7 +144,7 @@ void setupBMX280(bool bNewStart)
   	else
     	if(bBMEON)
 		{
-			#ifdef BOARD_TBEAM_V3
+			#if MC_I2C_NEEDS_BUS_RESET
 				Wire.end();
 				Wire.begin(I2C_SDA, I2C_SCL);
 			#else
@@ -174,7 +174,7 @@ void setupBMX280(bool bNewStart)
 	fPress = 0.0;
 	fHum = 0.0;
 
-	#if defined(BOARD_TBEAM_V3) || (BOARD_E22_S3)
+	#if MC_I2C_NEEDS_BUS_RESET
 		Wire.end();
 		Wire.begin(I2C_SDA, I2C_SCL);
 	#endif
@@ -216,7 +216,7 @@ bool loopBMX280(void)
 	if(!bmx_found)
 		return false;
 
-	#if defined(BOARD_TBEAM_V3) || (BOARD_E22_S3)
+	#if MC_I2C_NEEDS_BUS_RESET
 		Wire.end();
 		Wire.begin(I2C_SDA, I2C_SCL);
 	#endif

--- a/src/capture_functions.cpp
+++ b/src/capture_functions.cpp
@@ -1,0 +1,222 @@
+#include <Arduino.h>
+#include <atomic>
+#include <string.h>
+
+// Spitze Klammern (nicht Anfuehrungszeichen) fuer configuration.h und
+// printfdeb_functions.h -- siehe die gleiche Begruendung in
+// txring_functions.cpp.
+#include <configuration.h>
+#include <printfdeb_functions.h>
+
+#include "capture_functions.h"
+
+bool bTXCAPTURE = false;
+
+// Der RX-Mitschnitt haengt an bLORADEBUG (lora_functions.cpp). Hier nur
+// deklariert statt ueber loop_functions_extern.h gezogen: dieses Modul soll
+// nativ ohne den ganzen Loop-Header uebersetzbar bleiben. Der Typ muss exakt
+// zur Definition in loop_functions.cpp passen (bool) -- eine abweichende
+// Deklaration waere ein ODR-Verstoss.
+extern bool bLORADEBUG;
+
+// 768 Byte: ~9 typische Positionsbaken (45-130 Byte) oder 2 Maximalframes.
+// Kleiner macht den Mitschnitt in Kollisionslagen loechrig, groesser kostet
+// RAM, den nRF52 nicht hat.
+#define CAPTURE_RING_BYTES  768
+
+// Kopf je Satz: dir(1) len(2) rssi(2) snr(1)
+#define CAPTURE_HDR_LEN     6
+
+static uint8_t cap_ring[CAPTURE_RING_BYTES];
+
+// Konsument ist ausschliesslich der Loop (captureDrain()); er fasst nur
+// cap_tail schreibend an. Die Sichtbarkeitsordnung (release/acquire) sorgt
+// dafuer, dass er die Nutzdaten sieht bevor er den neuen Kopfstand sieht.
+static std::atomic<uint16_t> cap_head{0};   // naechste Schreibposition
+static std::atomic<uint16_t> cap_tail{0};   // naechste Leseposition
+static std::atomic<uint32_t> cap_dropped{0};
+
+// Nur vom Konsumenten (Loop) angefasst, deshalb kein Atomic noetig.
+static unsigned long cap_serial_last = 0;
+
+// Produzenten sind ZWEI: OnRxDone() und doTX(). Auf nRF52 laufen die in
+// verschiedenen Tasks (Timer-Service bzw. Loop), der Radio-Callback kann
+// doTX() also mitten im Schreiben unterbrechen -- beide haetten dann denselben
+// Kopfstand gelesen und wuerden einander ueberschreiben. Ein einfaches SPSC-
+// Schema traegt hier nicht.
+//
+// Ein Spinlock waere an dieser Stelle falsch: unterbricht der Timer-Task den
+// Loop-Task waehrend dieser das Schloss haelt, dreht der Timer-Task fuer
+// immer. Deshalb try-lock -- wer nicht sofort hineinkommt, verwirft seinen
+// Frame und zaehlt ihn. Ein gezaehlter Verlust ist harmlos, ein zerrissener
+// Ring nicht.
+static std::atomic_flag cap_writing = ATOMIC_FLAG_INIT;
+
+static inline uint16_t ring_free(uint16_t head, uint16_t tail)
+{
+    // Fallunterscheidung statt (head - tail) % CAPTURE_RING_BYTES: uint16_t
+    // wird vor der Subtraktion nach int befoerdert, bei head < tail (also nach
+    // jedem Umlauf) ist die Differenz negativ, und % liefert in C dann einen
+    // negativen Rest. Der Rueckweg nach uint16_t machte daraus einen riesigen
+    // "used"-Wert -- und damit reichlich vermeintlich freien Platz, ueber den
+    // der naechste Frame ungelesene Saetze ueberschrieb. CAPTURE_RING_BYTES
+    // ist keine Zweierpotenz, die Maskierungsabkuerzung gibt es hier nicht.
+    // Nachgewiesen von test_capture_ring/test_ueberlauf_wird_gezaehlt_und_gemeldet.
+    uint16_t used = (head >= tail)
+                  ? (uint16_t)(head - tail)
+                  : (uint16_t)(CAPTURE_RING_BYTES - tail + head);
+
+    // Ein Byte bleibt frei, sonst waere voll von leer nicht unterscheidbar.
+    return (uint16_t)(CAPTURE_RING_BYTES - used - 1);
+}
+
+static inline void ring_put(uint16_t &pos, uint8_t b)
+{
+    cap_ring[pos] = b;
+    pos = (uint16_t)((pos + 1) % CAPTURE_RING_BYTES);
+}
+
+static inline uint8_t ring_get(uint16_t &pos)
+{
+    uint8_t b = cap_ring[pos];
+    pos = (uint16_t)((pos + 1) % CAPTURE_RING_BYTES);
+    return b;
+}
+
+void captureFrame(char dir, const uint8_t *buf, uint16_t len, int16_t rssi, int8_t snr)
+{
+    if(buf == NULL || len == 0)
+        return;
+
+    if(len > UDP_TX_BUF_SIZE)
+        len = UDP_TX_BUF_SIZE;
+
+    if(cap_writing.test_and_set(std::memory_order_acquire))
+    {
+        // Der andere Produzent schreibt gerade.
+        cap_dropped.fetch_add(1, std::memory_order_relaxed);
+        return;
+    }
+
+    uint16_t head = cap_head.load(std::memory_order_relaxed);
+    uint16_t tail = cap_tail.load(std::memory_order_acquire);
+
+    uint16_t need = (uint16_t)(CAPTURE_HDR_LEN + len);
+    if(ring_free(head, tail) < need)
+    {
+        cap_dropped.fetch_add(1, std::memory_order_relaxed);
+        cap_writing.clear(std::memory_order_release);
+        return;
+    }
+
+    uint16_t pos = head;
+    ring_put(pos, (uint8_t)dir);
+    ring_put(pos, (uint8_t)(len & 0xFF));
+    ring_put(pos, (uint8_t)((len >> 8) & 0xFF));
+    ring_put(pos, (uint8_t)(rssi & 0xFF));
+    ring_put(pos, (uint8_t)((rssi >> 8) & 0xFF));
+    ring_put(pos, (uint8_t)snr);
+    for(uint16_t i = 0; i < len; i++)
+        ring_put(pos, buf[i]);
+
+    // Erst jetzt veroeffentlichen: alles oben Geschriebene ist vor diesem
+    // Store sichtbar.
+    cap_head.store(pos, std::memory_order_release);
+
+    cap_writing.clear(std::memory_order_release);
+}
+
+bool captureFormatNext(char *out, size_t outsz)
+{
+    if(out == NULL || outsz == 0)
+        return false;
+
+    uint16_t tail = cap_tail.load(std::memory_order_relaxed);
+    uint16_t head = cap_head.load(std::memory_order_acquire);
+
+    if(tail == head)
+    {
+        // Verluste auch dann melden, wenn der Ring gerade leergelaufen ist --
+        // sonst bliebe die Meldung genau in der Lage aus, die sie erzeugt hat.
+        uint32_t lost = cap_dropped.exchange(0, std::memory_order_relaxed);
+
+        // Zweite Verlustquelle, unabhaengig vom Ring: printfdeb() verwirft auf
+        // nRF52 Ausgabe, wenn der USB-CDC-Puffer voll bleibt. Ein Frame kann
+        // also sauber durch den Ring laufen und trotzdem unvollstaendig oder
+        // gar nicht im Log landen. Beide Zahlen gehoeren nebeneinander, sonst
+        // erklaert die eine die Luecken, die die andere gerissen hat.
+        unsigned long ser_now = printfdebDroppedBytes();
+        unsigned long ser_new = ser_now - cap_serial_last;   // Ueberlauf: modulo, korrekt
+        cap_serial_last = ser_now;
+
+        // Bei abgeschaltetem Mitschnitt nicht melden -- der Zaehlerstand ist
+        // oben trotzdem nachgezogen, damit das Einschalten keinen Rueckstau
+        // aus der Zeit davor meldet.
+        if(!bLORADEBUG && !bTXCAPTURE)
+            return false;
+
+        if(lost == 0 && ser_new == 0)
+            return false;
+
+        snprintf(out, outsz, "[MC-TEST] CAPTURE_DROPPED n=%lu serial_bytes=%lu",
+                 (unsigned long)lost, ser_new);
+        return true;
+    }
+
+    uint16_t pos = tail;
+    char     dir  = (char)ring_get(pos);
+    uint16_t len  = (uint16_t)ring_get(pos);
+    len |= (uint16_t)((uint16_t)ring_get(pos) << 8);
+    int16_t  rssi = (int16_t)ring_get(pos);
+    rssi |= (int16_t)((int16_t)ring_get(pos) << 8);
+    int8_t   snr  = (int8_t)ring_get(pos);
+
+    if(len > UDP_TX_BUF_SIZE)
+        len = UDP_TX_BUF_SIZE;   // kann nur bei zerstoertem Ring auftreten
+
+    // Hex direkt in den Ausgabepuffer schreiben statt ueber einen zweiten
+    // 511-Byte-Zwischenpuffer: der haette denselben Inhalt ein zweites Mal
+    // im RAM gehalten, und RAM ist auf nRF52 das knappe Gut.
+    int off;
+    if(dir == 'T')
+        off = snprintf(out, outsz, "[MC-TEST] TX_FRAME len=%u hex=", (unsigned)len);
+    else
+        off = snprintf(out, outsz, "[MC-TEST] RX_FRAME len=%u rssi=%d snr=%d hex=",
+                       (unsigned)len, (int)rssi, (int)snr);
+
+    if(off < 0 || (size_t)off >= outsz)
+    {
+        // Der Kopf passte schon nicht. Der Ring muss trotzdem weiterruecken,
+        // sonst laege derselbe Satz beim naechsten Aufruf wieder an.
+        for(uint16_t i = 0; i < len; i++)
+            (void)ring_get(pos);
+        cap_tail.store(pos, std::memory_order_release);
+        if(outsz > 0)
+            out[0] = 0x00;
+        return false;
+    }
+
+    for(uint16_t i = 0; i < len; i++)
+    {
+        uint8_t b = ring_get(pos);          // immer lesen, auch wenn kein Platz
+        if((size_t)off + 3 <= outsz)
+        {
+            snprintf(out + off, 3, "%02X", b);
+            off += 2;
+        }
+    }
+    out[off] = 0x00;
+
+    cap_tail.store(pos, std::memory_order_release);
+    return true;
+}
+
+void captureDrain(void)
+{
+    // 96 Byte Vorspann reichen fuer die laengste Kopfzeile
+    // ("RX_FRAME len=255 rssi=-128 snr=-128 hex=") mit Reserve.
+    static char line[2 * UDP_TX_BUF_SIZE + 96];
+
+    if(captureFormatNext(line, sizeof(line)))
+        printfdeb("%s\n", line);
+}

--- a/src/capture_functions.h
+++ b/src/capture_functions.h
@@ -1,0 +1,80 @@
+#pragma once
+
+// Rohframe-Mitschnitt fuer die Luftschnittstelle.
+//
+// Wozu: die Logausgabe der Firmware zeigt Frames DEKODIERT
+// (printBuffer_aprs()) -- also das Ergebnis unseres Parsers, nicht das, was
+// auf dem Kanal lag. Ein Frame, den der Decoder falsch liest, steht falsch
+// geparst im Log; nichts darin verraet die Wahrheit. Fuer Interop-Analysen
+// braucht es die Bytes selbst.
+//
+// Bisher gab es nur zwei Teilquellen: der CRC-Dump der VERWORFENEN Frames
+// (esp32_main.cpp, nur ESP32) und ein Hex-Dump hinter `-D MC_TEST_HOOKS`, der
+// in keinem Produktionsbuild einkompiliert ist. Dieses Modul macht den
+// Mitschnitt zur Laufzeit schaltbar.
+//
+// Warum gepuffert und nicht direkt gedruckt:
+//
+//   RX  OnRxDone() laeuft auf nRF52 im Timer-Service-Task mit 1 KB Stack;
+//       printfdeb() belegt allein ~900 Byte davon (300 B Formatpuffer +
+//       600 B Ausgabepuffer, printfdeb_functions.cpp:78/119). Dazu kaemen
+//       ~48 ms Serial-Zeit fuer eine 550 Zeichen lange Zeile -- mitten im
+//       RX-Pfad.
+//
+//   TX  Der Mitschnitt sitzt in doTX() zwischen der CAD-Entscheidung
+//       "Kanal frei" und startTransmit(). Eine halbe Sekunde Serial-Ausgabe
+//       an dieser Stelle wuerde die Kanalmessung entwerten, auf der der
+//       Sendezeitpunkt beruht.
+//
+// Deshalb: captureFrame() kopiert nur (memcpy, kein printf, keine
+// Allokation), captureDrain() gibt aus dem Loop-Kontext aus.
+//
+// Der Ring ist byteorientiert statt slotorientiert: typische Frames sind
+// 45-130 Byte, feste 255-Byte-Slots wuerden den groessten Teil des RAM
+// verschenken. Bei 768 Byte fasst er ~9 Positionsbaken oder 2 Maximalframes.
+//
+// Verworfene Frames werden gezaehlt und gemeldet. Das ist kein Beiwerk: der
+// Mitschnitt wird genau dann lueckenhaft, wenn der Kanal voll ist -- also in
+// den Kollisionslagen, um derentwillen man ihn einschaltet. Ein Korpus, der
+// nicht sagt was fehlt, behauptet Vollstaendigkeit die er nicht hat.
+
+#include <stdint.h>
+#include <stddef.h>
+
+// Schaltet den TX-Mitschnitt: "--txcapture on/off", persistiert in
+// node_sset4 Bit 0x0008. Der RX-Mitschnitt haengt an bLORADEBUG.
+extern bool bTXCAPTURE;
+
+/**
+ * @brief Legt einen Frame in den Mitschnittring.
+ *
+ * Aufrufbar aus Radio-Callback-Kontext: kopiert nur, druckt nicht, allokiert
+ * nicht. Passt der Frame nicht mehr in den Ring, wird er verworfen und
+ * gezaehlt (die Zaehlung erscheint in der naechsten Ausgabe).
+ *
+ * @param dir   'R' fuer Empfang, 'T' fuer Senden
+ * @param buf   Frame-Bytes
+ * @param len   Anzahl Bytes
+ * @param rssi  nur fuer 'R' sinnvoll
+ * @param snr   nur fuer 'R' sinnvoll
+ */
+void captureFrame(char dir, const uint8_t *buf, uint16_t len, int16_t rssi, int8_t snr);
+
+/**
+ * @brief Formatiert den naechsten gepufferten Satz nach `out`.
+ *
+ * Trennt das Formatieren vom Drucken, damit der Ring ohne Ausgabekanal
+ * pruefbar bleibt.
+ *
+ * @return true, wenn eine Zeile geschrieben wurde. Bei leerem Ring wird eine
+ *         etwaige Verlustmeldung ausgegeben, danach false.
+ */
+bool captureFormatNext(char *out, size_t outsz);
+
+/**
+ * @brief Gibt hoechstens einen gepufferten Frame aus.
+ *
+ * Aus dem Loop-Kontext aufzurufen (main.cpp). Ein Frame pro Durchlauf haelt
+ * die Loop-Latenz bei ~48 ms Serial-Zeit statt bei einem Vielfachen davon.
+ */
+void captureDrain(void);

--- a/src/clock.cpp
+++ b/src/clock.cpp
@@ -69,7 +69,7 @@ Clock::EEvent Clock::CheckEvent()
 	uint8_t        u8Day, u8Hour;
 
 	// check for next minute
-	if (millis() > u32Next_m)
+	if ((int32_t)(millis() - u32Next_m) > 0)
 	{
 		// next minute
 		u8Day      = suClock_m.tm_mday;

--- a/src/command_functions.cpp
+++ b/src/command_functions.cpp
@@ -1,5 +1,6 @@
 //2025-09-16 23:036
 #include "command_functions.h"
+#include "capture_functions.h"
 #include "loop_functions.h"
 #include "loop_functions_extern.h"
 #include "printfdeb_functions.h"
@@ -611,6 +612,33 @@ void commandAction(char *umsg_text, bool ble)
         return;
     }
     else
+    #if defined(NRF52_SERIES)
+    // --dfu: in den UF2-Bootloader neu starten, das Board meldet sich dann als
+    // USB-Laufwerk (RAK4631) und laesst sich per Datei-Kopie flashen.
+    //
+    // Warum das existiert: der UF2-Bootloader wird sonst nur per Doppeldruck auf
+    // Reset oder per 1200-Baud-Touch auf der USB-CDC erreicht. Beides faellt aus,
+    // wenn die CDC-Verbindung haengt -- dann bleibt nur physischer Zugriff aufs
+    // Geraet. Ueber diesen Befehl geht es auch per BLE oder Netz-Konsole.
+    //
+    // Der eigentliche Sprung passiert verzoegert im Loop (bEnterDfu), damit die
+    // Quittung noch rausgeht; ein Reset direkt hier verschluckt sie.
+    if(commandCheck(msg_text+2, (char*)"dfu") == 0)
+    {
+        if(ble)
+        {
+            addBLECommandBack((char*)"--dfu now");
+        }
+
+        printfdeb("...starte in den UF2-Bootloader, Board meldet sich als USB-Laufwerk\n");
+
+        bEnterDfu = true;
+        rebootAuto = millis() + 2000;   // 2 s, damit BLE/Seriell die Quittung noch senden
+
+        return;
+    }
+    else
+    #endif
     if(commandCheck(msg_text+2, (char*)"reboot") == 0)
     {
         if(ble)
@@ -693,6 +721,9 @@ void commandAction(char *umsg_text, bool ble)
 //        else
         {
             printfdeb("MeshCom %-4.4s%-1.1s commands\n--setcall  set callsign (OE0XXX-1)\n--operatorname set first name/none\n--setctry 0-99 set RX/RX-LoRa-Parameter\n--reboot   Node reboot\n", SOURCE_VERSION, SOURCE_VERSION_SUB);
+            #if defined(NRF52_SERIES)
+            printfdeb("--dfu      reboot into UF2 bootloader (node appears as USB drive)\n");
+            #endif
             delay(100);
 
             printlndeb("--setssid  WLAN SSID/none\n--setpwd   WLAN PASSWORD/none\n--setownip 255.255.255.255\n--setowngw 255.255.255.255\n--setownms mask:255.255.255.255\n--setowndns 255.255.255.255\n--setownntp 255.255.255.255\n--wifiap on/off WLAN AP\n--extudp  on/off\n--extudpip 255.255.255.255/none\n");
@@ -707,7 +738,7 @@ void commandAction(char *umsg_text, bool ble)
             delay(100);
             printlndeb("--symid  set prim/sec Sym-Table\n--symcd  set table column\n--aprscomment  set APRS Comment/none\n--showI2C\n");
             delay(100);
-            printlndeb("--debug    on/off\n--bledebug on/off\n--loradebug on/off\n--gpsdebug  on/off\n--softserdebug  on/off\n--wxdebug   on/off\n--display   on/off\n--setinfo   on/off\n--volt on/off   show battery voltage\n--proz on/off    show battery proz.\n");
+            printlndeb("--debug    on/off\n--bledebug on/off\n--loradebug on/off\n--txcapture on/off\n--gpsdebug  on/off\n--softserdebug  on/off\n--wxdebug   on/off\n--display   on/off\n--setinfo   on/off\n--volt on/off   show battery voltage\n--proz on/off    show battery proz.\n");
             delay(100);
 #if defined(WP_DISP)
             printlndeb("--rotate 0/90/180/270  E-Ink Display drehen (persistent, board-uebergreifend)\n");
@@ -1575,6 +1606,17 @@ void commandAction(char *umsg_text, bool ble)
 
         gpsInitDone = false;
 
+        // A-9 ist hier WIDERLEGT und braucht kein bReturn: der Zweig kehrt
+        // sofort zurueck und erreicht den bReturn-Konsumenten am Ende von
+        // commandAction() gar nicht erst. Ein "wrong command" kann also nicht
+        // entstehen -- auf Hardware gegengeprueft, das Log enthaelt keines.
+        // Ein bReturn = true waere hier ein toter Store.
+        //
+        // Was bleibt: ueber BLE gibt dieser Zweig keine Rueckmeldung, weil er
+        // kein addBLECommandBack() ruft. Auf der seriellen Konsole ist die
+        // GPS-Init-Ausgabe die Rueckmeldung. Welcher Text an die App gehen
+        // soll, ist eine Produktentscheidung und nicht Teil einer
+        // Aufraeumwelle.
         return;
     }
     else
@@ -1871,6 +1913,21 @@ void commandAction(char *umsg_text, bool ble)
         
         meshcom_settings.node_sset = meshcom_settings.node_sset & 0x7E7F;   // BME280/BMP280 off
         meshcom_settings.node_sset3 = meshcom_settings.node_sset3 & 0x7FEF;   // BMP390 off
+
+        // N-28: "--bmx" ist das Sammelkommando, und die Hilfe sagt seit jeher
+        // "--bmx BME/BMP/680 off". Der BME680 wurde davon aber nie erfasst.
+        // Folge: wer der Hilfe folgte und danach "--bme on" gab, bekam
+        // "BME680 and BMx280 can't be used together!" und stand ohne Sensor da.
+        // Nur das Sammelkommando raeumt mit auf -- "--bme off" und "--bmp off"
+        // meinen weiterhin genau ihren Chip. Kollateralschaden gibt es keinen:
+        // BME680 und BMx280 teilen sich die Adressen und koennen ohnehin nie
+        // gleichzeitig aktiv sein.
+        if(commandCheck(msg_text+2, (char*)"bmx off") == 0)
+        {
+            bBME680ON = false;
+            bme680_found = false;
+            meshcom_settings.node_sset2 &= ~0x0004;   // BME680 off
+        }
 
         if(ble)
         {
@@ -2521,6 +2578,43 @@ void commandAction(char *umsg_text, bool ble)
         if(ble)
         {
             addBLECommandBack((char*)"--loradebug on");
+        }
+
+        save_settings();
+
+        return;
+    }
+    else
+    if(commandCheck(msg_text+2, (char*)"txcapture on") == 0)
+    {
+        // Rohframe-Mitschnitt der SENDESEITE (siehe capture_functions.h).
+        // Eigener Schalter statt an bLORADEBUG gehaengt: die Empfangsseite
+        // will man oft dauerhaft mitlaufen lassen, die Sendeseite nur fuer
+        // gezielte Interop-Messungen -- und sie kostet je Frame eine weitere
+        // ~550 Zeichen lange Logzeile.
+        bTXCAPTURE=true;
+
+        meshcom_settings.node_sset4 = meshcom_settings.node_sset4 | 0x0008;
+
+        if(ble)
+        {
+            addBLECommandBack((char*)"--txcapture on");
+        }
+
+        save_settings();
+
+        return;
+    }
+    else
+    if(commandCheck(msg_text+2, (char*)"txcapture off") == 0)
+    {
+        bTXCAPTURE=false;
+
+        meshcom_settings.node_sset4 &= ~0x0008;
+
+        if(ble)
+        {
+            addBLECommandBack((char*)"--txcapture off");
         }
 
         save_settings();
@@ -3209,14 +3303,14 @@ void commandAction(char *umsg_text, bool ble)
         return;
     }
     else
-    if(commandCheck(msg_text+2, (char*)"symid") == 0)
+    if(commandCheck(msg_text+2, (char*)"symid ") == 0)
     {
         _owner_c[0] = meshcom_settings.node_symid;
 
         meshcom_settings.node_symid=msg_text[8];
 
         bool bSymbolTable = false;
-        if(meshcom_settings.node_symid == '/' || meshcom_settings.node_symid != '\'')
+        if(meshcom_settings.node_symid == '/' || meshcom_settings.node_symid == '\\')
             bSymbolTable = true;
         else
         if(meshcom_settings.node_symid >= '0' && meshcom_settings.node_symid <= '9')
@@ -3239,7 +3333,7 @@ void commandAction(char *umsg_text, bool ble)
         return;
     }
     else
-    if(commandCheck(msg_text+2, (char*)"symcd") == 0)
+    if(commandCheck(msg_text+2, (char*)"symcd ") == 0)
     {
         _owner_c[0] = meshcom_settings.node_symcd;
 
@@ -4924,7 +5018,7 @@ void commandAction(char *umsg_text, bool ble)
             printfdeb("...Flash-Version %i\n", meshcom_settings.node_fversion);
 
             printfdeb("...NOMSGALL %s ...MESH %s ...BUTTON (%i) %s ...SOFTSER %s ... SOFTSERREAD %s\n...PASSWD <%s>\n",
-                (bNoMSGtoALL?"on":"off"), (bMESH?"on":"off"), ibt, (bButtonCheck?"on":"off"), (bSOFTSERON?"on":"off"), (bSOFTSERREAD?"on":"off"), meshcom_settings.node_passwd);
+                (bNoMSGtoALL?"on":"off"), (bMESH?"on":"off"), ibt, (bButtonCheck?"on":"off"), (bSOFTSERON?"on":"off"), (bSOFTSERREAD?"on":"off"), maskSecret(meshcom_settings.node_passwd));
 
             printfdeb("...DEBUG %s ...DEBUG %s\n", (bDEBUGCSV?"csv":"man"), (bDEBUGEN?"en":"de"));
 
@@ -4998,7 +5092,7 @@ void commandAction(char *umsg_text, bool ble)
 
             #ifndef BOARD_T_ECHO
             printfdeb("\n...Webserver  %s", (bWEBSERVER?"on":"off"));
-            printfdeb(" / Webpwd <%s>", meshcom_settings.node_webpwd);
+            printfdeb(" / Webpwd <%s>", maskSecret(meshcom_settings.node_webpwd));
             printfdeb(" / Gateway %s %s\n", (bGATEWAY?"on":"off"), (bGATEWAY_NOPOS?"nopos":""));
 
             #if defined(ESP32) && !defined(DISABLE_TLS_CONSOLE)
@@ -5021,7 +5115,7 @@ void commandAction(char *umsg_text, bool ble)
                         printfdeb("...SSID <>");
 
                     if(strlen(meshcom_settings.node_pwd) > 0)
-                        printfdeb(" / PASSWORD <%s>\n", meshcom_settings.node_pwd);
+                        printfdeb(" / PASSWORD <%s>\n", maskSecret(meshcom_settings.node_pwd));
                     else
                         printfdeb(" / PASSWORD <>\n");
                 }
@@ -5300,7 +5394,7 @@ void sendGpsJson()
     pdoc["ALT"] = meshcom_settings.node_alt;
     pdoc["SAT"] = (int)posinfo_satcount;
     pdoc["SFIX"] = posinfo_fix;
-    pdoc["HDOP"] = posinfo_hdop;
+    pdoc["HDOP"] = (int)fposinfo_hdop;
     pdoc["RATE"] = (int)posinfo_interval;
     pdoc["NEXT"] = (int)(((posinfo_timer + (posinfo_interval * 1000)) - millis()) / 1000);
     pdoc["DIST"] = posinfo_distance;

--- a/src/command_functions.h
+++ b/src/command_functions.h
@@ -4,6 +4,7 @@
 #include <Arduino.h>
 //#include <configuration.h>
 #include <debugconf.h>
+#include <mask_secret.h>
 
 void commandAction(char *msg_text, bool ble);
 void commandAction(char *msg_text, int iphone, bool rxFromPhone);

--- a/src/configuration_global.h
+++ b/src/configuration_global.h
@@ -2,7 +2,79 @@
 #define SOURCE_VERSION_SUB "p"
 #define SOURCE_VERSION_WEB_SUB "p"
 
+// Werkseinstellung des Rufzeichens und der zugehoerige "Node ist noch nicht
+// konfiguriert"-Test. Beides stand bisher als Literal an fuenf Stellen in drei
+// Images (esp32_main, nrf52_main, safeboot) und wurde dort unterschiedlich
+// geprueft -- safeboot testete vier Formen, die Mains drei, und der Default wurde
+// an einer weiteren Stelle erneut als Literal hingeschrieben. Aendert sich die
+// Werkseinstellung, muss das genau einmal hier passieren. ALT-34.
+#define DEFAULT_CALL "XX0XXX-00"
+#define DEFAULT_CALL_PREFIX "XX0XXX"
+
+// true, wenn das Rufzeichen noch die Werkseinstellung ist (oder leer/"none").
+// Der 6-Zeichen-Praefixtest deckt "XX0XXX-00" mit ab -- die vier Formen, die
+// safeboot einzeln geprueft hat, sind damit vollstaendig abgedeckt.
+#ifdef __cplusplus
+inline bool isNodeUnconfigured(const char *call)
+{
+    if (call == nullptr || call[0] == 0x00)
+        return true;
+    if (__builtin_memcmp(call, DEFAULT_CALL_PREFIX, 6) == 0)
+        return true;
+    if (__builtin_memcmp(call, "none", 4) == 0)
+        return true;
+    return false;
+}
+#endif
+
+// ---------------------------------------------------------------------------
+// Settings-Persistenz: Build-Kennung und Layout-Generation sind ZWEI Dinge
+//
+// FLASH_VERSION ist die Build-/Release-Kennung. Sie wird pro Release
+// hochgezogen, wird in --info angezeigt und ist rein informativ.
+//
+// FLASH_STRUCT_VERSION benennt die Generation des Settings-Layouts, also den
+// Aufbau von struct s_meshcom_settings. Sie wird NUR hochgezogen, wenn sich
+// dieses Layout tatsaechlich aendert -- Feld hinzugefuegt, entfernt, Typ oder
+// Reihenfolge geaendert.
+//
+// Nur FLASH_STRUCT_VERSION entscheidet ueber clear_flash(). Vorher wurde
+// FLASH_VERSION verglichen: damit hat JEDES Release mit neuem Datum die
+// Konfiguration jedes aktualisierenden Knotens geloescht -- Rufzeichen, WLAN,
+// Sensoren --, auch wenn sich am Layout nichts geaendert hatte. Genau das ist
+// beim Sprung 20260724 -> 20260821 passiert: dieser Commit hat esp32_flash.h
+// nicht angefasst, die Einstellungen aller Knoten aber trotzdem verworfen.
+//
+// Letzte echte Layout-Aenderung: 6e7c012a (2026-07-24), node_pingmax,
+// node_pingcount und node_pingduration kamen hinzu. Daher 20260724.
 #define FLASH_VERSION 20260724
+#define FLASH_STRUCT_VERSION 20260724
+
+// Bestandsschutz. Diese Staende tragen dasselbe Layout wie
+// FLASH_STRUCT_VERSION, haben aber wegen der alten Semantik noch ihr
+// Build-Datum in node_fversion stehen. Sie duerfen nicht zurueckgesetzt
+// werden, nur weil sich die Bedeutung des Feldes geaendert hat.
+//
+// Die Liste waechst NICHT weiter: ab dieser Version speichert der Knoten
+// FLASH_STRUCT_VERSION in node_fversion, nicht mehr das Datum.
+#define FLASH_STRUCT_LEGACY_COUNT 1
+static const int FLASH_STRUCT_LEGACY[FLASH_STRUCT_LEGACY_COUNT] = { 20260821 };
+
+/// @return true, wenn der gespeicherte Wert dasselbe Settings-Layout meint
+///         wie dieser Build -- dann darf NICHT geloescht werden.
+static inline bool flashLayoutCompatible(int stored)
+{
+    if (stored == FLASH_STRUCT_VERSION)
+        return true;
+
+    for (int i = 0; i < FLASH_STRUCT_LEGACY_COUNT; i++)
+    {
+        if (stored == FLASH_STRUCT_LEGACY[i])
+            return true;
+    }
+
+    return false;
+}
 
 //Hardware Types
 #define TLORA_V2 1
@@ -79,14 +151,24 @@
 #define ALIVERESET_INTERVAL 2 * 10 * 30    // 1/2 Stunde
 #define BLEBLINK_INTERVAL 3000             // BLEBLINK interval in milliseconds
 
-#if defined(ENABLE_XML)
-#define MAX_MHEARD 50                      // max count of messages in mheard ringbuffer
-#define MAX_MHPATH 50                      // max count of messages in mhpath ringbuffer
-#define MAX_RING 20                        // max count of messages in ringbuffer
-#define MAX_DEDUP_RING 60                  // dedup ring for received msg_ids (separate from TX ring)
-#define MAX_LOG 20                         // max count of messages in ringbuffer
-#define MAX_RING_UDP 20                    // size of Ringbuffer for UDP TX messages received from LoRa
-#elif defined(ENABLE_SBUFFER)
+// Auf diesen Boards muss der I2C-Bus vor einem Sensorzugriff neu aufgesetzt
+// werden (Wire.end() + Wire.begin()), sonst haengt der Bus. Die Bedingung stand
+// bisher an neun Stellen in vier Sensordateien einzeln -- und war bereits
+// auseinandergelaufen: bmx280.cpp fragte an zwei Stellen nur BOARD_TBEAM_V3 ab
+// und liess BOARD_E22_S3 aus. Einmal zentral definiert, damit das nicht wieder
+// driften kann. DRY-25.
+#if defined(BOARD_TBEAM_V3) || defined(BOARD_E22_S3)
+#define MC_I2C_NEEDS_BUS_RESET 1
+#else
+#define MC_I2C_NEEDS_BUS_RESET 0
+#endif
+
+// Eine Speicherklasse pro Zweig. Jeder Zweig MUSS alle sechs Konstanten setzen --
+// wer eine vergisst, bekommt keinen stillen Fehlwert, sondern einen Compile-Fehler,
+// weil die Konstanten Array-Groessen sind. ALT-33.
+#if defined(ENABLE_XML) || defined(ENABLE_SBUFFER)
+// ENABLE_XML und ENABLE_SBUFFER hatten bis 2026-08-18 zwei byte-identische Zweige
+// nebeneinander; zusammengelegt, damit sie nicht auseinanderlaufen koennen.
 #define MAX_MHEARD 50                      // max count of messages in mheard ringbuffer
 #define MAX_MHPATH 50                      // max count of messages in mhpath ringbuffer
 #define MAX_RING 20                        // max count of messages in ringbuffer
@@ -126,6 +208,9 @@
 
 #define MAX_HOP_TEXT_DEFAULT 4             // max hop set on text-message
 #define MAX_HOP_POS_DEFAULT 2              // max hop set on pos-message
+#define MAX_HOP_LIMIT 7                    // obere Schranke fuer {SET} und ACK-Plausibilitaet
+                                           // (Byte 5 einer ACK fuehrt max_hop in 7 Bit; im Feld
+                                           //  beobachtet: gueltige ACKs 0..4, Textpakete bis 5)
 
 #define RECEIVE_TIMEOUT 4500               // [SX126x] 4.5sec
 #define RADIOLIB_SX126X_CAD 0x07           // 0x00...length off    0x07...32-bit detect

--- a/src/dedup_functions.cpp
+++ b/src/dedup_functions.cpp
@@ -1,0 +1,106 @@
+// Siehe dedup_functions.h. Reine Verschiebung aus lora_functions.cpp und
+// loop_functions.cpp -- die Funktionsrümpfe sind unveraendert uebernommen.
+
+#include <string.h>
+
+#include <configuration.h>
+#include <printfdeb_functions.h>
+
+#include "dedup_functions.h"
+
+// Der RX-Mitschnitt und die [MC-DBG]-Zeilen haengen an bLORADEBUG
+// (Definition in loop_functions.cpp). Hier nur deklariert statt ueber
+// loop_functions_extern.h gezogen, damit dieses Modul nativ ohne den
+// kompletten Loop-Header uebersetzt. Der Typ muss exakt zur Definition
+// passen (bool) -- eine abweichende Deklaration waere ein ODR-Verstoss.
+extern bool bLORADEBUG;
+
+uint8_t ringBufferLoraRX[MAX_DEDUP_RING][5] = {0};
+ring_index_t loraWrite{0};
+
+/**@brief Function to check if we have a Lora packet already received
+ */
+bool is_new_packet(uint8_t compBuffer[4])
+{
+    for(int ib=0; ib<MAX_DEDUP_RING; ib++)
+    {
+            if (memcmp(compBuffer, ringBufferLoraRX[ib], 4) == 0)
+            {
+                if(bLORADEBUG)
+                {
+                    uint32_t dup_id = (uint32_t)compBuffer[0] |
+                                      ((uint32_t)compBuffer[1] << 8) |
+                                      ((uint32_t)compBuffer[2] << 16) |
+                                      ((uint32_t)compBuffer[3] << 24);
+                    if(bLORADEBUG)
+                        printfdeb("[MC-DBG] RX_DEDUP_DUP msg_id=%08X slot=%d\n",dup_id, ib);
+                }
+                return false;
+            }
+    }
+
+    if(bLORADEBUG)
+    {
+        uint32_t new_id = (uint32_t)compBuffer[0] |
+                          ((uint32_t)compBuffer[1] << 8) |
+                          ((uint32_t)compBuffer[2] << 16) |
+                          ((uint32_t)compBuffer[3] << 24);
+        if(bLORADEBUG)
+            printfdeb("[MC-DBG] RX_DEDUP_NEW msg_id=%08X\n", new_id);
+    }
+    return true;
+}
+
+/**@brief Function adding messages into outgoing UDP ringbuffer
+ *
+ */
+void addLoraRxBuffer(unsigned int msg_id, bool bserver)
+{
+    // RACE-03 fix: local copy for atomic index — write buffer content first,
+    // then atomically update index so readers see complete entries
+    uint8_t slot = loraWrite.load();
+
+    if(bLORADEBUG)
+        printfdeb("[MC-DBG] RX_DEDUP_ADD msg_id=%08X srv=%d slot=%d/%d\n",
+                      msg_id, bserver, slot, MAX_DEDUP_RING);
+
+    // byte 0-3 msg_id
+    ringBufferLoraRX[slot][3] = msg_id >> 24;
+    ringBufferLoraRX[slot][2] = msg_id >> 16;
+    ringBufferLoraRX[slot][1] = msg_id >> 8;
+    ringBufferLoraRX[slot][0] = msg_id;
+    ringBufferLoraRX[slot][4] = bserver ? 1 : 0;
+
+    uint8_t next = slot + 1;
+    if (next >= MAX_DEDUP_RING)
+        next = 0;
+    loraWrite.store(next);
+}
+
+int checkOwnRx(uint8_t compBuffer[4])
+{
+    for(int ilo=0; ilo<MAX_DEDUP_RING; ilo++)
+    {
+        if(memcmp(ringBufferLoraRX[ilo], compBuffer, 4) == 0)
+            return ilo;
+    }
+
+    return -1;
+}
+
+bool checkServerRx(uint8_t compBuffer[4])
+{
+    for(int ilo=0; ilo<MAX_DEDUP_RING; ilo++)
+    {
+        if(memcmp(ringBufferLoraRX[ilo], compBuffer, 4) == 0)
+        {
+            // MSG wurde von einem anderen GW gesendet
+            if(ringBufferLoraRX[ilo][4] == 1)
+                return true;
+
+            break;
+        }
+    }
+
+    return false;
+}

--- a/src/dedup_functions.h
+++ b/src/dedup_functions.h
@@ -1,0 +1,65 @@
+#pragma once
+
+// Deduplizierungsring fuer empfangene msg_id.
+//
+// Aus lora_functions.cpp (is_new_packet) und loop_functions.cpp (Ring,
+// addLoraRxBuffer, checkOwnRx, checkServerRx) herausgeloest -- REINE
+// VERSCHIEBUNG, Logik unveraendert. Dieselbe Bewegung wie bei
+// txring_functions.cpp und aus demselben Grund: die vier Funktionen greifen
+// auf genau ein Array zu, haengen an nichts weiter, und lassen sich so gegen
+// den Ereignismitschnitt echter Knoten nachfahren.
+//
+// Was der Ring tut: er merkt sich die letzten MAX_DEDUP_RING msg_id und
+// verhindert, dass dieselbe Nachricht ein zweites Mal ins Mesh geflutet wird.
+// Er ist ein reiner Verdraengungsring ohne Alterung -- das Gedaechtnisfenster
+// ist damit lastabhaengig: je mehr Verkehr, desto kuerzer.
+//
+// Feldmessung 2026-08-25 (DG0OPK-11/-12/-13, 48 Knotenstunden, MAX_DEDUP_RING
+// = 100, Fenster rund 38 min):
+//
+//   112 msg_id kehrten nach Verdraengung zurueck, davon
+//     1  echtes Duplikat (gleicher Absender, gleiche Nutzlast, anderer Pfad)
+//    96  msg_id-Wiederverwendung (andere Nachricht, gleiche id) -- Haeufung
+//        bei 180-210 min Abstand, kuerzester Fall 48,5 min
+//    15  nicht aufloesbar (ACK-Frames, die printBuffer_aprs nicht druckt)
+//
+// Daraus folgt die Groesse: ein groesserer Ring faengt praktisch nichts
+// zusaetzlich ab (das eine echte Duplikat), beginnt aber ab etwa 500
+// Eintraegen legitime Nachrichten zu unterdruecken, weil er in die
+// Wiederverwendung hineinreicht (52 von 96 Faellen). 100 bleibt.
+
+#include <stdint.h>
+
+#include "configuration.h"
+#include "ring_index.h"
+
+// Eintrag: Byte 0..3 msg_id (little endian), Byte 4 Server-Flag.
+extern uint8_t ringBufferLoraRX[MAX_DEDUP_RING][5];
+extern ring_index_t loraWrite;
+
+/**
+ * @brief Prueft, ob die msg_id noch nicht im Ring steht.
+ *
+ * @param compBuffer 4 Byte msg_id in Speicherreihenfolge (little endian).
+ * @return true, wenn die Nachricht neu ist und weitergeleitet werden darf.
+ */
+bool is_new_packet(uint8_t compBuffer[4]);
+
+/**
+ * @brief Traegt eine msg_id in den Ring ein und rueckt den Schreibzeiger vor.
+ *
+ * @param msg_id     die Kennung der empfangenen Nachricht
+ * @param msg_server true, wenn die Nachricht ueber einen Gateway/Server kam
+ */
+void addLoraRxBuffer(unsigned int msg_id, bool msg_server);
+
+/**
+ * @brief Sucht eine msg_id im Ring.
+ * @return Slotnummer, oder -1 wenn nicht enthalten.
+ */
+int checkOwnRx(uint8_t compBuffer[4]);
+
+/**
+ * @brief Prueft, ob die msg_id im Ring als "kam ueber einen Server" markiert ist.
+ */
+bool checkServerRx(uint8_t compBuffer[4]);

--- a/src/esp32/esp32_main.cpp
+++ b/src/esp32/esp32_main.cpp
@@ -12,6 +12,8 @@
 #include <Arduino.h>
 #include <atomic>
 #include <configuration.h>
+#include "capture_functions.h"
+#include "dedup_functions.h"
 #include <RadioLib.h>
 
 #include <Wire.h>               
@@ -26,6 +28,8 @@ SPIClass ethSPI(FSPI);
 #include "esp32_pmu.h"
 #include "esp32_flash.h"
 #include <esp_adc_cal.h>
+#include "esp_system.h"
+#include "esp_task_wdt.h"
 
 #if not defined(BOARD_T_DECK_PRO)
 //====== Timer for periodical events u.a.
@@ -474,10 +478,7 @@ unsigned long inoReceiveTimeOutTime = 0;
 std::atomic<bool> transmittedFlag{false};
 std::atomic<bool> bEnableInterruptTransmit{false};
 
-// flag to indicate that a packet was detected or CAD timed out
-volatile bool scanFlag = false;
-
-// flag to indicate one second 
+// flag to indicate one second
 unsigned long retransmit_timer = 0;
 
 // blink frequency for board_led
@@ -585,7 +586,7 @@ float getTempForNTC()
 {
     static float temperature = 0.0f;
     static uint32_t check_temperature = 0;
-    if (millis() > check_temperature) {
+    if ((int32_t)(millis() - check_temperature) > 0) {
         analogSetAttenuation(ADC_11db); // bis <2,2V
         float voltage = analogReadMilliVolts(NTC_PIN);
         uint16_t raw = analogReadRaw(NTC_PIN);
@@ -617,10 +618,13 @@ void esp32setup()
 // 1.1.1??   pinMode(45,OUTPUT);
 // 1.1.1??    digitalWrite(45, LOW);
 
-    // Wartet maximal 3 Sekunden auf den seriellen Monitor
+    // Wartet maximal 5 Sekunden auf den seriellen Monitor.
+    // Achtung: delay() füttert den Task-Watchdog NICHT -- nur
+    // esp_task_wdt_reset() tut das. Diese Schleife ist nur deshalb
+    // unkritisch, weil esp32setup() bewusst nicht überwacht wird (N-25/S1).
     unsigned long startTime = millis();
     while (!Serial && (millis() - startTime < 5000)) {
-        delay(10); // Verhindert das Auslösen des Watchdog-Timers
+        delay(10);
     }
 
     #if defined(HAS_TFT_CONNECT)
@@ -731,9 +735,12 @@ void esp32setup()
 
     printfdeb("[INIT]...build %s / %s\n", __DATE__, __TIME__);
 
-    if(meshcom_settings.node_fversion != FLASH_VERSION || bClear)
+    // Geloescht wird nur bei echter Layout-Aenderung, nicht bei jedem neuen
+    // Build-Datum. Siehe configuration_global.h.
+    if(!flashLayoutCompatible(meshcom_settings.node_fversion) || bClear)
     {
-        printfdeb("[INIT]...FLASH cleared new version %i\n", FLASH_VERSION);
+        printfdeb("[INIT]...FLASH cleared, Settings-Layout %i -> %i\n",
+                  meshcom_settings.node_fversion, FLASH_STRUCT_VERSION);
 
         initTimePersistence();
 
@@ -741,13 +748,14 @@ void esp32setup()
     }
     else
     {
-        printfdeb("[INIT]...FLASH version %i\n", meshcom_settings.node_fversion);
+        printfdeb("[INIT]...FLASH layout %i ok, build %i\n",
+                  meshcom_settings.node_fversion, FLASH_VERSION);
     }
 
     if(bClear)
         init_flash();
 
-    meshcom_settings.node_fversion = FLASH_VERSION;
+    meshcom_settings.node_fversion = FLASH_STRUCT_VERSION;
     meshcom_settings.node_mversion = MODUL_HARDWARE;
     meshcom_settings.node_cleanflash = 0;
     snprintf(meshcom_settings.node_fwversion, sizeof(meshcom_settings.node_fwversion), "%-4.4s%-1.1s", SOURCE_VERSION, SOURCE_VERSION_SUB);
@@ -823,6 +831,7 @@ void esp32setup()
     bDEBUGCSV = meshcom_settings.node_sset4 & 0x0001;
     bDEBUGEN = meshcom_settings.node_sset4 & 0x0002;
     bDisplayLog = meshcom_settings.node_sset4 & 0x0004;
+    bTXCAPTURE = meshcom_settings.node_sset4 & 0x0008;
 
     if(strlen(meshcom_settings.node_aprsmc) < 4)
     {
@@ -866,7 +875,7 @@ void esp32setup()
     #endif
 
     // if Node not set --> WifiAP Mode on
-    if(memcmp(meshcom_settings.node_call, "XX0XXX", 6) == 0 || meshcom_settings.node_call[0] == 0x00 || memcmp(meshcom_settings.node_call, "none", 4) == 0)
+    if(isNodeUnconfigured(meshcom_settings.node_call))
     {
         bWIFIAP = true;
         printlndeb("[INIT]...WIFIAP starting...");
@@ -1002,7 +1011,7 @@ void esp32setup()
         #endif
     }
 
-    if(memcmp(meshcom_settings.node_ssid, "XX0XXX", 6) == 0)
+    if(memcmp(meshcom_settings.node_ssid, DEFAULT_CALL_PREFIX, 6) == 0)
     {
         snprintf(meshcom_settings.node_ssid, sizeof(meshcom_settings.node_ssid), (char*)"none");
         snprintf(meshcom_settings.node_pwd, sizeof(meshcom_settings.node_pwd), (char*)"none");
@@ -1424,12 +1433,14 @@ void esp32setup()
         #if defined(BOARD_T_DECK_PRO)
         if (radio.setOutputPower(tx_power) == RADIOLIB_ERR_INVALID_OUTPUT_POWER) {
             printlndeb(F("Selected output power is invalid for this module!"));
-            while (true);
+            Serial.printf("[LoRa] radio config failed, restarting\n");
+            esp_restart();
         }
         #else
         if (radio.setOutputPower(tx_power, false) == RADIOLIB_ERR_INVALID_OUTPUT_POWER) {
             printlndeb(F("Selected output power is invalid for this module!"));
-            while (true);
+            Serial.printf("[LoRa] radio config failed, restarting\n");
+            esp_restart();
         }
         #endif
 
@@ -1437,7 +1448,8 @@ void esp32setup()
         // NOTE: set value to 0 to disable overcurrent protection
         if (radio.setCurrentLimit(CURRENT_LIMIT) == RADIOLIB_ERR_INVALID_CURRENT_LIMIT) {
             printlndeb(F("Selected current limit is invalid for this module!"));
-            while (true);
+            Serial.printf("[LoRa] radio config failed, restarting\n");
+            esp_restart();
         }
 
         // set LoRa preamble length to 15 symbols (accepted range is 6 - 65535)
@@ -1445,7 +1457,8 @@ void esp32setup()
         
         if (radio.setPreambleLength(meshcom_settings.node_preamplebits) == RADIOLIB_ERR_INVALID_PREAMBLE_LENGTH) {
             printlndeb(F("Selected preamble length is invalid for this module!"));
-            while (true);
+            Serial.printf("[LoRa] radio config failed, restarting\n");
+            esp_restart();
         }
 
         #if defined(SX127X)
@@ -1455,7 +1468,8 @@ void esp32setup()
         if (radio.setGain(0) == RADIOLIB_ERR_INVALID_GAIN)
         {
             printlndeb(F("Selected gain is invalid for this module!"));
-            while (true);
+            Serial.printf("[LoRa] radio config failed, restarting\n");
+            esp_restart();
         }
 
         // set the function that will be called
@@ -1492,7 +1506,8 @@ void esp32setup()
         if (radio.setCRC(true) == RADIOLIB_ERR_INVALID_CRC_CONFIGURATION)
         {
             printlndeb(F("Selected CRC is invalid for this module!"));
-            while (true);
+            Serial.printf("[LoRa] radio config failed, restarting\n");
+            esp_restart();
         }
 
         #endif
@@ -1532,7 +1547,8 @@ void esp32setup()
         if (radio.setCRC(2) == RADIOLIB_ERR_INVALID_CRC_CONFIGURATION)
         {
             printlndeb(F("Selected CRC is invalid for this module!"));
-            while (true);
+            Serial.printf("[LoRa] radio config failed, restarting\n");
+            esp_restart();
         }
         #endif
 
@@ -1565,10 +1581,11 @@ void esp32setup()
             if (radio.setCRC(2) == RADIOLIB_ERR_INVALID_CRC_CONFIGURATION)
             {
                 printlndeb("Selected CRC is invalid for this module!");
-                while (true);
+                Serial.printf("[LoRa] radio config failed, restarting\n");
+                esp_restart();
             }
         #endif
-        
+
         // setup for E220 Radios
         #if defined(BOARD_E220)
 
@@ -1591,9 +1608,10 @@ void esp32setup()
             // enable CRC
             if (radio.setCRC(2) == RADIOLIB_ERR_INVALID_CRC_CONFIGURATION) {
                 printlndeb(F("Selected CRC is invalid for this module!"));
-                while (true);
+                Serial.printf("[LoRa] radio config failed, restarting\n");
+                esp_restart();
             }
-        
+
         #endif
     }
 
@@ -1604,7 +1622,7 @@ void esp32setup()
 
     if(meshcom_settings.node_call[0] == 0x00)
     {
-        snprintf(meshcom_settings.node_call, sizeof(meshcom_settings.node_call), "%s", (char*)"XX0XXX-00");
+        snprintf(meshcom_settings.node_call, sizeof(meshcom_settings.node_call), "%s", (char*)DEFAULT_CALL);
     }
 
     // Create the BLE Device & WiFiAP
@@ -1769,6 +1787,14 @@ void esp32setup()
             digitalWrite(RELAY_SWITCH, HIGH);
     #endif
 
+    // N-25/S1: Der Task-Watchdog wird erst hier scharf geschaltet, nicht am
+    // Anfang von esp32setup(). setup() führt legitim sekundenlange
+    // Einmal-Initialisierung aus (USB-CDC-Wartezeit, Display-Timeouts,
+    // MCU811, die while(true)-Fehlerpfade der Peripherie-Init). Diese zu
+    // überwachen war nie Sinn der Maßnahme -- sie hätte diagnostizierbare
+    // Hänger in einen anonymen Boot-Loop verwandelt. Bewacht wird ab jetzt
+    // ausschließlich esp32loop(), das sich in :esp32loop() selbst füttert.
+    esp_task_wdt_add(NULL);
 }
 
 // BLE TX Function -> Node to Client
@@ -1788,7 +1814,6 @@ void esp32_write_ble(uint8_t confBuff[300], uint8_t conf_len)
 // the local-radio loop and the external-radio path flush pending RX displays.
 static void flushDeferredDisplayUpdates()
 {
-    portENTER_CRITICAL(&displayMux);
     bool _pendText = bPendingDisplayText;
     bool _pendPos = bPendingDisplayPos;
     struct aprsMessage _msg;
@@ -1801,13 +1826,14 @@ static void flushDeferredDisplayUpdates()
         bPendingDisplayText = false;
         bPendingDisplayPos = false;
     }
-    portEXIT_CRITICAL(&displayMux);
     if(_pendText) sendDisplayText(_msg, _rssi, _snr);
     if(_pendPos)  sendDisplayPosition(_msg, _rssi, _snr);
 }
 
 void esp32loop()
 {
+    esp_task_wdt_reset();
+
     #if not defined(BOARD_T_DECK_PRO)
     btn.tick();
     #endif
@@ -1895,7 +1921,7 @@ void esp32loop()
             }
             else
             {
-                if(pixels_delay + DELAYVAL < millis())
+                if((uint32_t)(millis() - pixels_delay) >= DELAYVAL)
                 {
                     pixels_delay = 0;
                     bLED_CLEAR=true;
@@ -1908,7 +1934,7 @@ void esp32loop()
     #ifdef BOARD_LED
         if(bUSER_BOARD_LED)
         {
-            if ((led_timer + 1000) < millis())   // repeat 1 seconds
+            if ((uint32_t)(millis() - led_timer) >= 1000)   // repeat 1 seconds
             {
                 #ifdef LED_PIN
                     if(pixels_delay == 0 && !bLED_CLEAR)
@@ -1948,7 +1974,7 @@ void esp32loop()
         if(inoReceiveTimeOutTime > 0)
         {
             // Timeout RECEIVE_TIMEOUT
-            if((inoReceiveTimeOutTime + (60 * 6 * 1000)) < millis())  // 6 Minuten
+            if((uint32_t)(millis() - inoReceiveTimeOutTime) >= (60 * 6 * 1000))  // 6 Minuten
             {
                 inoReceiveTimeOutTime=0;
 
@@ -1964,7 +1990,7 @@ void esp32loop()
         // Retransmission status must tick on ALL nodes (including gateways).
         // Without this, gateway text messages stay stuck at RING_STATUS_SENT
         // forever if no echo is received via LoRa (RING_ZOMBIE).
-        if ((retransmit_timer + (1000 * 2)) < millis())
+        if ((uint32_t)(millis() - retransmit_timer) >= (1000 * 2))
         {
             updateRetransmissionStatus();
 
@@ -2115,7 +2141,7 @@ void esp32loop()
         if(iReceiveTimeOutTime > 0)
         {
             // Timeout csma_timeout (slot-basierter Backoff)
-            if((iReceiveTimeOutTime + csma_timeout) < millis())
+            if((uint32_t)(millis() - iReceiveTimeOutTime) >= csma_timeout)
             {
                 // Debug A: RX_TIMEOUT_FIRE
                 if(bLORADEBUG)
@@ -2554,7 +2580,7 @@ void esp32loop()
         strTime = "none";
 
         // every 15 minutes
-        if((updateTimeClient + 1000 * 60 * 15) < millis() || updateTimeClient == 0)
+        if((uint32_t)(millis() - updateTimeClient) >= 1000 * 60 * 15 || updateTimeClient == 0)
         {
             strTime = udpUpdateTimeClient();
 
@@ -2606,7 +2632,7 @@ void esp32loop()
 
         if(posinfo_fix) // GPS hat Vorang zur RTC und setzt RTC
         {
-            if((rtc_refresh_timer + 60000) > millis())
+            if((uint32_t)(millis() - rtc_refresh_timer) < 60000)
             {
                 //only every minute
                 setRTCNow(meshcom_settings.node_date_year, meshcom_settings.node_date_month, meshcom_settings.node_date_day, meshcom_settings.node_date_hour, meshcom_settings.node_date_minute, meshcom_settings.node_date_second);
@@ -2673,7 +2699,7 @@ void esp32loop()
             #if defined(ENABLE_RTC)
             if(bRTCON && bNTPDateTimeValid) // NTP hat Vorang zur RTC und setzt RTC
             {
-                if((rtc_refresh_timer + 60000) > millis())
+                if((uint32_t)(millis() - rtc_refresh_timer) < 60000)
                 {
                     //only every minute
                     setRTCNow(meshcom_settings.node_date_year, meshcom_settings.node_date_month, meshcom_settings.node_date_day, meshcom_settings.node_date_hour, meshcom_settings.node_date_minute, meshcom_settings.node_date_second);
@@ -2708,7 +2734,7 @@ void esp32loop()
     #endif
 
     // check WiFI connected with Ping every 30 sec
-    if(meshcom_settings.node_netmode == 0 && (wifi_active_timer + 30000) < millis())
+    if(meshcom_settings.node_netmode == 0 && (uint32_t)(millis() - wifi_active_timer) >= 30000)
     {
         if(!checkWifiPing())
         {
@@ -2750,7 +2776,7 @@ void esp32loop()
             }
 
             // check every 15 minuten to check telemetry via serial interface is ok
-            if ((lTELE_TIMER + (15 * 60 * 1000)) < millis())
+            if ((int32_t)(millis() - (lTELE_TIMER + (15 * 60 * 1000))) > 0)
             {
                 printfdeb("[SOFTSER] Reset Node, XML not working\n");
                 delay(1000);
@@ -2759,7 +2785,7 @@ void esp32loop()
             #endif
 
             // check every 5 seconds to ready next telemetry via serial interface
-            if ((softser_refresh_timer + 5000) < millis() && softserFunktion == 0)
+            if ((uint32_t)(millis() - softser_refresh_timer) >= 5000 && softserFunktion == 0)
             {
                 if(lastSOFTSER_MINUTE != meshcom_settings.node_date_minute && meshcom_settings.node_date_second > 20)
                 {
@@ -2892,7 +2918,7 @@ void esp32loop()
         else
         {
             // wait after BLE Connect 3 sec.
-            if(millis() < config_to_phone_prepare_timer + 3000)
+            if((uint32_t)(millis() - config_to_phone_prepare_timer) < 3000)
                 iPhoneState = 0;
 
             if (iPhoneState > 3)   // only every 3 times of mainloop send to phone - main loop has no additional delay anymore! 14.06.2025
@@ -2903,7 +2929,7 @@ void esp32loop()
                 if (ComToPhoneWrite != ComToPhoneRead)
                 {
                     // check every 300 ms to send to phone
-                    if ((ble_wait + 300) < millis())
+                    if ((uint32_t)(millis() - ble_wait) >= 300)
                     {
                         sendComToPhone();
 
@@ -2913,7 +2939,7 @@ void esp32loop()
                 else if (toPhoneWrite != toPhoneRead)
                 {
                     // wait for each message to send to phone
-                    if ((ble_wait + 400) < millis())
+                    if ((uint32_t)(millis() - ble_wait) >= 400)
                     {
                         sendToPhone();
 
@@ -2934,7 +2960,7 @@ void esp32loop()
         }
 
         // 5 minuten
-        if((config_to_phone_datetime_timer + (5 * 60 * 1000)) < millis())
+        if((uint32_t)(millis() - config_to_phone_datetime_timer) >= (5 * 60 * 1000))
         {
             bNTPDateTimeValid=false;
 
@@ -2945,7 +2971,7 @@ void esp32loop()
 
     #if defined(ENABLE_MCP23017)
     // 5 sec
-    if ((mcp_refresh_timer + 5000) < millis())
+    if ((uint32_t)(millis() - mcp_refresh_timer) >= 5000)
     {
         // get i/o state
         if(loopMCP23017())
@@ -2969,7 +2995,7 @@ void esp32loop()
         gps_refresh_intervall = 1.0;
     }
 
-    if ((gps_refresh_timer + ((unsigned long)gps_refresh_intervall * 1000)) < millis())
+    if ((uint32_t)(millis() - gps_refresh_timer) >= ((unsigned long)gps_refresh_intervall * 1000))
     {
         #ifdef ENABLE_GPS
 
@@ -2992,7 +3018,7 @@ void esp32loop()
 
             posinfo_fix = false;
             posinfo_satcount = 0;
-            posinfo_hdop = 0;
+            fposinfo_hdop = 0.0;
         }
         else
         {
@@ -3101,7 +3127,7 @@ void esp32loop()
     if(ncnt_hold != incnt)
     {
         // minimal alle 60 sec
-        if((posinfo_timer_min + 60000) < millis())
+        if((uint32_t)(millis() - posinfo_timer_min) >= 60000)
         {
             posinfo_shot = true;
             ncnt_hold = incnt;
@@ -3109,10 +3135,10 @@ void esp32loop()
     }
 
     // posinfo_interval in Seconds
-    if (((posinfo_timer + (posinfo_interval * 1000)) < millis()) || (millis() > 100000 && millis() < 130000 && bPosFirst) || posinfo_shot)
+    if (((uint32_t)(millis() - posinfo_timer) >= (posinfo_interval * 1000)) || (millis() > 100000 && millis() < 130000 && bPosFirst) || posinfo_shot)
     {
         // minimal transmit time only max 30 sec
-        if((posinfo_timer_min + 30000) < millis())
+        if((uint32_t)(millis() - posinfo_timer_min) >= 30000)
         {
             if(bDisplayInfo)
             {
@@ -3190,7 +3216,7 @@ void esp32loop()
     #if defined(ENABLE_SOFTSER)
         extra_hey_time = 10 * 60 * 1000; // 10 minutes extra
     #endif
-    if (((heyinfo_timer + trickle_interval_ms + extra_hey_time) < millis()) || (bHeyFirst && bAllStarted))
+    if (((uint32_t)(millis() - heyinfo_timer) >= (trickle_interval_ms + extra_hey_time)) || (bHeyFirst && bAllStarted))
     {
         bHeyFirst = false;
 
@@ -3243,7 +3269,7 @@ void esp32loop()
         akt_timer = 20 * 1000; // 20 Seconds PARM, UNIT, EQNS and 1st T-Message
     }
         
-    if (((telemetry_timer + akt_timer) < millis()) || (bTeleFirst && bAllStarted))
+    if (((uint32_t)(millis() - telemetry_timer) >= akt_timer) || (bTeleFirst && bAllStarted))
     {
         bTeleFirst=false;
 
@@ -3259,7 +3285,7 @@ void esp32loop()
     #if not defined(BOARD_T_DECK_PRO)
     if(DisplayOffWait > 0)
     {
-        if (millis() > DisplayOffWait)
+        if ((int32_t)(millis() - DisplayOffWait) > 0)
         {
             DisplayOffWait = 0;
             if(bDisplayOff)
@@ -3280,7 +3306,7 @@ void esp32loop()
     // rebootAuto
     if(rebootAuto > 0)
     {
-        if (millis() > rebootAuto)
+        if ((int32_t)(millis() - rebootAuto) > 0)
         {
             rebootAuto = 0;
 
@@ -3295,7 +3321,7 @@ void esp32loop()
     if(BattTimeWait == 0)
         BattTimeWait = millis() - 500;
 
-    if ((BattTimeWait + 500) < millis())  // 0.5 sec OE3WAS
+    if ((uint32_t)(millis() - BattTimeWait) >= 500)  // 0.5 sec OE3WAS
     {
         BattWaitCounter++;
 
@@ -3327,6 +3353,12 @@ void esp32loop()
                 {
                     global_batt = 0;
                     global_proz = 0;
+
+                    // Ohne PMU gibt es keine Messung. Ohne diese Zeile wuerde
+                    // PositionToAPRS() jetzt dauerhaft "/B=000" senden und damit
+                    // "Akku leer" behaupten, wo in Wahrheit "nicht messbar" gilt --
+                    // genau die Falschmeldung, die der /B=000-Fix beseitigen soll.
+                    battProbeState = BATT_PROBE_NONE;
                 }
 
                 if(bDisplayCont && BattWaitCounter > 20)
@@ -3391,7 +3423,7 @@ void esp32loop()
         if (heapMonTimer == 0)
             heapMonTimer = millis();
 
-        if ((heapMonTimer + 60000) < millis())
+        if ((uint32_t)(millis() - heapMonTimer) >= 60000)
         {
             if(ESP.getFreeHeap() != lFreeHeap || ESP.getFreePsram() != lFreePsram)
             {
@@ -3420,7 +3452,7 @@ void esp32loop()
     #ifdef OneWire_GPIO
     if(bONEWIRE)
     {
-        if ((onewireTimeWait + 30000) < millis())  // 30 sec
+        if ((uint32_t)(millis() - onewireTimeWait) >= 30000)  // 30 sec
         {
             unsigned long lreduction = 0;
 
@@ -3460,7 +3492,7 @@ void esp32loop()
     {
         unsigned long lreduction = 0;
 
-        if ((BMXTimeWait + 60000) < millis())   // 60 sec
+        if ((uint32_t)(millis() - BMXTimeWait) >= 60000)   // 60 sec
         {
             #if defined(ENABLE_BMX280)
                 if(loopBMX280())
@@ -3523,7 +3555,7 @@ void esp32loop()
     #if defined(ENABLE_BMP390)
     if((bBMP3ON && bmp3_found))
     {
-        if ((BMP3TimeWait + 60000) < millis())   // 60 sec
+        if ((uint32_t)(millis() - BMP3TimeWait) >= 60000)   // 60 sec
         {
             if(loopBMP390())
             {
@@ -3544,7 +3576,7 @@ void esp32loop()
     #if defined(ENABLE_MC811)
     if(bMCU811ON && mcu811_found)
     {
-        if ((MCU811TimeWait + 60000) < millis())   // 60 sec
+        if ((uint32_t)(millis() - MCU811TimeWait) >= 60000)   // 60 sec
         {
             // read MCU-811 Sensor
             if(loopMCU811())
@@ -3569,7 +3601,7 @@ void esp32loop()
         if(INA226TimeWait == 0)
             INA226TimeWait = millis() - 10000;
 
-        if ((INA226TimeWait + 15000) < millis())   // 15 sec
+        if ((uint32_t)(millis() - INA226TimeWait) >= 15000)   // 15 sec
         {
             // read INA226 Sensor
             if(loopINA226())
@@ -3589,7 +3621,7 @@ void esp32loop()
     #if defined(ENABLE_BMX680)
     if(bBME680ON && bme680_found)
     {
-        if ((bme680_timer + 60000) < millis() || delay_bme680 <= 0)
+        if ((uint32_t)(millis() - bme680_timer) >= 60000 || delay_bme680 <= 0)
         {
             #if defined(ENABLE_BMX280)
                 
@@ -3623,7 +3655,7 @@ void esp32loop()
         sendMeshComUDP();
 
         // heartbeat
-        if ((hb_timer + (HEARTBEAT_INTERVAL * 1000)) < millis())
+        if ((uint32_t)(millis() - hb_timer) >= (HEARTBEAT_INTERVAL * 1000))
         {
             sendMeshComHeartbeat();
             hb_timer = millis();
@@ -3686,7 +3718,7 @@ void esp32loop()
 
     if(bWEBSERVER || bEXTUDP || bGATEWAY || bNETCONSOLE)
     {
-        if (web_timer == 0 || (iWlanWait > 0 && ((web_timer + 1000) < millis())) || ((web_timer + (HEARTBEAT_INTERVAL * 1000 * 10)) < millis()))   // repeat 5 minutes
+        if (web_timer == 0 || (iWlanWait > 0 && ((uint32_t)(millis() - web_timer) >= 1000)) || ((uint32_t)(millis() - web_timer) >= (HEARTBEAT_INTERVAL * 1000 * 10)))   // repeat 5 minutes
         {
 
             web_timer = millis();
@@ -3781,7 +3813,7 @@ void esp32loop()
 
     if(meshcom_settings.node_pingtime > 29 && meshcom_settings.node_pingcall[0] != 0x00 && meshcom_settings.node_pingcount > 0)
     {
-        if((resendPing + meshcom_settings.node_pingtime * 1000) < millis())
+        if((int32_t)(millis() - (resendPing + meshcom_settings.node_pingtime * 1000)) > 0)
         {
             if(bPingSend)
             {
@@ -3801,7 +3833,7 @@ void esp32loop()
 
     #if defined(BOARD_T_DECK) || defined(BOARD_T_DECK_PLUS)
 
-    if ((tdeck_tft_timer + (TDECK_TFT_TIMEOUT * 1000)) < millis())
+    if ((uint32_t)(millis() - tdeck_tft_timer) >= (TDECK_TFT_TIMEOUT * 1000))
     {
         // printfdeb("Loop: Timeout reached. Timer: %lu, Millis: %lu\n", tdeck_tft_timer, millis());
         tft_off();
@@ -3821,7 +3853,7 @@ void esp32loop()
     //    the normal budget, and skips RING_STATUS_EXT_PENDING. It touches only the
     //    ring (no CAD/TX/RX/RadioLib). A requeued retry becomes a READY slot that
     //    externalRadioTxStep() submits with a fresh ownership token.
-    if((retransmit_timer + (1000 * 2)) < millis())
+    if((int32_t)(millis() - (retransmit_timer + (1000 * 2))) > 0)
     {
         updateRetransmissionStatus();
         retransmit_timer = millis();
@@ -3870,8 +3902,27 @@ int checkRX(bool bRadio)
     is_receiving=true;
 
     uint8_t payload[UDP_TX_BUF_SIZE+10];
-    
-    size_t ibytes = UDP_TX_BUF_SIZE;
+
+    // Die echte Paketlaenge muss VOR readData() vom Chip gelesen werden.
+    // RadioLib nimmt `len` per WERT und schreibt die tatsaechliche Laenge NICHT
+    // zurueck -- es dient nur als obere Schranke (SX126x::readData, dokumentiert
+    // in SX126x.h: "getPacketLength method must be called BEFORE calling
+    // readData!"). Wer hier UDP_TX_BUF_SIZE uebergibt, bekommt fuer JEDES Paket
+    // 255 heraus, egal wie kurz der Frame war: readData fuellt nur die echten
+    // Bytes, der Rest von `payload` bleibt uninitialisierter Stackinhalt.
+    //
+    // Am Mitschnitt eines laufenden Knotens gemessen (DK5EN-98, 25.08.2026):
+    // jedes RX_FRAME meldete len=255 bei tatsaechlich 48-133 Byte, gefolgt von
+    // immer demselben Stackmuster. Zwei Folgen davon:
+    //   - Kanalauslastung: getTimeOnAir(255) buchte fuer JEDEN Empfang 2476 ms
+    //     statt der echten 608-1394 ms -- rx war um Faktor 1,8-4,1 zu hoch.
+    //   - Korpus/Diagnose: CRC_PAYLOAD- und Mitschnitt-Dumps hingen ~190 Byte
+    //     RAM-Inhalt an jeden Frame.
+    // Auf nRF52 tritt das nicht auf, dort liefert der Radio-Callback die Laenge.
+    size_t ibytes = radio.getPacketLength();
+
+    if(ibytes > UDP_TX_BUF_SIZE)
+        ibytes = UDP_TX_BUF_SIZE;
 
     state = radio.readData(payload, ibytes);
 
@@ -3934,9 +3985,19 @@ int checkRX(bool bRadio)
 
         // RX channel utilization: calculate airtime from packet length
         // (ESP32 has no OnHeaderDetect, so ch_util_rx_start is never set)
-        ch_util_rx_accum.fetch_add(radio.getTimeOnAir(ibytes) / 1000);  // us -> ms
+        if(ibytes > 0)
+        {
+            ch_util_rx_accum.fetch_add(radio.getTimeOnAir(ibytes) / 1000);  // us -> ms
 
-        OnRxDone(payload, (uint16_t)ibytes, saved_rssi, saved_snr);
+            OnRxDone(payload, (uint16_t)ibytes, saved_rssi, saved_snr);
+        }
+        else
+        if(bLORADEBUG)
+        {
+            // Laenge 0 heisst: der Chip hat nichts im Puffer. Frueher lief das
+            // als 255-Byte-Frame aus uninitialisiertem Stack weiter.
+            printlndeb("[MC-DBG] CHECKRX zero_length");
+        }
     }
     else
     if (state == RADIOLIB_ERR_CRC_MISMATCH)

--- a/src/extudp_functions.cpp
+++ b/src/extudp_functions.cpp
@@ -1,4 +1,5 @@
 #include <Arduino.h>
+#include <atomic>
 
 #include <extudp_functions.h>
 #include <loop_functions.h>
@@ -51,7 +52,7 @@ struct externQueueEntry {
     int16_t  rssi;
     int8_t   snr;
     char     src_type[8];
-    bool     used;
+    std::atomic<bool> used{false};
 };
 static struct externQueueEntry externQueue[MAX_EXTERN_QUEUE];
 static int externQueueWrite = 0;
@@ -295,6 +296,32 @@ void getExternUDP()
   if(!hasExternIPaddress)
     return;
 
+#ifdef MC_TEST_HOOKS
+  // N-20-Soak-Instrumentierung (compile-gated, Produktionsbuilds unberuehrt):
+  // sequenznummerierter Takt an den EXTUDP-Peer alle 500 ms. Eine Luecke in
+  // seq zeigt von aussen praezise, WANN der Sendepfad stockte; der Abgleich
+  // mit der Serial-Echo-Probe unterscheidet "Netz weg, Loop lebt" von
+  // "Loop-Task haengt". Bewusst im normalen Loop-Kontext gesendet -- der
+  // Takt IST die Last auf genau dem Socket-Pfad, den der Kabel-Flap trifft.
+  {
+    static uint32_t hb_seq = 0;
+    static unsigned long hb_last = 0;
+    if((unsigned long)(millis() - hb_last) >= 500)
+    {
+      hb_last = millis();
+      char hb[80];
+      int hlen = snprintf(hb, sizeof(hb), "{\"type\":\"hb\",\"seq\":%lu,\"ms\":%lu}",
+                          (unsigned long)hb_seq++, (unsigned long)millis());
+      if(hlen > 0)
+      {
+        UdpExtern.beginPacket(apip, EXTERN_PORT);
+        UdpExtern.write((const uint8_t *)hb, (size_t)hlen);
+        UdpExtern.endPacket();
+      }
+    }
+  }
+#endif
+
   int len=0;
 
   if(bEXTUDP && (int)strlen(meshcom_settings.node_extern) > 7)
@@ -304,7 +331,7 @@ void getExternUDP()
     
     if (packetExtSize > 0)
     {
-      len = UdpExtern.read(incomingExtPacket, UDP_TX_BUF_SIZE);
+      len = UdpExtern.read(incomingExtPacket, UDP_TX_BUF_SIZE - 1);
     }
   }
 
@@ -319,6 +346,7 @@ void getExternUDP()
 
 void sendExtern(bool bUDP, char *src_type, uint8_t buffer[500], uint16_t buflen, int16_t rssi, int8_t snr)
 {
+  (void)bUDP;
   #ifdef ESP32
     if(bWIFIAP)
       return;
@@ -340,8 +368,18 @@ void sendExtern(bool bUDP, char *src_type, uint8_t buffer[500], uint16_t buflen,
     return;
   }
 
+  // ESP32 Loop-Task-Stack = 8 KB → 1000 B auf Stack ok.
+  // nRF52 Loop-Task-Stack = 4 KB → BSS, sonst Stack-Overflow Crash bei
+  // sendPosition → sendExtern (siehe Commit 1951aa7d, fix RAK4631).
+#ifdef ESP32
   char c_json[500] = {0};
   char c_tjson[500] = {0};
+#else
+  static char c_json[500];
+  static char c_tjson[500];
+  memset(c_json, 0, sizeof(c_json));
+  memset(c_tjson, 0, sizeof(c_tjson));
+#endif
 
   char escape_symbol[3];
   char escape_group[3];
@@ -582,13 +620,17 @@ void sendExtern(bool bUDP, char *src_type, uint8_t buffer[500], uint16_t buflen,
 void queueExtern(char *src_type, uint8_t buffer[500], uint16_t buflen, int16_t rssi, int8_t snr)
 {
     struct externQueueEntry *entry = &externQueue[externQueueWrite];
-    if(buflen > 500) buflen = 500;
+    if(buflen > sizeof(entry->buffer)) {
+        Serial.printf("[EXT] queueExtern: buflen %u > %u, dropped\n",
+                      (unsigned)buflen, (unsigned)sizeof(entry->buffer));
+        return;
+    }
     memcpy(entry->buffer, buffer, buflen);
     entry->buflen = buflen;
     entry->rssi = rssi;
     entry->snr = snr;
     snprintf(entry->src_type, sizeof(entry->src_type), "%s", src_type);
-    entry->used = true;
+    entry->used.store(true, std::memory_order_release);
     externQueueWrite = (externQueueWrite + 1) % MAX_EXTERN_QUEUE;
 }
 
@@ -596,11 +638,11 @@ void flushExternQueue()
 {
     for(int i = 0; i < MAX_EXTERN_QUEUE; i++)
     {
-        if(externQueue[i].used)
+        if(externQueue[i].used.load(std::memory_order_acquire))
         {
             sendExtern(true, externQueue[i].src_type, externQueue[i].buffer,
                        externQueue[i].buflen, externQueue[i].rssi, externQueue[i].snr);
-            externQueue[i].used = false;
+            externQueue[i].used.store(false, std::memory_order_relaxed);
         }
     }
 }

--- a/src/gps_functions.cpp
+++ b/src/gps_functions.cpp
@@ -14,12 +14,27 @@
 
 #include "gps_functions.h"
 
+#include "watchdog_feed.h"
+
 #include <clock.h>
 
 #include <loop_functions.h>
 #include <loop_functions_extern.h>
 
-#define GPS_BAUDRATE_SOFTCHECK        // GPS Baudratenermittlung wird mit Software Loop geprüft
+// A-1/A-4: Hier stand ein unbedingtes "#define GPS_BAUDRATE_SOFTCHECK".
+// Das Makro ist eigentlich eine Variantenoption -- 15 variants/*/configuration.h
+// setzen oder kommentieren es --, aber diese Zeile hat die Wahl jeder Variante
+// ueberschrieben. Der #else-Zweig (Baudratenerkennung ueber Flankenmessung im
+// ISR) war damit auf ALLEN Boards unerreichbar und ist entfallen; die
+// Software-Schleife ist jetzt der einzige Weg. Zwei Implementierungen, von
+// denen eine nie uebersetzt wird, sind genau der Mechanismus, ueber den die
+// beiden Varianten auseinandergedriftet sind (Befunde A-2 und A-3).
+//
+// Die Defines in den Varianten sind dadurch wirkungslos geworden und koennen
+// gesondert entfernt werden.
+//
+// GPS_BAUDRATE_SETFIX wird jetzt unbedingt ausgewertet (A-4). Vorher lag der
+// vorzeitige return nur im SOFTCHECK-Zweig; der andere kannte SETFIX nicht.
 
 #include <TinyGPSPlus.h>
 
@@ -45,8 +60,24 @@ static HardwareSerial GPSSerial(1);  // UART1
 
 GPSData gpsData;
 
-// Baudrate-Erkennung: Viele Module starten mit 9600, manche mit 38400/115200
-static const unsigned long GPS_BAUDS[] = {1200, 2400, 4800, 9600, 19200, 38400, 57600, 115200};
+// Baudrate-Erkennung. Die Reihenfolge ist nach Trefferwahrscheinlichkeit
+// sortiert, nicht numerisch: seit der Scan bei der ersten gueltigen
+// NMEA-Pruefsumme abbricht (N-25/S5), bestimmt sie unmittelbar die Dauer der
+// GPS-Initialisierung. Fuer das ERGEBNIS ist sie unerheblich -- es entscheidet
+// die Pruefsumme, nicht die Position.
+//
+// 38400 steht vorn, obwohl 9600 die Werkseinstellung der meisten Module ist.
+// Grund ist der Lebenszyklus, nicht die Verbreitung: SetupL76K() und
+// SetupUBLOX() stellen das Modul beim ersten erfolgreichen Init auf 38400 und
+// speichern das im Modul-Flash. Ab dann laeuft das Modul dauerhaft auf 38400.
+// 9600 trifft also genau einmal zu -- beim allerersten Kontakt --, 38400 bei
+// jedem weiteren Boot.
+//
+// Auf der Bank gemessen (T-Beam, 2026-08-22, u-blox): mit 9600 vorn
+// 535 ms beim Erstkontakt, aber 1956 ms bei jedem Reboot danach, weil das
+// 9600-Fenster voll auslaeuft, bevor 38400 drankommt. Mit 38400 vorn kehrt
+// sich das um -- und Reboots sind der haeufigere Fall.
+static const unsigned long GPS_BAUDS[] = {38400, 9600, 115200, 57600, 19200, 4800, 2400, 1200};
 static const size_t   GPS_BAUD_COUNT = sizeof(GPS_BAUDS) / sizeof(GPS_BAUDS[0]);
 int GPS_BAUDS_RX[GPS_BAUD_COUNT];
 
@@ -62,7 +93,109 @@ uint32_t startTimeout;
 
 const int WAIT_DURATION = 2000;   // max. Wartedauer
 
-#if defined(GPS_BAUDRATE_SOFTCHECK)
+
+// ---------------------------------------------------------------------------
+// NMEA-Rahmenpruefung fuer die Baudratenerkennung (N-25/S5, B-15)
+//
+// Ein NMEA-0183-Satz hat die Form  $<payload>*HH<CR><LF>.  HH ist das XOR
+// aller Zeichen zwischen '$' und '*', hexadezimal in Grossbuchstaben.
+//
+// Der Pruefer laeuft ueber den ROHEN Bytestrom, nicht ueber den gefilterten:
+// der Zeichenfilter der Erkennung laesst '.' und '-' nicht durch, beide
+// kommen in jedem realen Satz vor ($GPRMC,064829.00,...). Ueber dem
+// gefilterten Strom koennte die Pruefsumme nie stimmen.
+//
+// Zweck: Rauschen von einem Modul unterscheiden. Die alte Erkennung nahm
+// schlicht die Baudrate mit den meisten passenden Zeichen (Argmax ohne
+// Mindestanzahl, Befund B-15). Da GPS_RX_PIN ohne Pull-up als INPUT
+// konfiguriert wird, "erkennt" ein einziges Rauschbyte auf einem Board ohne
+// angeschlossenes Modul eine Phantom-Baudrate.
+// ---------------------------------------------------------------------------
+
+#define NMEA_MAX_PAYLOAD 82   // NMEA-0183: max. 82 Zeichen je Satz
+
+struct NMEAframeCheck
+{
+    uint8_t  state;    // 0 = wartet auf '$', 1 = Nutzlast, 2 = Hex hoch, 3 = Hex tief
+    uint8_t  sum;      // laufendes XOR ueber die Nutzlast
+    uint8_t  want;     // aus dem Rahmen gelesene Soll-Pruefsumme
+    uint16_t len;      // Laenge der Nutzlast
+};
+
+static void nmeaCheckReset(struct NMEAframeCheck *nc)
+{
+    nc->state = 0;
+    nc->sum = 0;
+    nc->want = 0;
+    nc->len = 0;
+}
+
+static int nmeaHexVal(char ch)
+{
+    if(ch >= '0' && ch <= '9') return ch - '0';
+    if(ch >= 'A' && ch <= 'F') return ch - 'A' + 10;
+    if(ch >= 'a' && ch <= 'f') return ch - 'a' + 10;
+    return -1;
+}
+
+/// @return true, sobald ein vollstaendiger Satz mit gueltiger Pruefsumme endet
+static bool nmeaCheckFeed(struct NMEAframeCheck *nc, char ch)
+{
+    // '$' beginnt immer einen neuen Satz, egal in welchem Zustand
+    if(ch == '$')
+    {
+        nc->state = 1;
+        nc->sum = 0;
+        nc->len = 0;
+        return false;
+    }
+
+    switch(nc->state)
+    {
+        case 1:
+            if(ch == '*')
+            {
+                // leere Nutzlast ist kein Satz
+                if(nc->len == 0)
+                    nc->state = 0;
+                else
+                    nc->state = 2;
+            }
+            else if(ch == 0x0D || ch == 0x0A || nc->len >= NMEA_MAX_PAYLOAD)
+            {
+                nc->state = 0;   // abgebrochener oder ueberlanger Satz
+            }
+            else
+            {
+                nc->sum = nc->sum ^ (uint8_t)ch;
+                nc->len++;
+            }
+            break;
+
+        case 2:
+        {
+            int v = nmeaHexVal(ch);
+            if(v < 0) { nc->state = 0; break; }
+            nc->want = (uint8_t)(v << 4);
+            nc->state = 3;
+            break;
+        }
+
+        case 3:
+        {
+            int v = nmeaHexVal(ch);
+            nc->state = 0;
+            if(v < 0) break;
+            nc->want = (uint8_t)(nc->want | v);
+            return nc->want == nc->sum;
+        }
+
+        default:
+            break;
+    }
+
+    return false;
+}
 
 unsigned long detectBaudrate()
 {
@@ -70,14 +203,17 @@ unsigned long detectBaudrate()
         return GPS_BAUDRATE_SETFIX;
     #endif
 
-    unsigned long detectedBaud=0;
+    int ipos = -1;      // Index der Baudrate mit gueltigem NMEA-Satz
+    uint32_t tScan = millis();
 
+    // Vollstaendig zuruecksetzen: der Scan bricht jetzt vorzeitig ab, sonst
+    // stuenden in den restlichen Eintraegen die Zaehlerstaende des letzten
+    // Durchlaufs (--gps reset ruft erneut hier herein).
     for(int iGpsBaud=0; iGpsBaud < (int)GPS_BAUD_COUNT; iGpsBaud++)
-    {
         GPS_BAUDS_RX[iGpsBaud] = 0;
 
-        detectedBaud =  GPS_BAUDS[iGpsBaud];
-
+    for(int iGpsBaud=0; iGpsBaud < (int)GPS_BAUD_COUNT && ipos < 0; iGpsBaud++)
+    {
         #if defined(USE_HELTEC_T114) or defined(BOARD_T_ECHO)
         Serial1.begin(GPS_BAUDS[iGpsBaud]);
         Serial1.flush();
@@ -91,13 +227,26 @@ unsigned long detectBaudrate()
         NMEAlineIndex = 0;
         memset(msg_text, 0x00, maxNMEAline);
 
-         // 2 Sekunden lang auf gueltige NMEA-Daten warten
-        while (millis() - start < 1500)
+        struct NMEAframeCheck nmeaCheck;
+        nmeaCheckReset(&nmeaCheck);
+        bool bFrameOK = false;
+
+        // N-25: Eine Fütterung pro Baudstufe genügt -- das Fenster unten ist
+        // hart auf 1500 ms begrenzt, der Watchdog löst erst nach 5 s aus.
+        meshcom_wdt_feed();
+
+        // Bis zu 1,5 Sekunden auf einen vollstaendigen NMEA-Satz warten.
+        // Liegt einer vor, endet das Fenster sofort -- es gibt nichts mehr
+        // zu entscheiden.
+        while ((millis() - start < 1500) && !bFrameOK)
         {
+            // Die innere Schleife war unbegrenzt: bei einem dauerhaft
+            // sendenden Modul bleibt available() beliebig lange wahr. Sie
+            // erbt jetzt dasselbe 1500-ms-Fenster wie die äußere.
             #if defined(USE_HELTEC_T114) or defined(BOARD_T_ECHO)
-            while (Serial1.available())
+            while (Serial1.available() && (millis() - start < 1500) && !bFrameOK)
             #else
-            while (GPSSerial.available())
+            while (GPSSerial.available() && (millis() - start < 1500) && !bFrameOK)
             #endif
             {
                 #if defined(USE_HELTEC_T114) or defined(BOARD_T_ECHO)
@@ -106,7 +255,11 @@ unsigned long detectBaudrate()
                 c = char(GPSSerial.read());
                 #endif
 
-                
+                // Pruefsumme ueber den ROHEN Strom -- der Filter unten laesst
+                // '.' und '-' nicht durch, beide stehen in jedem realen Satz.
+                if(nmeaCheckFeed(&nmeaCheck, c))
+                    bFrameOK = true;
+
                 // A-Z 0-9 $ , * CR LF
                 if((c >='A' && c <='Z') || (c >='0' && c<= '9') || c=='!' || c=='$' || c=='*' || c==',' || c=='\\' || c==0x0A || c==0x0D)
                 {
@@ -126,120 +279,40 @@ unsigned long detectBaudrate()
         }
 
         if(iGPSDEBUG >= 2 && GPS_BAUDS_RX[iGpsBaud] > 0)
-          Serial.printf("[GPS ]...%lu baud --> %i chars\n", GPS_BAUDS[iGpsBaud], GPS_BAUDS_RX[iGpsBaud]);
+          Serial.printf("[GPS ]...%lu baud --> %i chars%s\n", GPS_BAUDS[iGpsBaud], GPS_BAUDS_RX[iGpsBaud],
+                        bFrameOK ? " (NMEA ok)" : "");
 
         #if defined(USE_HELTEC_T114) or defined(BOARD_T_ECHO)
         Serial1.end();
         #else
         GPSSerial.end();
         #endif
-    }
 
-    int itxt = 0;
-    int ipos = -1;
+        if(bFrameOK)
+            ipos = iGpsBaud;
+    }
 
     gpsDetected = false;
 
-    for(int iGpsBaud=0; iGpsBaud < (int)GPS_BAUD_COUNT; iGpsBaud++)
-    {
-        if(GPS_BAUDS_RX[iGpsBaud] > itxt)
-        {
-          itxt = GPS_BAUDS_RX[iGpsBaud];
-          ipos = iGpsBaud;
-        }
-    }
-
     if(ipos >= 0)
     {
-        Serial.printf("[GPS ]...found with %lu baud (%i chars)\n", GPS_BAUDS[ipos], itxt);
+        Serial.printf("[GPS ]...found with %lu baud (%i chars, NMEA-Pruefsumme gueltig, %lu ms)\n",
+                      GPS_BAUDS[ipos], GPS_BAUDS_RX[ipos], (unsigned long)(millis() - tScan));
 
         gpsDetected = true;
 
-        detectedBaud = GPS_BAUDS[ipos];
-
-        return detectedBaud;
+        return GPS_BAUDS[ipos];
     }
 
-    detectedBaud = 0;
-    
-    return detectedBaud;
+    // Kein einziger Satz mit gueltiger Pruefsumme: kein Modul, falsch
+    // verkabelt oder stumm. Frueher lieferte hier der Argmax ueber die
+    // Zeichenzaehler eine Phantom-Baudrate (B-15) und der Aufrufer lief in
+    // GPSprobe() gegen nichts.
+    Serial.printf("[GPS ]...keine gueltige NMEA-Sequenz auf %d Baudraten (%lu ms)\n",
+                  (int)GPS_BAUD_COUNT, (unsigned long)(millis() - tScan));
+
+    return 0;
 }
-#else
-
-//=======================================================================================
-const int SAMPLE_COUNT = 50;      // Anzahl der zu messenden Signalflanken
-const int SAMPLE_DURATION = 5000; // max. Messdauer 5s
-volatile unsigned long pulseTimes[SAMPLE_COUNT];
-volatile int pulseIndex = 0;
-volatile unsigned long lastMicros = 0;
-volatile unsigned long currentMicros = 0;
-volatile unsigned long duration = 0;
-volatile unsigned long startWait = 0;
-
-/**
- * @brief ISR für detectBaudrate
- */
-void IRAM_ATTR handleRxInterrupt() {
-  currentMicros = micros();
-  duration = currentMicros - lastMicros;
-  
-  if (pulseIndex < SAMPLE_COUNT && duration > 2) {
-    pulseIndex = pulseIndex+1;
-    pulseTimes[pulseIndex] = duration;
-  }
-  lastMicros = currentMicros;
-}
-
-/**
- * @brief detect Baudrate durch Messung der Zeit zwischen RX-Flanken
- * @return long = detected Baudrate
- */
-unsigned long detectBaudrate() {
-  pulseIndex = 0;
-  lastMicros = micros();
-
-  // Messung: warten, bis genügend Flanken gemessen wurden oder Timeout
-  attachInterrupt(GPS_RX_PIN, handleRxInterrupt, CHANGE);
-  startWait = millis();
-  while (pulseIndex < SAMPLE_COUNT && (millis() - startWait < SAMPLE_DURATION)) { delay(10); }
-  detachInterrupt(GPS_RX_PIN);
-
-  // Auswertung
-  Serial.printf("[GPS ]...messured %u\n", pulseIndex);
-  long minDiff = 1000000;
-  if (pulseIndex < 5) return -1; // Zu wenig Daten empfangen
-  unsigned long minDuration = minDiff;
-  for (int i = 1; i < pulseIndex; i++) {  // Suche nach dem kürzesten Puls (entspricht 1 Bit)
-    if (pulseTimes[i] < minDuration && pulseTimes[i] > 2) { // Rauschfilter > 2µs, ist zwar schon in der Erfassung
-      minDuration = pulseTimes[i];
-    }
-  }
- 
-  // Mapping auf Standard-Baudraten
-  long calculatedBaud = minDiff / minDuration;
-  if(iGPSDEBUG >= 2)
-    Serial.printf("[GPS ]...1st attempt: %lu Baud of %i\n", calculatedBaud, GPS_BAUD_COUNT);
-
-  long bestMatch = 0;
-  if ((calculatedBaud > (GPS_BAUDS[GPS_BAUD_COUNT-1]+1000)) || (calculatedBaud < (GPS_BAUDS[0]-100)) )
-  {
-     return -1;
-  }
-  
-  for (long b : GPS_BAUDS)
-  {
-    long diff = abs(calculatedBaud - b);
-    if (diff < minDiff)
-    {
-      minDiff = diff;
-      bestMatch = b;
-    }
-  }
-
-  return bestMatch;
-}
-
-#endif
 /* 9600 
 unsigned long new_baud = 9600;
 // B5 62 06 00 14 00 01 00 00 00 D0 08 00 00 80 25 00 00 07 00 02 00 00 00 00 00 A1 AF
@@ -367,7 +440,12 @@ void sendUBX_CFG_CFG() {  // Binäres Paket senden
 String readUBX() {
   startTimeout = millis() + 500;
   ver = "";
-  while (millis() < startTimeout) {
+  while ((int32_t)(millis() - startTimeout) < 0) {
+    // N-25/B-9: Das Timeout wird bei JEDEM empfangenen Byte neu gesetzt.
+    // Gegen ein dauerhaft sendendes Modul hat diese Schleife daher keine
+    // obere Schranke; ohne Fütterung reboot der Knoten mitten in der
+    // GPS-Erkennung. Die Schranke selbst gehört noch gezogen (S2).
+    meshcom_wdt_feed();
     #if defined(USE_HELTEC_T114) or defined(BOARD_T_ECHO)
     while (Serial1.available()) {
     #else
@@ -388,7 +466,8 @@ String readUBX() {
 String readUBXbin() {
   startTimeout = millis() + 500;
   ver = "";
-    while (millis() < startTimeout) {
+    while ((int32_t)(millis() - startTimeout) < 0) {
+    meshcom_wdt_feed();   // N-25/B-9: gleiches gleitendes Timeout wie readUBX()
     #if defined(USE_HELTEC_T114) or defined(BOARD_T_ECHO)
     while (Serial1.available()) {
       int c = Serial1.read();
@@ -409,16 +488,18 @@ String readUBXbin() {
 
 
 void WaitPause() {
+  meshcom_wdt_feed();   // N-25: die erste Schleife wartet bis zu 1000 ms
   startTimeout = millis() + 1000;
   #if defined(USE_HELTEC_T114) or defined(BOARD_T_ECHO)
-  while ((!Serial1.available()) && (millis() < startTimeout)) { delay(5); } // auf Block von Zeichen warten
+  while ((!Serial1.available()) && ((int32_t)(millis() - startTimeout) < 0)) { delay(5); } // auf Block von Zeichen warten
   #else
-  while ((!GPSSerial.available()) && (millis() < startTimeout)) { delay(5); } // auf Block von Zeichen warten
+  while ((!GPSSerial.available()) && ((int32_t)(millis() - startTimeout) < 0)) { delay(5); } // auf Block von Zeichen warten
   #endif
   if(iGPSDEBUG >= 2)
     Serial.printf("[GPS ]...wait");
   startTimeout = millis() + 50;  // für Serial Sync Zeichenblock lesen und Pause von 50ms abwarten
-  while (millis() < startTimeout) {
+  while ((int32_t)(millis() - startTimeout) < 0) {
+    meshcom_wdt_feed();   // N-25: 50-ms-Timeout wird pro Byte neu gesetzt
     #if defined(USE_HELTEC_T114) or defined(BOARD_T_ECHO)
     if (Serial1.available()) {
       Serial1.read();
@@ -596,7 +677,9 @@ bool GPSprobe() {
     ver = ver + char(GPSSerial.read());
   #endif
 
-    if (millis() > startTimeout) { // RC-Buffer muss nach WAIT_DURATION leer sein
+    meshcom_wdt_feed();   // N-25: bis zu WAIT_DURATION = 2000 ms
+
+    if ((int32_t)(millis() - startTimeout) > 0) { // RC-Buffer muss nach WAIT_DURATION leer sein
       Serial.printf("[GPS_ERR] wait stop NMEA timeout!\n");
       return false;
     }
@@ -705,6 +788,13 @@ void WZ_GPS_Reset() {
  * @brief automatische Baudrate Erkennung, L76K | UBLOX Erkennung, jeweils Parameter bei jedem Start setzen:
  * 
  */
+// A-6: gpsDetected hat drei Schreiber -- detectBaudrate(), WZ_GPS_Init() und den
+// "--gps off"-Zweig in command_functions.cpp. Deklariert ist es in
+// loop_functions.cpp. Das ist redundant, aber heute widerspruchsfrei: die
+// Erkennung setzt es, der Aufrufer bestaetigt oder verwirft es, das Kommando
+// schaltet ab. Bewusst nicht zusammengefasst -- eine Umstellung auf einen
+// einzigen Schreiber beruehrt den Kommandopfad und gehoert nicht in eine
+// Aufraeumwelle ohne Verhaltensaenderung.
 void WZ_GPS_Init()
 {
   if(gpsInitDone)
@@ -718,7 +808,14 @@ void WZ_GPS_Init()
   
   #if defined(USE_HELTEC_T114) or defined(BOARD_T_ECHO)
   Serial1.setPins(GPS_RX_PIN, GPS_TX_PIN);
-  //Serial1.end();  // vorsorglich schließen, damit Interrupt nicht gestört wird
+  // A-8: Der ESP32-Zweig unten schliesst den Port vorsorglich, dieser nicht --
+  // das Serial1.end() ist hier auskommentiert. Folge: "--gps on" und
+  // "--gps reset" betreten auf T114/T-Echo Serial1.begin() erneut, ohne die
+  // vorherige Instanz zu schliessen. Ob die nRF52-UARTE ein doppeltes begin()
+  // vertraegt, ist aus diesem Repo nicht zu beantworten und wurde nicht auf
+  // Hardware geprueft -- deshalb bleibt das Verhalten unveraendert und ist
+  // hier nur benannt. Wer eines der beiden Boards auf der Bank hat: Re-Init
+  // mehrfach ausloesen und pruefen, ob der Empfang danach noch laeuft.
   #else
   pinMode(GPS_RX_PIN, INPUT);
   pinMode(GPS_TX_PIN, OUTPUT);
@@ -846,12 +943,11 @@ int WZ_GPS_Loop() {
         updateGPSdata = false;
 
         posinfo_satcount = gpsData.satellites;
-        posinfo_hdop = gpsData.hdop;
         fposinfo_hdop= gpsData.hdop;
 
         bool has_gnss_location=false;
 
-        if ((posinfo_hdop < 6.0) && (posinfo_satcount > 5))
+        if ((fposinfo_hdop < 6.0) && (posinfo_satcount > 5))
         {
             has_gnss_location = true;
             posinfo_fix = true;

--- a/src/loop_functions.cpp
+++ b/src/loop_functions.cpp
@@ -7,6 +7,7 @@
 #endif
 
 #include "loop_functions.h"
+#include "dedup_functions.h"
 #include "mheard_functions.h"
 #include "command_functions.h"
 
@@ -114,6 +115,9 @@ bool bDisplayRetx = false;
 unsigned long DisplayOffWait = 0;
 bool bDisplayTrack = false;
 bool bOneButton = false;
+bool bEnterDfu = false;   // --dfu: beim naechsten faelligen rebootAuto in den UF2-Bootloader statt Neustart
+// ALT-35: getrennt von bOneButton -- "Anzeige neu aufbauen", nicht "Taste gedrueckt".
+bool bDisplayDirty = false;
 bool bGPSON = false;
 bool bGPSAutosymbol = false;
 bool bGPSUBLOX = false;
@@ -388,16 +392,15 @@ int iWriteOwn=0;
 
 // RINGBUFFER for incoming UDP lora packets for lora TX
 unsigned char ringBuffer[MAX_RING][UDP_TX_BUF_SIZE+5] = {0};
-volatile int iWrite = 0;
-volatile int iRead = 0;
+ring_index_t iWrite{0};
+ring_index_t iRead{0};
 int iRetransmit=-1;
 
 // FIX: Per-slot retry counter for retransmit cap
 uint8_t retryCount[MAX_RING] = {0};
 
 // RINGBUFFER for incomming LoRa RX msg_id
-uint8_t ringBufferLoraRX[MAX_DEDUP_RING][5] = {0};
-std::atomic<uint8_t> loraWrite{0};   // counter for ringbuffer
+// ringBufferLoraRX/loraWrite liegen jetzt in dedup_functions.cpp.
 
 // RINGBUFFER RAW LoRa RX
 unsigned char ringbufferRAWLoraRX[MAX_LOG][UDP_TX_BUF_SIZE+5] = {0};
@@ -425,7 +428,7 @@ int ComToPhoneRead=0;
 bool hasMsgFromPhone = false;
 
 // LoRa RX/TX sequence control
-std::atomic<bool> is_receiving{false};  // flag to store we are receiving a lora packet.
+is_receiving_t is_receiving{false};  // flag to store we are receiving a lora packet.
 std::atomic<bool> tx_is_active{false};  // flag to store we are transmitting  a lora packet.
 
 int cad_attempt = 0;
@@ -433,10 +436,10 @@ unsigned long csma_timeout = CSMA_BASE_0;
 int rx_irq_defer_count = 0;
 
 // Channel utilization tracking (10s window)
-std::atomic<unsigned long> ch_util_rx_start{0};   // timestamp when RX started
-std::atomic<unsigned long> ch_util_tx_start{0};   // timestamp when TX started
-std::atomic<unsigned long> ch_util_rx_accum{0};   // accumulated RX airtime (ms) in current window
-std::atomic<unsigned long> ch_util_tx_accum{0};   // accumulated TX airtime (ms) in current window
+ch_util_rx_start_t ch_util_rx_start{0};   // timestamp when RX started
+ch_util_ulong_t ch_util_tx_start{0};   // timestamp when TX started
+ch_util_ulong_t ch_util_rx_accum{0};   // accumulated RX airtime (ms) in current window
+ch_util_ulong_t ch_util_tx_accum{0};   // accumulated TX airtime (ms) in current window
 
 int isPhoneReady = 0;      // flag we receive from phone when itis ready to receive data
 
@@ -461,7 +464,6 @@ double posinfo_last_direction = 0.0;
 unsigned int posinfo_last_rate = POSINFO_INTERVAL;  // seconds
 
 uint32_t posinfo_satcount = 0;
-int posinfo_hdop = 0;
 float fposinfo_hdop = 0.0;
 bool posinfo_fix = false;
 bool posinfo_shot=false;
@@ -531,8 +533,23 @@ unsigned long getUnixClock()
  */
 void addBLEOutBuffer(uint8_t *buffer, uint16_t len)
 {
-    if (len > UDP_TX_BUF_SIZE)
-        len = UDP_TX_BUF_SIZE-4; // just for safety
+    // Das Laengenbyte unten ist ein uint8_t. Im Nicht-'D'-Zweig kommen noch 4 Byte
+    // Zeitstempel dazu, dort muss also len+4 hineinpassen; im 'D'-Zweig (JSON) wird
+    // len unveraendert abgelegt und darf die vollen 255 nutzen.
+    uint16_t maxlen = (buffer[0] != 'D') ? (UDP_TX_BUF_SIZE - 4) : UDP_TX_BUF_SIZE;
+    if (len > maxlen)
+        len = maxlen;
+
+    // CONC-15: toPhoneWrite/toPhoneRead are plain ints. addBLEOutBuffer() is
+    // reachable from OnRxDone (the FreeRTOS timer-service task on nRF52,
+    // priority 2, see C-01) while sendToPhone() drains the same ring from the
+    // Main Loop task. Snapshot the target slot before the critical section so
+    // the debug print below (kept outside the lock — it can call into
+    // Serial/heap) still reports the slot this call actually wrote.
+    uint8_t debugSlot = (uint8_t)toPhoneWrite;
+#if defined(NRF52_SERIES)
+    taskENTER_CRITICAL();
+#endif
 
     //first two bytes are always the message length
     memcpy(BLEtoPhoneBuff[toPhoneWrite] + 1, buffer, len);
@@ -540,7 +557,7 @@ void addBLEOutBuffer(uint8_t *buffer, uint16_t len)
     if(buffer[0] != 'D')
     {
         unsigned long unix_time = getUnixClock();
-        
+
         //printfdeb("UNIX TME:%lu\n", unix_time);
 
         uint8_t tbuffer[5];
@@ -555,15 +572,19 @@ void addBLEOutBuffer(uint8_t *buffer, uint16_t len)
     else
         BLEtoPhoneBuff[toPhoneWrite][0] = len;
 
-    if(bBLEDEBUG)
-    {
-        printfdeb("<%02X>BLEtoPhone RingBuff added len=%i to element: %u\n", buffer[0], len, toPhoneWrite);
-        printBuffer(BLEtoPhoneBuff[toPhoneWrite], len + 1 + 4);
-    }
-
     //printfdeb("toPhone write:%i read:%i max:%i ", toPhoneWrite, toPhoneRead, MAX_RING);
 
     addRingPointer(toPhoneWrite, toPhoneRead, MAX_RING, "phone");
+
+#if defined(NRF52_SERIES)
+    taskEXIT_CRITICAL();
+#endif
+
+    if(bBLEDEBUG)
+    {
+        printfdeb("<%02X>BLEtoPhone RingBuff added len=%i to element: %u\n", buffer[0], len, debugSlot);
+        printBuffer(BLEtoPhoneBuff[debugSlot], len + 1 + 4);
+    }
 
     //printfdeb("next write:%i read:%i max:%i\n", toPhoneWrite, toPhoneRead, MAX_RING);
 
@@ -586,6 +607,7 @@ void addBLEComToOutBuffer(uint8_t *buffer, uint16_t len)
     if (len > 245)
     {
         printfdeb("[ERR]...BLE out-buffer to long <%i> <%-245.245s>\n", len, buffer);
+        len = 245; // clamp - length byte and destination buffer both size to this
     }
 
     //first two bytes are always the message length
@@ -635,59 +657,8 @@ void addBLECommandBack(char text[UDP_TX_BUF_SIZE])
     addBLEOutBuffer(msg_buffer, aprsmsg.msg_len);
 }
 
-/**@brief Function adding messages into outgoing UDP ringbuffer
- * 
- */
-void addLoraRxBuffer(unsigned int msg_id, bool bserver)
-{
-    // RACE-03 fix: local copy for atomic index — write buffer content first,
-    // then atomically update index so readers see complete entries
-    uint8_t slot = loraWrite.load();
-
-    if(bLORADEBUG)
-        printfdeb("[MC-DBG] RX_DEDUP_ADD msg_id=%08X srv=%d slot=%d/%d\n",
-                      msg_id, bserver, slot, MAX_DEDUP_RING);
-
-    // byte 0-3 msg_id
-    ringBufferLoraRX[slot][3] = msg_id >> 24;
-    ringBufferLoraRX[slot][2] = msg_id >> 16;
-    ringBufferLoraRX[slot][1] = msg_id >> 8;
-    ringBufferLoraRX[slot][0] = msg_id;
-    ringBufferLoraRX[slot][4] = bserver ? 1 : 0;
-
-    uint8_t next = slot + 1;
-    if (next >= MAX_DEDUP_RING)
-        next = 0;
-    loraWrite.store(next);
-}
-
-int checkOwnRx(uint8_t compBuffer[4])
-{
-    for(int ilo=0; ilo<MAX_DEDUP_RING; ilo++)
-    {
-        if(memcmp(ringBufferLoraRX[ilo], compBuffer, 4) == 0)
-            return ilo;
-    }
-
-    return -1;
-}
-
-bool checkServerRx(uint8_t compBuffer[4])
-{
-    for(int ilo=0; ilo<MAX_DEDUP_RING; ilo++)
-    {
-        if(memcmp(ringBufferLoraRX[ilo], compBuffer, 4) == 0)
-        {
-            // MSG wurde von einem anderen GW gesendet
-            if(ringBufferLoraRX[ilo][4] == 1)
-                return true;
-
-            break;
-        }
-    }
-
-    return false;
-}
+// addLoraRxBuffer()/checkOwnRx()/checkServerRx() sind nach
+// dedup_functions.cpp gewandert (reine Verschiebung).
 
 int checkOwnTx(unsigned int msg_id)
 {
@@ -1332,9 +1303,10 @@ void sendDisplayTrack()
     iDisplayType=9;
 
     // nur alle 15 sekunden
-    if(meshcom_settings.node_date_second == 0 || meshcom_settings.node_date_second == 15 || meshcom_settings.node_date_second == 30 || meshcom_settings.node_date_second == 45 || bOneButton)
+    if(meshcom_settings.node_date_second == 0 || meshcom_settings.node_date_second == 15 || meshcom_settings.node_date_second == 30 || meshcom_settings.node_date_second == 45 || bOneButton || bDisplayDirty)
     {
-        bOneButton = false;
+        bOneButton    = false;
+        bDisplayDirty = false;
 
         sendDisplayMainline();
 
@@ -1539,9 +1511,10 @@ void sendDisplayTime()
         snprintf(cstatus, sizeof(cstatus),  "%-4.4s%-1.1s ", SOURCE_VERSION, SOURCE_VERSION_SUB);
 
     // nur alle 15 sekunden
-    if(meshcom_settings.node_date_second == 0 || meshcom_settings.node_date_second == 15 || meshcom_settings.node_date_second == 30 || meshcom_settings.node_date_second == 45 || bOneButton)
+    if(meshcom_settings.node_date_second == 0 || meshcom_settings.node_date_second == 15 || meshcom_settings.node_date_second == 30 || meshcom_settings.node_date_second == 45 || bOneButton || bDisplayDirty)
     {
-        bOneButton = false;
+        bOneButton    = false;
+        bDisplayDirty = false;
 
         #ifdef BOARD_T_ECHO
         snprintf(msg_text, sizeof(msg_text), "%02i:%02i:%02i   %s", meshcom_settings.node_date_hour, meshcom_settings.node_date_minute, meshcom_settings.node_date_second, cbatt);
@@ -1916,7 +1889,7 @@ void mainStartTimeLoop()
                     {
                         epaper_display.clear();          // physischer Voll-Clear (weiss)
                         if(bDisplayTrack)
-                            bOneButton = true;           // Track-Seite sofort aufbauen
+                            bDisplayDirty = true;        // Track-Seite sofort aufbauen (kein Tastendruck)
                         else
                             sendDisplayHead(true);       // normale Info-Seite wiederherstellen
                     }
@@ -1968,7 +1941,7 @@ void mainStartTimeLoop()
                     // letzten Track-Render geaendert. Quelle eines Updates auf der GPS-losen WP:
                     // Phone-App/BLE (phone_commands.cpp), empfangenes Mesh-Pos-Paket bzw. manuelles
                     // --setlat/--setlon (command_functions.cpp) - oder, auf GPS-Modulen, ein Fix.
-                    // Die Track-Seite wird beim Einschalten (bOneButton aus dem Track-Transition-
+                    // Die Track-Seite wird beim Einschalten (bDisplayDirty aus dem Track-Transition-
                     // Handler weiter oben) und bei jedem echten Positionsupdate fuer ~10 s gezeigt
                     // und blendet danach AUTOMATISCH zurueck auf die Normalansicht (neueste
                     // Nachricht; ersatzweise Info-/Statusseite). Grund: auf der GPS-losen WP aendern
@@ -1989,7 +1962,7 @@ void mainStartTimeLoop()
                                      || (meshcom_settings.node_lat != wpTrackLat)
                                      || (meshcom_settings.node_lon != wpTrackLon);
 
-                    if(DisplayOffWait == 0 && (wpPosUpdated || bOneButton))
+                    if(DisplayOffWait == 0 && (wpPosUpdated || bOneButton || bDisplayDirty))
                     {
                         // echtes Positionsupdate (oder erstmaliger Aufbau): Track-/WX-Seite zeichnen
                         // und den 10s-Rueckblende-Timer (neu) starten.
@@ -1997,7 +1970,7 @@ void mainStartTimeLoop()
                         wpTrackLon     = meshcom_settings.node_lon;
                         wpTrackInit    = true;
                         wpTrackShownAt = millis();
-                        bOneButton     = true;   // erzwingt sofortigen Aufbau (umgeht das 15s-Raster in sendDisplayTrack)
+                        bDisplayDirty  = true;   // erzwingt sofortigen Aufbau (umgeht das 15s-Raster in sendDisplayTrack)
 
                         if(iDisplayChange > 10)
                             sendDisplayWX(); // Show WX
@@ -2196,7 +2169,27 @@ void sendDisplayText(struct aprsMessage &aprsmsg, int16_t rssi, int8_t snr)
     {
         char cset[30];
         snprintf(cset, sizeof(cset), "%s", aprsmsg.msg_payload.c_str());
-        sscanf(cset+5, "%d;%d;", &meshcom_settings.max_hop_text, &meshcom_settings.max_hop_pos);
+
+        // Ohne Bereichspruefung landete ein Tippfehler wie {SET}44;2; direkt im
+        // Hop-Feld der ausgesendeten Pakete. Byte 5 einer ACK fuehrt max_hop in
+        // 7 Bit, der Weiterleitungspfad dekrementiert nur und begrenzt nicht
+        // nach oben -- ein solcher Knoten wuerde das Netz mit Paketen fluten,
+        // die 44 statt 4 Relaissprunge weit laufen.
+        //
+        // Wie bisher wird jedes Feld einzeln uebernommen, sobald sscanf es
+        // gelesen hat ({SET}4; setzt weiterhin nur max_hop_text). Neu ist
+        // ausschliesslich, dass Werte ausserhalb 0..MAX_HOP_LIMIT den
+        // bisherigen Wert stehen lassen, statt ihn zu ueberschreiben.
+        int iHopText = meshcom_settings.max_hop_text;
+        int iHopPos  = meshcom_settings.max_hop_pos;
+
+        int iParsed = sscanf(cset+5, "%d;%d;", &iHopText, &iHopPos);
+
+        if(iParsed >= 1 && iHopText >= 0 && iHopText <= MAX_HOP_LIMIT)
+            meshcom_settings.max_hop_text = iHopText;
+
+        if(iParsed >= 2 && iHopPos >= 0 && iHopPos <= MAX_HOP_LIMIT)
+            meshcom_settings.max_hop_pos = iHopPos;
 
         return;
     }
@@ -2576,7 +2569,7 @@ void init_loop_function()
 {
     posinfo_last_direction = 0.0;
     posinfo_satcount = 0;
-    posinfo_hdop = 0;
+    fposinfo_hdop = 0.0;
     posinfo_fix = false;
 
     meshcom_settings.node_vbus = 0.0f;
@@ -2610,6 +2603,7 @@ void initAnalogPin()
 
 void sendDisplayPosition(struct aprsMessage &aprsmsg, int16_t rssi, int8_t snr)
 {
+    (void)snr;
     //printfdeb("bPosDisplay:%i DisplayOffWait:%i bSetDisplay:%i pageHold:%i bDisplayTrack:%i bDisplayIsOff:%i\n", bPosDisplay, DisplayOffWait, bSetDisplay, pageHold, bDisplayTrack, bDisplayIsOff);
 
     if(!bPosDisplay)
@@ -3125,11 +3119,7 @@ void sendPing(char msg_call[10])
 
     // Master RingBuffer for transmission
     // local messages send to LoRa TX
-    ringBuffer[iWrite][0] = aprsmsg.msg_len;
-    ringBuffer[iWrite][1] = 0xFF; // retransmission Status ...0xFF no retransmission
-    memcpy(ringBuffer[iWrite]+2, msg_buffer, aprsmsg.msg_len);
-
-    addTxRingEntry("phone_msg");
+    addTxRingEntry(msg_buffer, (uint16_t)aprsmsg.msg_len, 0xFF, "phone_msg"); // 0xFF no retransmission
 
     if(!bPingSend)
     {
@@ -3206,11 +3196,7 @@ void SendPong(String msg_call, unsigned int msg_id)
 
     // Master RingBuffer for transmission
     // local messages send to LoRa TX
-    ringBuffer[iWrite][0] = aprsmsg.msg_len;
-    ringBuffer[iWrite][1] = 0xFF; // retransmission Status ...0xFF no retransmission
-    memcpy(ringBuffer[iWrite]+2, msg_buffer, aprsmsg.msg_len);
-
-    addTxRingEntry("phone_msg");
+    addTxRingEntry(msg_buffer, (uint16_t)aprsmsg.msg_len, 0xFF, "phone_msg"); // 0xFF no retransmission
 }
 
 void sendMessage(char *msg_text, int len)
@@ -3245,8 +3231,23 @@ void sendMessage(char *msg_text, int len)
     int ii=0;
     int in=0;
     unsigned int ib=0;
+    // N-22: der Loop-Task-Stack auf nRF52 ist 4 KB (LOOP_STACK_SZ im
+    // Adafruit-Core, nicht per Build-Flag ueberschreibbar). Der Pfad
+    // checkSerialCommand() -> sendMessage() -> sendExtern() lief mit
+    // Stack-Watermark 0 (auf Hardware gemessen, 2026-08-21) und zerstoerte
+    // Nachbar-RAM — Absturz Sekunden spaeter (SREQ). Grosse Puffer deshalb
+    // in BSS; sendMessage() laeuft auf nRF52 ausschliesslich im Loop-Task
+    // (Aufrufer: checkSerialCommand, hasMsgFromPhone-Zweig in nrf52loop,
+    // getExtern — alle Loop-Kontext). Gleiches Muster wie Commit 1951aa7d
+    // in sendExtern(). Die memset()-Aufrufe direkt darunter initialisieren
+    // beide Puffer ohnehin bei jedem Aufruf.
+#if defined(NRF52_SERIES)
+    static char msg_text_check[200];
+    static char msg_text_checked[200];
+#else
     char msg_text_check[200];
     char msg_text_checked[200];
+#endif
     int len_check=len;
     if(len_check > (int)sizeof(msg_text_check)-1)
         len_check = sizeof(msg_text_check)-1;
@@ -3263,8 +3264,16 @@ void sendMessage(char *msg_text, int len)
 
     int iulng=0;
 
-    for(int iu=ispos; iu<=len_check; iu++)
+    // Loop is driven by ii, the real source-consumption index (advances by
+    // up to 12 per multi-byte %-escape), not by a decoupled counter.
+    while(ii < len_check)
     {
+        // Bound every destination write: never let 'in' reach or pass the
+        // last byte of msg_text_checked, which must stay NUL (buffer is
+        // used as a C string afterwards).
+        if(in >= (int)sizeof(msg_text_checked)-1)
+            break;
+
         if(memcmp(msg_text_check+ii, "%C2", 3) == 0)
             iulng=6;
         if(memcmp(msg_text_check+ii, "%EF", 3) == 0)
@@ -3286,6 +3295,12 @@ void sendMessage(char *msg_text, int len)
         {
             for(int is=1;is<iulng;is=is+3)
             {
+                if(ii+is+1 >= (int)sizeof(msg_text_check))
+                    break;
+
+                if(in >= (int)sizeof(msg_text_checked)-1)
+                    break;
+
                 if(msg_text_check[ii+is] >= 'A')
                     ib = (msg_text_check[ii+is] - 'A') + 10;
                 else
@@ -3353,7 +3368,7 @@ void sendMessage(char *msg_text, int len)
             {
                 char cId[4] = {0};
                 snprintf(cId, sizeof(cId), "%03i", meshcom_settings.node_msgid);
-                char cnewMsg[10];
+                char cnewMsg[64];
                 snprintf(cnewMsg, sizeof(cnewMsg), "{mcp}%c%s%c%s%c%s", cId[0], strMsg.substring(5, 7).c_str(), cId[1], strMsg.substring(7, 9).c_str(), cId[2], strMsg.substring(9).c_str());
                 strMsg = cnewMsg;
             }
@@ -3370,7 +3385,13 @@ void sendMessage(char *msg_text, int len)
         }
     }
 
+    // N-22: siehe Kommentar bei msg_text_check oben — auf nRF52 in BSS,
+    // encodeAPRS() beschreibt den Puffer bei jedem Aufruf vollstaendig.
+#if defined(NRF52_SERIES)
+    static uint8_t msg_buffer[MAX_MSG_LEN_PHONE];
+#else
     uint8_t msg_buffer[MAX_MSG_LEN_PHONE];
+#endif
 
     struct aprsMessage aprsmsg;
 
@@ -3456,30 +3477,31 @@ void sendMessage(char *msg_text, int len)
 
     // Master RingBuffer for transmission
     // local messages send to LoRa TX
-    ringBuffer[iWrite][0]=aprsmsg.msg_len;
-    memcpy(ringBuffer[iWrite]+2, msg_buffer, aprsmsg.msg_len);
-    
-    if (ringBuffer[iWrite][2] == 0x3A) // only Messages
+    if (iWrite == iRead) {   // ring full: about to overwrite an unread slot
+        Serial.printf("[RING] overflow, slot %d dropped\n", (int)iWrite);
+    }
+    // Status vorab aus msg_buffer bestimmen (statt aus dem Ring zu lesen): der
+    // Slot wird erst in addTxRingEntry() unter Lock gewaehlt/beschrieben.
+    uint8_t user_msg_status;
+    if (msg_buffer[0] == 0x3A) // only Messages
     {
         if(aprsmsg.msg_payload.startsWith("{CET}") || aprsmsg.msg_payload.startsWith("{MCP}") || aprsmsg.msg_payload.startsWith("{SET}"))
-            ringBuffer[iWrite][1] = 0xFF; // retransmission Status ...0xFF no retransmission on {CET} & Co.
+            user_msg_status = 0xFF; // retransmission Status ...0xFF no retransmission on {CET} & Co.
         else
-            ringBuffer[iWrite][1] = 0x00; // retransmission Status ...0xFF no retransmission
+            user_msg_status = 0x00; // retransmission Status ...0xFF no retransmission
     }
     else
     {
-        ringBuffer[iWrite][1] = 0xFF; // retransmission Status ...0xFF no retransmission
-    }   
+        user_msg_status = 0xFF; // retransmission Status ...0xFF no retransmission
+    }
 
-    if(bDisplayRetx)
+    int w = addTxRingEntry(msg_buffer, (uint16_t)aprsmsg.msg_len, user_msg_status, "user_msg", 0);
+
+    if(bDisplayRetx && w >= 0)
     {
-        int w = iWrite;
         unsigned int ring_msg_id = (ringBuffer[w][6]<<24) | (ringBuffer[w][5]<<16) | (ringBuffer[w][4]<<8) | ringBuffer[w][3];
         printfdeb("einfügen retid:%i status:%02X lng;%02X msg-id: %c-%08X\n", w, ringBuffer[w][1], ringBuffer[w][0], ringBuffer[w][2], ring_msg_id);
     }
-
-    retryCount[iWrite] = 0;
-    addTxRingEntry("user_msg");
 
     /*
     iWrite++;
@@ -3612,7 +3634,12 @@ String PositionToAPRS(bool bConvPos, bool bSsendTele, bool bFuss, double plat, c
             else
                 snprintf(calt, sizeof(calt), "/A=%05i", alt);
         }
-        snprintf(cbatt, sizeof(cbatt), "/B=%i", global_proz);
+        // /B= immer senden wenn Batterie-Hardware vorhanden ist, auch bei 0 Prozent
+        // (leerer Tag wuerde sonst "kein Akku bestueckt" bedeuten statt "leer")
+        if(battHardwarePresent())
+        {
+            snprintf(cbatt, sizeof(cbatt), "/B=%03d", global_proz);
+        }
         snprintf(cinaU, sizeof(cinaU), "/U=%.2f", meshcom_settings.node_vbus);
         snprintf(cinaI, sizeof(cinaI), "/I=%.1f", meshcom_settings.node_vcurrent);
 
@@ -3623,7 +3650,9 @@ String PositionToAPRS(bool bConvPos, bool bSsendTele, bool bFuss, double plat, c
     }
     else
     {
-        if(global_proz > 0)
+        // /B= immer senden wenn Batterie-Hardware vorhanden ist, auch bei 0 Prozent
+        // (leerer Tag wuerde sonst "kein Akku bestueckt" bedeuten statt "leer")
+        if(battHardwarePresent())
         {
             snprintf(cbatt, sizeof(cbatt), "/B=%03d", global_proz);
         }
@@ -3809,7 +3838,7 @@ void sendPosition(unsigned long uintervall, double lat, char lat_c, double lon, 
         bSendViaAPRS=true;
     }
 
-    if(lastHeardTime + 15000 < millis() && (intervall == POSINFO_INTERVAL || intervall == 0x9999)) // wenn die letzte gehörte LoRa-Nachricht < 5sec dann auch via MeshCom
+    if((uint32_t)(millis() - lastHeardTime) >= 15000 && (intervall == POSINFO_INTERVAL || intervall == 0x9999)) // wenn die letzte gehörte LoRa-Nachricht < 5sec dann auch via MeshCom
     {
         bSendViaMesh = true;
 
@@ -3817,7 +3846,7 @@ void sendPosition(unsigned long uintervall, double lat, char lat_c, double lon, 
         posfixinterall = millis();
     }
 
-    if(((posfixinterall + (POSINFO_INTERVAL * 1000)) < millis()))
+    if((uint32_t)(millis() - posfixinterall) >= (POSINFO_INTERVAL * 1000))
     {
         bSendViaMesh = true;
 
@@ -3832,7 +3861,7 @@ void sendPosition(unsigned long uintervall, double lat, char lat_c, double lon, 
     // set default
     // Symbol Table / \ 0-9 A-Z  (compressed a-z)
     bool bSymbolTable = false;
-    if(meshcom_settings.node_symid == '/' || meshcom_settings.node_symid != '\'')
+    if(meshcom_settings.node_symid == '/' || meshcom_settings.node_symid == '\\')
         bSymbolTable = true;
     else
     if(meshcom_settings.node_symid >= '0' && meshcom_settings.node_symid <= '9')
@@ -3867,11 +3896,7 @@ void sendPosition(unsigned long uintervall, double lat, char lat_c, double lon, 
         }
 
         // local LoRa-APRS position-messages send to LoRa TX
-        ringBuffer[iWrite][0]=ilng;
-        ringBuffer[iWrite][1]=0xFF;    // Status byte for retransmission 0xFF no retransmission
-        memcpy(ringBuffer[iWrite]+2, msg_buffer, ilng);
-
-        addTxRingEntry("user_pos");
+        addTxRingEntry(msg_buffer, (uint16_t)ilng, 0xFF, "user_pos"); // 0xFF no retransmission
 
         #if defined(BOARD_T_DECK) || defined(BOARD_T_DECK_PLUS) || defined(BOARD_T_DECK_PRO)
             tdeck_send_track_view();
@@ -4005,11 +4030,7 @@ void sendPosition(unsigned long uintervall, double lat, char lat_c, double lon, 
         }
 
         // local position-messages send to LoRa TX
-        ringBuffer[iWrite][0]=aprsmsg.msg_len;
-        ringBuffer[iWrite][1]=0xFF;    // Status byte for retransmission 0xFF no retransmission
-        memcpy(ringBuffer[iWrite]+2, msg_buffer, aprsmsg.msg_len);
-
-        addTxRingEntry("user_wx");
+        addTxRingEntry(msg_buffer, (uint16_t)aprsmsg.msg_len, 0xFF, "user_wx"); // 0xFF no retransmission
 
         #if defined(BOARD_T_DECK) || defined(BOARD_T_DECK_PLUS) || defined(BOARD_T_DECK_PRO)
             tdeck_send_track_view();
@@ -4086,11 +4107,7 @@ void sendAPPPosition(double lat, char lat_c, double lon, char lon_c, float temp2
     }
 
     // local position-messages send to LoRa TX
-    ringBuffer[iWrite][0]=aprsmsg.msg_len;
-    ringBuffer[iWrite][1]=0xFF;    // Status byte for retransmission 0xFF no retransmission
-    memcpy(ringBuffer[iWrite]+2, msg_buffer, aprsmsg.msg_len);
-
-    addTxRingEntry("user_hey");
+    addTxRingEntry(msg_buffer, (uint16_t)aprsmsg.msg_len, 0xFF, "user_hey"); // 0xFF no retransmission
 
     /*
     iWrite++;
@@ -4163,14 +4180,22 @@ void SendAckMessage(String dest_call, unsigned int iAckId)
         printfdeb("");
     }
 
-    int savedAckSlot = iWrite;
-    ringBuffer[iWrite][0]=aprsmsg.msg_len;
-    ringBuffer[iWrite][1]=0x00;  // temp READY (0x00) so getMessagePriority parses destination correctly
-    memcpy(ringBuffer[iWrite]+2, msg_buffer, aprsmsg.msg_len);
+    // Status kann nicht vorab auf 0xFF (DONE) gesetzt werden: getMessagePriority()
+    // liest innerhalb von addTxRingEntry() das Status-Byte und stuft eine TEXT-
+    // Nachricht mit Status DONE als "Relay" (MSG_PRIO_NORMAL) statt als echte
+    // Ziel-Message (MSG_PRIO_CRITICAL) ein. Also mit temp-READY (0x00) einreihen,
+    // damit die Prio-Klassifizierung den Zielrufzeichen-Pfad parst, und danach
+    // per zurueckgegebenem Slot auf DONE setzen. Restrisiko des Nachtrags:
+    // preemptet der Timer-Service-Task GENAU zwischen den beiden Statements UND
+    // ist der Ring voll UND waehlt dessen Eviction ausgerechnet diesen frisch
+    // als HIGH/CRITICAL eingestuften Slot als niedrigste Prio, traefe das 0xFF
+    // einen fremden Eintrag. Akzeptiert: alle drei Bedingungen zusammen sind
+    // praktisch ausgeschlossen, und das Fenster ist strikt kleiner als das der
+    // alten Vorab-iWrite-Schreibsequenz (N-14).
+    int savedAckSlot = addTxRingEntry(msg_buffer, (uint16_t)aprsmsg.msg_len, 0x00, "beacon");
 
-    addTxRingEntry("beacon");
-
-    ringBuffer[savedAckSlot][1]=0xFF;   // no retransmission (set after priority is recorded)
+    if(savedAckSlot >= 0)
+        ringBuffer[savedAckSlot][1]=0xFF;   // no retransmission (set after priority is recorded)
 
     /*
     iWrite++;
@@ -4246,11 +4271,7 @@ void sendHey()
     {
         // Master RingBuffer for transmission
         // local messages send to LoRa TX
-        ringBuffer[iWrite][0] = aprsmsg.msg_len;
-        ringBuffer[iWrite][1] = 0xFF; // retransmission Status ...0xFF no retransmission
-        memcpy(ringBuffer[iWrite]+2, msg_buffer, aprsmsg.msg_len);
-
-        addTxRingEntry("auto_pos");
+        addTxRingEntry(msg_buffer, (uint16_t)aprsmsg.msg_len, 0xFF, "auto_pos"); // 0xFF no retransmission
 
         /*
         iWrite++;
@@ -4530,12 +4551,8 @@ void sendTelemetry(int ID)
         {
             // Master RingBuffer for transmission
             // local messages send to LoRa TX
-            ringBuffer[iWrite][0] = aprsmsg.msg_len;
-            ringBuffer[iWrite][1] = 0xFF; // retransmission Status ...0xFF no retransmission
-            memcpy(ringBuffer[iWrite]+2, msg_buffer, aprsmsg.msg_len);
-
             if(!bDisplayTrack)
-                addTxRingEntry("phone_msg");
+                addTxRingEntry(msg_buffer, (uint16_t)aprsmsg.msg_len, 0xFF, "phone_msg"); // 0xFF no retransmission
         }
 
         // send value messages to Lora-APRS
@@ -4547,11 +4564,7 @@ void sendTelemetry(int ID)
 
             // Master RingBuffer for transmission
             // local messages send to LoRa TX
-            ringBuffer[iWrite][0] = tlng;
-            ringBuffer[iWrite][1] = 0xFF; // retransmission Status ...0xFF no retransmission
-            memcpy(ringBuffer[iWrite]+2, msg_buffer, tlng);
-
-            addTxRingEntry("phone_raw");
+            addTxRingEntry(msg_buffer, tlng, 0xFF, "phone_raw"); // 0xFF no retransmission
         }
     }
 }
@@ -4973,7 +4986,7 @@ void addRingPointer(volatile int &pWrite, volatile int &pRead, int iMAX, const c
             if (pRead >= iMAX) // if the buffer is full we start at index 0 -> take care of overwriting!
                 pRead = 0;
 
-            if(bLORADEBUG && strcmp(bufName, "raw_rx") != 0 && strcmp(bufName, "phone") != 0)
+            if(bLORADEBUG && strcmp(bufName, "raw_rx") != 0 && strcmp(bufName, "phone") != 0 && strcmp(bufName, "udp") != 0)
             {
                 printfdeb("[MC-DBG] RING_OVERFLOW buf=%s\n", bufName);
             }

--- a/src/loop_functions.h
+++ b/src/loop_functions.h
@@ -48,11 +48,16 @@ void printBuffer_ack(char *msgSource, uint8_t payload[UDP_TX_BUF_SIZE+10], int16
 void addBLEOutBuffer(uint8_t *buffer, uint16_t len);
 void addBLEComToOutBuffer(uint8_t *buffer, uint16_t len);
 void addBLECommandBack(char *text);
-void addLoraRxBuffer(unsigned int msg_id, bool msg_server);
-void addTxRingEntry(const char* source);
+// addLoraRxBuffer() wird jetzt in dedup_functions.h deklariert.
+// N-14: kompletter TX-Ring-Enqueue (Slot-Wahl, Payload-Kopie, Prio/Overflow,
+// iWrite/iRead) in einer Funktion unter einem Lock (nRF52) -- siehe
+// lora_functions.cpp fuer Details/Locking-Begruendung. Rueckgabe: Slot-Index
+// oder -1 wenn die Overflow-Logik den Eintrag verworfen hat.
+// retryCountIn: -1 (Default) laesst retryCount[Slot] unangetastet.
+int addTxRingEntry(const uint8_t* frame, uint16_t len, uint8_t ring_status,
+                    const char* source, int retryCountIn = -1, bool clearSlotFirst = false);
 
-int checkOwnRx(uint8_t compBuffer[4]);
-bool checkServerRx(uint8_t compBuffer[4]);
+// checkOwnRx()/checkServerRx() werden jetzt in dedup_functions.h deklariert.
 int checkOwnTx(unsigned int msg_id);
 void insertOwnTx(unsigned int id);
 

--- a/src/loop_functions_extern.h
+++ b/src/loop_functions_extern.h
@@ -1,4 +1,6 @@
-// (C) 2023 OE1KBC Kurt Baumann, OE1KFR Rainer 
+#pragma once
+
+// (C) 2023 OE1KBC Kurt Baumann, OE1KFR Rainer
 // (C) 2016, 2017, 2018, 2018, 2019, 2020 OE1KBC Kurt Baumann
 //
 // 20230326: Version 4.00: START
@@ -78,6 +80,8 @@ extern float fBattFaktor;
 
 extern bool bDisplayTrack;
 extern bool bOneButton;
+extern bool bEnterDfu;       // --dfu (nur nRF52): UF2-Bootloader statt normalem Neustart
+extern bool bDisplayDirty;   // ALT-35: Render-Anforderung, unabhaengig vom Tastendruck
 
 extern bool bGPSON;
 extern bool bGPSAutosymbol;
@@ -177,14 +181,24 @@ extern float BATTexp12;
 extern float BATexp12pre;
 extern float BATexp2;
 
+// ring_index_t liegt jetzt in ring_index.h (reine Verschiebung), damit
+// einzelne Ringe in eigene Uebersetzungseinheiten wandern koennen.
+#include "ring_index.h"
+
 // RINGBUFFER for incoming UDP lora packets for lora TX
 extern unsigned char ringBuffer[MAX_RING][UDP_TX_BUF_SIZE+5];
-extern volatile int iWrite;
-extern volatile int iRead;
+extern ring_index_t iWrite;
+extern ring_index_t iRead;
 extern int iRetransmit;
 extern uint8_t retryCount[MAX_RING];
 extern uint8_t ringPriority[MAX_RING];         // Prio 1-5 pro Slot
 extern uint32_t ringEnqueueTime[MAX_RING];     // millis() timestamp when enqueued
+
+// N-14: kanonische Deklaration mit Default-Argumenten steht in loop_functions.h
+// (ein Default darf pro Parameter nur einmal je Uebersetzungseinheit stehen);
+// diese Zeile deckt nur TUs ab, die ausschliesslich dieses Extern-Header ziehen.
+int addTxRingEntry(const uint8_t* frame, uint16_t len, uint8_t ring_status,
+                    const char* source, int retryCountIn, bool clearSlotFirst);
 
 extern unsigned char ringbufferRAWLoraRX[MAX_LOG][UDP_TX_BUF_SIZE+5];
 extern int RAWLoRaWrite;
@@ -207,18 +221,32 @@ extern unsigned char BLEComToPhoneBuff[MAX_RING][MAX_MSG_LEN_PHONE+5];
 extern int ComToPhoneWrite;
 extern int ComToPhoneRead;
 
-extern uint8_t ringBufferLoraRX[MAX_DEDUP_RING][5]; //Ringbuffer for received msg_id deduplication
-extern std::atomic<uint8_t> loraWrite;   // counter for ringbuffer
+// ringBufferLoraRX/loraWrite werden jetzt in dedup_functions.h deklariert.
 
-extern std::atomic<bool> is_receiving;   // flag to store we are receiving a lora packet.
+// is_receiving: same reasoning as ch_util_rx_start_t below -- on ESP32, OnRxDone()/OnTxDone()
+// and friends run synchronously off the esp32loop() -> checkRX() call chain (no ISR, no
+// second task touches this flag there), so the atomic is unnecessary overhead. nRF52
+// registers these as real interrupt callbacks -- genuine concurrency, keep std::atomic. N-13.
+#if defined(ESP32)
+struct is_receiving_t {
+    bool v = false;
+    is_receiving_t() = default;
+    is_receiving_t(bool nv) : v(nv) {}
+    is_receiving_t &operator=(bool nv) { v = nv; return *this; }
+    operator bool() const { return v; }
+};
+#else
+using is_receiving_t = std::atomic<bool>;
+#endif
+extern is_receiving_t is_receiving;   // flag to store we are receiving a lora packet.
 extern std::atomic<bool> tx_is_active;   // flag to store we are transmitting  a lora packet.
 
 extern int cad_attempt;
 extern unsigned long csma_timeout;
 extern int rx_irq_defer_count;
-extern volatile bool cad_in_progress;
-extern volatile bool cad_done_flag;
-extern volatile bool cad_double_check;
+extern std::atomic<bool> cad_in_progress;
+extern std::atomic<bool> cad_done_flag;
+extern std::atomic<bool> cad_double_check;
 
 
 // RACE-01 fix: spinlock for deferred display update (ISR → main loop)
@@ -227,10 +255,38 @@ extern portMUX_TYPE displayMux;
 #endif
 
 // Channel utilization tracking (10s window)
-extern std::atomic<unsigned long> ch_util_rx_start;
-extern std::atomic<unsigned long> ch_util_tx_start;
-extern std::atomic<unsigned long> ch_util_rx_accum;
-extern std::atomic<unsigned long> ch_util_tx_accum;
+#if defined(ESP32)
+// ESP32 never registers OnHeaderDetect as a radio callback (see esp32_main.cpp),
+// so ch_util_rx_start has no writer reachable from an ISR or any concurrent task
+// on this platform -- no atomic needed. N-13.
+struct ch_util_rx_start_t {
+    unsigned long v = 0;
+    ch_util_rx_start_t() = default;
+    ch_util_rx_start_t(unsigned long nv) : v(nv) {}
+    ch_util_rx_start_t &operator=(unsigned long nv) { v = nv; return *this; }
+    unsigned long exchange(unsigned long nv) { unsigned long old = v; v = nv; return old; }
+};
+
+// Same reasoning for the accumulators/timestamps below: on ESP32 they are only touched
+// from OnRxDone()/OnTxDone()/checkRX(), all called synchronously from esp32loop() -- no
+// ISR, no second task. nRF52 runs these as real interrupt callbacks, keep std::atomic.
+struct ch_util_ulong_t {
+    unsigned long v = 0;
+    ch_util_ulong_t() = default;
+    ch_util_ulong_t(unsigned long nv) : v(nv) {}
+    ch_util_ulong_t &operator=(unsigned long nv) { v = nv; return *this; }
+    operator unsigned long() const { return v; }
+    unsigned long exchange(unsigned long nv) { unsigned long old = v; v = nv; return old; }
+    unsigned long fetch_add(unsigned long nv) { unsigned long old = v; v += nv; return old; }
+};
+#else
+using ch_util_rx_start_t = std::atomic<unsigned long>;
+using ch_util_ulong_t = std::atomic<unsigned long>;
+#endif
+extern ch_util_rx_start_t ch_util_rx_start;
+extern ch_util_ulong_t ch_util_tx_start;
+extern ch_util_ulong_t ch_util_rx_accum;
+extern ch_util_ulong_t ch_util_tx_accum;
 
 
 // Trickle-HEY state
@@ -277,7 +333,6 @@ extern double posinfo_prev_lat;
 extern double posinfo_prev_lon;
 extern double posinfo_last_direction;
 extern uint32_t posinfo_satcount;
-extern int posinfo_hdop;
 extern float fposinfo_hdop;
 extern bool posinfo_fix;
 extern bool posinfo_shot;
@@ -325,7 +380,6 @@ extern int softserFunktion;
 extern String strSOFTSERAPP_ID;    // ID der Messstelle
 extern String strSOFTSERAPP_NAME;  // Name der Messstelle
 
-extern String strSOFTSERAPP_ID;
 extern String strSOFTSERAPP_PEGEL;
 extern String strSOFTSERAPP_PEGEL2;
 extern String strSOFTSERAPP_TEMP;

--- a/src/lora_functions.cpp
+++ b/src/lora_functions.cpp
@@ -2,6 +2,10 @@
 #include "configuration.h"
 
 #include "printfdeb_functions.h"
+#include "txring_functions.h"
+#include "ack_functions.h"
+#include "capture_functions.h"
+#include "dedup_functions.h"
 
 #ifdef SX127X
     #include <RadioLib.h>
@@ -128,18 +132,14 @@ portMUX_TYPE displayMux = portMUX_INITIALIZER_UNLOCKED;
 // Queue display text update for main loop execution
 static void queueDisplayText(struct aprsMessage &aprsmsg, int16_t rssi, int8_t snr)
 {
-#if defined(ESP32)
-    portENTER_CRITICAL(&displayMux);
-#elif defined(BOARD_RAK4630)
+#if defined(BOARD_RAK4630)
     taskENTER_CRITICAL();
 #endif
     pendingDisplayMsg = aprsmsg;
     pendingDisplayRssi = rssi;
     pendingDisplaySnr = snr;
     bPendingDisplayText = true;
-#if defined(ESP32)
-    portEXIT_CRITICAL(&displayMux);
-#elif defined(BOARD_RAK4630)
+#if defined(BOARD_RAK4630)
     taskEXIT_CRITICAL();
 #endif
 }
@@ -147,18 +147,14 @@ static void queueDisplayText(struct aprsMessage &aprsmsg, int16_t rssi, int8_t s
 // Queue display position update for main loop execution
 static void queueDisplayPosition(struct aprsMessage &aprsmsg, int16_t rssi, int8_t snr)
 {
-#if defined(ESP32)
-    portENTER_CRITICAL(&displayMux);
-#elif defined(BOARD_RAK4630)
+#if defined(BOARD_RAK4630)
     taskENTER_CRITICAL();
 #endif
     pendingDisplayMsg = aprsmsg;
     pendingDisplayRssi = rssi;
     pendingDisplaySnr = snr;
     bPendingDisplayPos = true;
-#if defined(ESP32)
-    portEXIT_CRITICAL(&displayMux);
-#elif defined(BOARD_RAK4630)
+#if defined(BOARD_RAK4630)
     taskEXIT_CRITICAL();
 #endif
 }
@@ -240,8 +236,25 @@ static int findAndStopRingSlot(uint32_t msgId)
  */
 static bool handleACK(uint8_t *payload, uint16_t size, int rssi, int snr)
 {
+    (void)rssi;
+    (void)snr;
     if(payload[0] != MSG_TYPE_ACK)
         return false;
+
+    if(size < 12)
+        return false;
+
+    // Plausibilitaetspruefung vor jeder weiteren Verarbeitung: 0x41 ist als
+    // ASCII der Buchstabe 'A', ohne diese Pruefung laeuft jedes Bruchstueck,
+    // das damit beginnt, durch den ACK-Pfad und wird mit Prio 1 weitergesendet.
+    // Begruendung und Feldmessung siehe ack_functions.h.
+    if(!isPlausibleAckFrame(payload, size, MAX_HOP_LIMIT))
+    {
+        if(bLORADEBUG)
+            printfdeb("[MC-DBG] ACK_REJECT b5=%02X len=%u\n", payload[5], (unsigned)size);
+
+        return false;
+    }
 
     uint8_t print_buff[30];
 
@@ -298,12 +311,7 @@ static bool handleACK(uint8_t *payload, uint16_t size, int rssi, int snr)
             {
                 print_buff[5]--;
 
-                ringBuffer[iWrite][0]=12;
-                ringBuffer[iWrite][1]=RING_STATUS_DONE; // no retransmission
-                memcpy(ringBuffer[iWrite]+2, print_buff, 12);
-
-                retryCount[iWrite] = 0;
-                addTxRingEntry("rx_ack_fwd");
+                addTxRingEntry(print_buff, 12, RING_STATUS_DONE, "rx_ack_fwd", 0);
 
                 if(bDisplayInfo)
                 {
@@ -326,6 +334,20 @@ static bool handleACK(uint8_t *payload, uint16_t size, int rssi, int snr)
 
 void OnRxDone(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr)
 {
+    // Testfang-Hook (Katalog doc 08 §4, Mechanismus 2): akzeptierte Frames als
+    // Rohbytes — das Gegenstueck zum CRC_PAYLOAD-Dump der VERWORFENEN Frames
+    // in checkRX (esp32_main.cpp). OnRxDone ist auf beiden Plattformen der
+    // erste Punkt, den nur akzeptierte Frames erreichen.
+    //
+    // Frueher hing das hinter `-D MC_TEST_HOOKS` und druckte hier direkt, was
+    // in keinem Produktionsbuild lief: der Dump saesse im Radio-Callback
+    // (nRF52: Timer-Service-Task, 1 KB Stack) und printfdeb() braucht davon
+    // allein ~900 Byte, dazu ~48 ms Serial-Zeit mitten im RX-Pfad.
+    // captureFrame() kopiert nur; ausgegeben wird aus dem Loop
+    // (captureDrain() in main.cpp), siehe capture_functions.h.
+    if(bLORADEBUG)
+        captureFrame('R', payload, size, rssi, snr);
+
     // Debug I: OnRxDone timing — capture start time
     unsigned long _onrxdone_start = millis();
 
@@ -365,9 +387,17 @@ void OnRxDone(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr)
 
     // Debug logging outside critical section
     if(_overwrite)
+    {
+#ifdef LORA_ISR_DEBUG
         printfdeb("[MC-DBG] RX_BUF_OVERWRITE buf=%d (still in use)\n", rxBufIndex);
+#endif
+    }
     else if(bLORADEBUG)
+    {
+#ifdef LORA_ISR_DEBUG
         printfdeb("[MC-DBG] RX_BUF_SWITCH buf=%d\n", rxBufIndex);
+#endif
+    }
     // SPI guard: defer Radio.Rx() if Ethernet (W5100S) owns the shared SPI bus
     if(bSPI_ETH_Active) {
         bPendingRadioRx = true;
@@ -384,13 +414,25 @@ void OnRxDone(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr)
     }
     taskEXIT_CRITICAL();
     if(_cad_was_active && bLORADEBUG)
+    {
+#ifdef LORA_ISR_DEBUG
         printfdeb("[MC-DBG] CAD_ABORT_BY_RX\n");
+#endif
+    }
     if(bLORADEBUG)
+    {
+#ifdef LORA_ISR_DEBUG
         printfdeb("[MC-DBG] RX_RESTART_EARLY src=OnRxDone\n");
+#endif
+    }
     // Log RX_LISTEN -> RX_PROCESS here (not in OnHeaderDetect ISR where
     // Serial.printf is unreliable on nRF52)
     if(bLORADEBUG)
+    {
+#ifdef LORA_ISR_DEBUG
         printfdeb("[MC-SM] RX_LISTEN -> RX_PROCESS rc=0\n");
+#endif
+    }
     #endif
 
     // only for Test T5_EPAPER
@@ -1061,17 +1103,7 @@ void OnRxDone(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr)
                                                 print_buff[10]=0x01;     // switch ack GW / Node currently fixed to 0x00
                                                 print_buff[11]=0x00;     // msg always 0x00 at the end
                                                 
-                                                ringBuffer[iWrite][0]=12;
-                                                ringBuffer[iWrite][1]=RING_STATUS_DONE; // no retransmission
-                                                memcpy(ringBuffer[iWrite]+2, print_buff, 12);
-
-                                                addTxRingEntry("rx_dm_ack_gw");
-
-                                                /*
-                                                iWrite++;
-                                                if(iWrite >= MAX_RING)
-                                                    iWrite=0;
-                                                */
+                                                addTxRingEntry(print_buff, 12, RING_STATUS_DONE, "rx_dm_ack_gw");
 
                                                 if(bDisplayInfo)
                                                 {
@@ -1095,17 +1127,7 @@ void OnRxDone(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr)
                                                 print_buff[3]=(msg_counter >> 16) & 0xFF;
                                                 print_buff[4]=(msg_counter >> 24) & 0xFF;
 
-                                                ringBuffer[iWrite][0]=12;
-                                                ringBuffer[iWrite][1]=RING_STATUS_DONE; // no retransmission
-                                                memcpy(ringBuffer[iWrite]+2, print_buff, 12);
-
-                                                addTxRingEntry("rx_dm_ack_new");
-
-                                                /*
-                                                iWrite++;
-                                                if(iWrite >= MAX_RING)
-                                                    iWrite=0;
-                                                */
+                                                addTxRingEntry(print_buff, 12, RING_STATUS_DONE, "rx_dm_ack_new");
 
                                                 mid = (print_buff[1]) | (print_buff[2]<<8) | (print_buff[3]<<16) | (print_buff[4]<<24);
                                                 
@@ -1172,8 +1194,23 @@ void OnRxDone(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr)
 
                         // GATEWAY action before MESH
                         // and not MESHed from another Gateways
+                        bool bHeyReportAppended = false;
                         if(bGATEWAY && (!aprsmsg.msg_server || aprsmsg.payload_type == '@'))  // HEY always send to Server
                         {
+                            if(aprsmsg.payload_type == '@')
+                            {
+                                // append own signal report (NCT,RSSI,SNR) before UDP out, so the
+                                // server gets the same report the mesh gets — the relay path below
+                                // skips its append (RcvBuffer is re-encoded there anyway)
+                                appendHeySignalReport(aprsmsg, rssi, snr, getMheardCount());
+                                bHeyReportAppended = true;
+
+                                memset(RcvBuffer, 0x00, UDP_TX_BUF_SIZE);
+                                size = encodeAPRS(RcvBuffer, aprsmsg);
+                                if(size + 2 > UDP_TX_BUF_SIZE)
+                                    size = UDP_TX_BUF_SIZE - 2;
+                            }
+
                             addNodeData(RcvBuffer, size, rssi, snr);
                         }
 
@@ -1234,15 +1271,8 @@ void OnRxDone(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr)
                                     aprsmsg.msg_source_path.concat(meshcom_settings.node_call);
                                 }
 
-                                if(aprsmsg.payload_type == '@')
-                                {
-                                    aprsmsg.msg_payload.concat(String(getMheardCount()));
-                                    aprsmsg.msg_payload.concat(',');
-                                    aprsmsg.msg_payload.concat(String(rssi*-1.0, 0));
-                                    aprsmsg.msg_payload.concat(',');
-                                    aprsmsg.msg_payload.concat(String(snr));
-                                    aprsmsg.msg_payload.concat(';');
-                                }
+                                if(aprsmsg.payload_type == '@' && !bHeyReportAppended)
+                                    appendHeySignalReport(aprsmsg, rssi, snr, getMheardCount());
                                 
                                 memset(RcvBuffer, 0x00, UDP_TX_BUF_SIZE);
 
@@ -1251,24 +1281,20 @@ void OnRxDone(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr)
                                 if(size + 2 > UDP_TX_BUF_SIZE)
                                     size = UDP_TX_BUF_SIZE - 2;
 
-                                memset(ringBuffer[iWrite], 0x00, UDP_TX_BUF_SIZE+1);
-
-                                ringBuffer[iWrite][0]=size;
-                                memcpy(ringBuffer[iWrite]+2, RcvBuffer, size);
-
                                 // FIX: Relay messages are fire-and-forget.
                                 // Only the ORIGINATING node should retransmit.
-                                ringBuffer[iWrite][1] = RING_STATUS_DONE; // no retransmission for ANY relay message
-
                                 if(bLORADEBUG)
                                 {
-                                    unsigned int relay_msg_id = (ringBuffer[iWrite][6]<<24) | (ringBuffer[iWrite][5]<<16) | (ringBuffer[iWrite][4]<<8) | ringBuffer[iWrite][3];
+                                    // Werte aus RcvBuffer statt aus dem Ring lesen: der Slot wird
+                                    // erst innerhalb von addTxRingEntry() unter Lock gewaehlt/beschrieben.
+                                    unsigned int relay_msg_id = (RcvBuffer[4]<<24) | (RcvBuffer[3]<<16) | (RcvBuffer[2]<<8) | RcvBuffer[1];
                                     printfdeb("[MC-DBG] RELAY_QUEUED msg_id=%08X type=%02X len=%d\n",
-                                        relay_msg_id, ringBuffer[iWrite][2], size);
+                                        relay_msg_id, RcvBuffer[0], size);
                                 }
 
-                                retryCount[iWrite] = 0;
-                                addTxRingEntry("rx_relay");
+                                // no retransmission for ANY relay message; Slot vorher komplett
+                                // nullen (Alt-Verhalten: memset des ganzen Rings vor dem Schreiben)
+                                addTxRingEntry(RcvBuffer, size, RING_STATUS_DONE, "rx_relay", 0, true);
 
                                 /*
                                 if(bDisplayInfo)
@@ -1410,281 +1436,14 @@ void OnRxError(void)
     is_receiving = false;
 }
 
-/**@brief Function to check if we have a Lora packet already received
- */
-bool is_new_packet(uint8_t compBuffer[4])
-{
-    for(int ib=0; ib<MAX_DEDUP_RING; ib++)
-    {
-            if (memcmp(compBuffer, ringBufferLoraRX[ib], 4) == 0)
-            {
-                if(bLORADEBUG)
-                {
-                    uint32_t dup_id = (uint32_t)compBuffer[0] |
-                                      ((uint32_t)compBuffer[1] << 8) |
-                                      ((uint32_t)compBuffer[2] << 16) |
-                                      ((uint32_t)compBuffer[3] << 24);
-                    if(bLORADEBUG)
-                        printfdeb("[MC-DBG] RX_DEDUP_DUP msg_id=%08X slot=%d\n",dup_id, ib);
-                }
-                return false;
-            }
-    }
-
-    if(bLORADEBUG)
-    {
-        uint32_t new_id = (uint32_t)compBuffer[0] |
-                          ((uint32_t)compBuffer[1] << 8) |
-                          ((uint32_t)compBuffer[2] << 16) |
-                          ((uint32_t)compBuffer[3] << 24);
-        if(bLORADEBUG)
-            printfdeb("[MC-DBG] RX_DEDUP_NEW msg_id=%08X\n", new_id);
-    }
-    return true;
-}
+// is_new_packet() ist nach dedup_functions.cpp gewandert (reine Verschiebung).
 
 //////////////////////////////////////////////////////////////////////////
 // LoRa TX functions
-
-/**
- * Determine message priority from ring buffer slot content.
- * Ring buffer layout: [0]=len, [1]=status, [2]=payload_type, [3-6]=msg_id, [7]=flags, [8+]=path
- * Encoded path format: "SOURCE>DEST:" starting at offset 8 (relative to ringBuffer[slot]+2)
- * i.e. ringBuffer[slot][8] is the first char of the source callsign.
- */
-uint8_t getMessagePriority(int slot)
-{
-    uint8_t msg_type = ringBuffer[slot][2];
-
-    if(msg_type == MSG_TYPE_ACK)
-        return MSG_PRIO_CRITICAL;
-
-    if(msg_type == MSG_TYPE_POSITION)
-        return MSG_PRIO_LOW;
-
-    if(msg_type == MSG_TYPE_HEY)
-        return MSG_PRIO_BACKGROUND;
-
-    if(msg_type == MSG_TYPE_TEXT)
-    {
-        // Relay detection: OnRxDone sets RING_STATUS_DONE for relayed packets
-        if(ringBuffer[slot][1] == RING_STATUS_DONE)
-            return MSG_PRIO_NORMAL; // Relay
-
-        // User-originated text: parse destination from encoded APRS path
-        // Path starts at ringBuffer[slot][8] (offset 6 in encoded data = after type+id+flags)
-        // Format: "SOURCE>DEST:" — find '>' then read until payload_type char
-        int len = ringBuffer[slot][0];
-        int path_start = 8; // slot[2] + 6 bytes header = slot[8]
-        int dest_start = -1;
-        int dest_end = -1;
-
-        for(int i = path_start; i < len + 2 && i < (UDP_TX_BUF_SIZE + 4); i++)
-        {
-            if(ringBuffer[slot][i] == '>' && dest_start < 0)
-            {
-                dest_start = i + 1;
-            }
-            else if(dest_start >= 0 && (ringBuffer[slot][i] == ':' || ringBuffer[slot][i] == MSG_TYPE_TEXT))
-            {
-                dest_end = i;
-                break;
-            }
-        }
-
-        if(dest_start >= 0 && dest_end > dest_start)
-        {
-            char dest[12] = {0};
-            int dlen = dest_end - dest_start;
-            if(dlen > 10) dlen = 10;
-            memcpy(dest, &ringBuffer[slot][dest_start], dlen);
-            dest[dlen] = 0;
-
-            if(strcmp(dest, "*") == 0)
-                return MSG_PRIO_HIGH; // Broadcast
-
-            if(CheckGroup(String(dest)) != 0)
-                return MSG_PRIO_HIGH; // Group message
-
-            return MSG_PRIO_CRITICAL; // Personal DM
-        }
-
-        // Fallback: treat as high priority if parsing fails
-        return MSG_PRIO_HIGH;
-    }
-
-    // Unknown type: normal priority
-    return MSG_PRIO_NORMAL;
-}
-
-/**
- * Find the next slot to transmit from the ring buffer, based on priority.
- * Scans all occupied slots between iRead and iWrite.
- * Returns slot index, or -1 if empty.
- * Within same priority, oldest entry (closest to iRead) wins (FIFO).
- */
-int getNextTxSlot(void)
-{
-    if(iWrite == iRead)
-        return -1;
-
-    int best_slot = -1;
-    uint8_t best_prio = 255;
-
-    int pos = iRead;
-    while(pos != iWrite)
-    {
-#if defined(EXTERNAL_RADIO)
-        // owned-slot status invariant: a slot owned by an in-flight external TX must never be
-        // reselected. RING_STATUS_EXT_PENDING is neither READY nor DONE, so the
-        // test below already skips it; this explicit skip states the intent.
-        if(ringBuffer[pos][1] == RING_STATUS_EXT_PENDING)
-        {
-            pos++;
-            if(pos >= MAX_RING)
-                pos = 0;
-            continue;
-        }
-#endif
-        // Only consider slots with data that are ready to send (READY or DONE/fire-and-forget).
-        // Skip slots with status SENT..threshold (awaiting retransmission timer).
-        if(ringBuffer[pos][0] > 0 &&
-           (ringBuffer[pos][1] == RING_STATUS_READY || ringBuffer[pos][1] == RING_STATUS_DONE))
-        {
-            uint8_t prio = ringPriority[pos];
-            if(prio < best_prio)
-            {
-                best_prio = prio;
-                best_slot = pos;
-            }
-            // Same prio: keep first found (= oldest = FIFO)
-        }
-
-        pos++;
-        if(pos >= MAX_RING)
-            pos = 0;
-    }
-
-    return best_slot;
-}
-
-/**
- * Advance iRead past any empty (already-transmitted) slots at the front.
- */
-static void advanceIReadPastEmpty(void)
-{
-    int localRead = iRead;
-    int localWrite = iWrite;
-    while(localRead != localWrite && ringBuffer[localRead][0] == 0)
-    {
-        localRead++;
-        if(localRead >= MAX_RING)
-            localRead = 0;
-    }
-    iRead = localRead;
-}
-
-/**
- * Log + advance TX ring buffer write pointer.
- * Replaces direct addRingPointer(iWrite, iRead, MAX_RING, "tx") calls.
- * @param source  Short label for the calling code path (e.g. "rx_relay", "udp")
- */
-void addTxRingEntry(const char* source)
-{
-    int w = iWrite;
-    int r = iRead;
-
-    if(bLORADEBUG)
-    {
-        uint32_t mid = ((uint32_t)ringBuffer[w][6] << 24) |
-                       ((uint32_t)ringBuffer[w][5] << 16) |
-                       ((uint32_t)ringBuffer[w][4] << 8)  |
-                        (uint32_t)ringBuffer[w][3];
-        int queued = (w >= r) ? (w - r) : (MAX_RING - r + w);
-        if(bLORADEBUG)
-            printfdeb("[MC-DBG] RING_WRITE slot=%d type=%02X status=%02X "
-                      "len=%d msg_id=%08X queued=%d/%d src=%s\n",
-                      w, ringBuffer[w][2], ringBuffer[w][1],
-                      ringBuffer[w][0], mid, queued, MAX_RING, source);
-    }
-
-    // Assign priority and enqueue timestamp
-    ringPriority[w] = getMessagePriority(w);
-    ringEnqueueTime[w] = millis();
-
-    // Track queue depth for high-water mark
-    int queued_now = (w >= r) ? (w - r) : (MAX_RING - r + w);
-    if(queued_now + 1 > stat_queue_hwm)
-        stat_queue_hwm = queued_now + 1;
-
-    if(bLORADEBUG)
-        printfdeb("[MC-DBG] RING_PRIO slot=%d prio=%d\n", w, ringPriority[w]);
-
-    // Priority-aware overflow: when queue is full, drop lowest-priority oldest entry
-    int nextWrite = w + 1;
-    if(nextWrite >= MAX_RING) nextWrite = 0;
-    if(nextWrite == r && ringBuffer[r][0] > 0)
-    {
-        // Find the oldest entry of the lowest priority in the queue
-        uint8_t new_prio = ringPriority[w];
-        int worst_slot = -1;
-        uint8_t worst_prio = 0;
-        int scan = r;
-        while(scan != w)
-        {
-            bool evictable = ringBuffer[scan][0] > 0;
-#if defined(EXTERNAL_RADIO)
-            // Never evict an in-flight external-TX slot: its length must stay
-            // valid until the bridge result resolves it, and the ownership record
-            // is not notified by this overflow path. Dropping it here would lose a
-            // pending TX or let a late result corrupt the reused slot.
-            if(ringBuffer[scan][1] == RING_STATUS_EXT_PENDING)
-                evictable = false;
-#endif
-            if(evictable && ringPriority[scan] > worst_prio)
-            {
-                worst_prio = ringPriority[scan];
-                worst_slot = scan;
-            }
-            scan++;
-            if(scan >= MAX_RING) scan = 0;
-        }
-
-        if(worst_slot >= 0 && new_prio < worst_prio)
-        {
-            // Drop the lowest-priority entry to make room
-            uint32_t lost_id = ((uint32_t)ringBuffer[worst_slot][6] << 24) |
-                               ((uint32_t)ringBuffer[worst_slot][5] << 16) |
-                               ((uint32_t)ringBuffer[worst_slot][4] << 8)  |
-                                (uint32_t)ringBuffer[worst_slot][3];
-            if(bLORADEBUG)
-                printfdeb("[MC-DBG] RING_DROP_PRIO slot=%d prio=%d type=%02X "
-                          "msg_id=%08X replaced_by_prio=%d src=%s\n",
-                          worst_slot, worst_prio, ringBuffer[worst_slot][2],
-                          lost_id, new_prio, source);
-            stat_drop_count[worst_prio]++;
-            ringBuffer[worst_slot][0] = 0; // Mark as empty
-            advanceIReadPastEmpty();
-        }
-        else
-        {
-            // New packet is same or lower priority than everything in queue — drop it
-            uint32_t lost_id = ((uint32_t)ringBuffer[w][6] << 24) |
-                               ((uint32_t)ringBuffer[w][5] << 16) |
-                               ((uint32_t)ringBuffer[w][4] << 8)  |
-                                (uint32_t)ringBuffer[w][3];
-            if(bLORADEBUG)
-                printfdeb("[MC-DBG] RING_DROP_NEW slot=%d prio=%d type=%02X "
-                          "msg_id=%08X (queue full, no lower prio to evict)\n",
-                          w, new_prio, ringBuffer[w][2], lost_id);
-            stat_drop_count[new_prio]++;
-            ringBuffer[w][0] = 0; // Don't enqueue
-            return; // Don't advance write pointer
-        }
-    }
-
-    addRingPointer(iWrite, iRead, MAX_RING, "tx");
-}
+//
+// getMessagePriority/getNextTxSlot/advanceIReadPastEmpty/addTxRingEntry
+// wurden nach txring_functions.cpp verschoben -- reine Verschiebung, Logik
+// unveraendert. Siehe txring_functions.h/.cpp.
 
 /**@brief our Lora TX sequence — priority-based slot selection
  */
@@ -1759,6 +1518,19 @@ bool doTX()
         // restore the slot and retry on the next call.
         // For rollback: we restore ringBuffer[save_read][0] = sendlng.
 
+        // Testfang-Hook TX (siehe capture_functions.h): die Bytes, die dieser
+        // Knoten gleich auf den Kanal legt. Ohne diese Seite zeigt der
+        // Mitschnitt nur, was empfangen wurde -- ob unser eigenes
+        // Re-Enkodieren auf dem Relay-Pfad (Hop-Dekrement, Pfadanhang)
+        // byte-treu ist, laesst sich daraus nicht pruefen.
+        //
+        // Nur puffern, nicht drucken: diese Stelle liegt zwischen der
+        // CAD-Entscheidung "Kanal frei" und startTransmit(); eine halbe
+        // Sekunde Serial-Ausgabe dazwischen wuerde die Kanalmessung
+        // entwerten, auf der der Sendezeitpunkt beruht.
+        if(bTXCAPTURE && sendlng > 0)
+            captureFrame('T', lora_tx_buffer, (uint16_t)sendlng, 0, 0);
+
         // we can now tx the message
         if (TX_ENABLE == 1)
         {
@@ -1771,12 +1543,19 @@ bool doTX()
                 // you can transmit C-string or Arduino string up to
                 // 256 characters long
                 // Position zumindest alle funf Minuten auch zu MeshCom senden
-                if(millis() > track_to_meshcom_timer + 1000 * 60 * 5)
+                if((uint32_t)(millis() - track_to_meshcom_timer) >= 1000 * 60 * 5)
                 {
                     #if defined BOARD_RAK4630
-                        taskENTER_CRITICAL();
+                        // N-16: taskENTER_CRITICAL() masks interrupts, including the
+                        // tick — SX126xWaitOnBusy() inside Radio.Send() calls delay(1)
+                        // in a loop, which needs the tick to ever return, so the old
+                        // critical section could hang forever. vTaskSuspendAll() only
+                        // blocks task scheduling, which is enough to keep the FreeRTOS
+                        // timer-service task (OnRxDone, priority 2, see C-01) from
+                        // touching the radio mid-send, without freezing the tick.
+                        vTaskSuspendAll();
                         Radio.Send(lora_tx_buffer, sendlng);
-                        taskEXIT_CRITICAL();
+                        xTaskResumeAll();
                     #else
                         #ifndef BOARD_T5_EPAPER
                         #ifdef RADIO_CTRL
@@ -1815,9 +1594,11 @@ bool doTX()
                 // you can transmit C-string or Arduino string up to
                 // 256 characters long
                 #if defined BOARD_RAK4630
-                    taskENTER_CRITICAL();
+                    // N-16, see the "track" send above for why vTaskSuspendAll()
+                    // replaces taskENTER_CRITICAL() here.
+                    vTaskSuspendAll();
                     Radio.Send(lora_tx_buffer, sendlng);
-                    taskEXIT_CRITICAL();
+                    xTaskResumeAll();
                 #else
                     #ifndef BOARD_T5_EPAPER
                     #ifdef RADIO_CTRL
@@ -1876,9 +1657,11 @@ bool doTX()
                     // you can transmit C-string or Arduino string up to
                     // 256 characters long
                     #if defined BOARD_RAK4630
-                        taskENTER_CRITICAL();
+                        // N-16, see the "track" send above for why vTaskSuspendAll()
+                        // replaces taskENTER_CRITICAL() here.
+                        vTaskSuspendAll();
                         Radio.Send(lora_tx_buffer, sendlng);
-                        taskEXIT_CRITICAL();
+                        xTaskResumeAll();
                     #else
                         #ifndef BOARD_T5_EPAPER
                         #ifdef RADIO_CTRL
@@ -2023,22 +1806,22 @@ bool updateRetransmissionStatus()
                     printfdeb("");
                 }
 
-                // Copy message to new slot BEFORE clearing original (len must still be valid)
-                memcpy(ringBuffer[iWrite], ringBuffer[ircheck], size + 2);
+                // ready for doTX (text messages) or fire-and-forget, wie zuvor
+                uint8_t retransmitStatus = (ringBuffer[ircheck][2] == MSG_TYPE_TEXT)
+                                            ? RING_STATUS_READY : RING_STATUS_DONE;
 
-                if (ringBuffer[iWrite][2] == MSG_TYPE_TEXT) // text messages
-                    ringBuffer[iWrite][1] = RING_STATUS_READY;  // ready for doTX; timer starts after send
-                else
-                    ringBuffer[iWrite][1] = RING_STATUS_DONE;
-
-                // Transfer and increment retry count
-                retryCount[iWrite] = retryCount[ircheck] + 1;
+                // Quelle ist ircheck, Ziel wird erst innerhalb der Funktion (unter
+                // Lock) gewaehlt — ircheck != iWrite im Normalfall (iWrite zeigt auf
+                // einen leeren Slot); selbst im theoretischen Gleichstand ist
+                // memcpy(dst==src) hier folgenlos (Quelle == Ziel-Byte fuer Byte).
+                // Original erst NACH dem Kopieren freigeben, damit die Payload beim
+                // Kopiervorgang garantiert noch gueltig ist.
+                addTxRingEntry(&ringBuffer[ircheck][2], (uint16_t)size, retransmitStatus,
+                                "retransmit", retryCount[ircheck] + 1);
 
                 // Mark original as done and free slot (after copy, so len is correct in new slot)
                 ringBuffer[ircheck][1] = RING_STATUS_DONE;
                 ringBuffer[ircheck][0] = 0;  // free slot so getNextTxSlot skips it
-
-                addTxRingEntry("retransmit");
 
                 return true;
             }

--- a/src/lora_functions.h
+++ b/src/lora_functions.h
@@ -9,7 +9,7 @@
 void OnRxDone(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr);
 void OnRxTimeout(void);
 void OnRxError(void);
-bool is_new_packet(uint8_t compBuffer[4]);
+// is_new_packet() wird jetzt in dedup_functions.h deklariert.
 
 void StartReceiveAgain();
 
@@ -26,8 +26,7 @@ unsigned long csma_compute_timeout(int attempt);
 unsigned long csma_compute_timeout_prio(int attempt, uint8_t priority);
 void csma_reset(void);
 
-uint8_t getMessagePriority(int slot);
-int getNextTxSlot(void);
+// getMessagePriority/getNextTxSlot: siehe txring_functions.h (verschoben).
 
 #if defined(EXTERNAL_RADIO)
 // --- asynchronous external-radio TX queue ownership -----------------------

--- a/src/lora_setchip.cpp
+++ b/src/lora_setchip.cpp
@@ -711,12 +711,15 @@ bool lora_setchip_aprs()
 
 bool lora_setchip_new(float rf_freq, float rf_bw, int rf_sf, int rf_cr, int rf_syncword, uint16_t rf_preamble_length, bool rf_crc)
 {
+    // Only the ESP32/RadioLib branch below actually uses these — on every other
+    // platform (e.g. nRF52, which configures its SX126x driver elsewhere) this
+    // function compiles down to a no-op, leaving all seven parameters unused.
+    (void)rf_freq; (void)rf_bw; (void)rf_sf; (void)rf_cr;
+    (void)rf_syncword; (void)rf_preamble_length; (void)rf_crc;
 
 #if defined(EXTERNAL_RADIO)
     // External radio mode never drives the local RF chip. Accept as a no-op so any
     // residual caller cannot touch RadioLib hardware.
-    (void)rf_freq; (void)rf_bw; (void)rf_sf; (void)rf_cr;
-    (void)rf_syncword; (void)rf_preamble_length; (void)rf_crc;
     return true;
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 #endif
 
 #include <configuration.h>
+#include <capture_functions.h>
 
 #ifdef ESP32
   #include <esp32/esp32_main.h>
@@ -67,4 +68,8 @@ void loop()
     esp32loop();
   #endif
 
+  // Rohframe-Mitschnitt ausgeben. Die Erfassung sitzt im Radio-Callback bzw.
+  // zwischen CAD und startTransmit() und darf dort nicht drucken; hier ist
+  // Loop-Kontext. Ein Frame je Durchlauf, siehe capture_functions.h.
+  captureDrain();
 }

--- a/src/mask_secret.h
+++ b/src/mask_secret.h
@@ -1,0 +1,37 @@
+#pragma once
+
+// Maskierung von Passwoertern in der Klartextausgabe der Firmware.
+//
+// Die Ausgabe laeuft ueber printfdeb() und damit nicht nur auf die serielle
+// Schnittstelle, sondern auch auf die Netzkonsole (Port 2323, net_console.h).
+// Die steht ohne gesetztes node_passwd ohne jede Authentisierung offen: ein
+// `nc <node> 2323` gefolgt von `--info` lieferte bis hierher das WLAN-PSK, das
+// Webserver-Passwort und das Konsolenpasswort im Klartext an jeden im selben
+// Netz. Am laufenden Knoten nachgestellt (DK5EN-98, 25.08.2026).
+//
+// Sichtbar bleibt, OB ein Passwort gesetzt ist -- das ist die Information, um
+// derentwillen die Zeile in --info steht. Die Settings-JSON an die App
+// (nsetdoc["WSPWD"]) bleibt unberuehrt: sie muss den Wert tragen, damit die App
+// ihn anzeigen und aendern kann.
+
+#include <stddef.h>
+
+/**
+ * @brief Ersetzt ein gesetztes Passwort durch "***".
+ *
+ * @param secret  Passwortpuffer, darf NULL sein.
+ * @return "***" wenn gesetzt, sonst "" -- nie NULL, direkt an %s uebergebbar.
+ */
+static inline const char *maskSecret(const char *secret)
+{
+    if(secret == NULL)
+        return "";
+
+    // node_passwd wird mit "%-14.14s" gespeichert, ist also mit Leerzeichen
+    // aufgefuellt; ein fuehrendes Leerzeichen heisst "nicht gesetzt" -- dieselbe
+    // Pruefung wie bei hasPasswd im --passwd-Zweig (command_functions.cpp).
+    if(secret[0] == 0x00 || secret[0] == ' ')
+        return "";
+
+    return "***";
+}

--- a/src/mheard_functions.cpp
+++ b/src/mheard_functions.cpp
@@ -159,7 +159,7 @@ void saveMHeardPersistence()
         }
 
         // check to save to SD only every 30 sec
-        if(lastsaveMHEARDPersistence + 30000 > millis())
+        if((uint32_t)(millis() - lastsaveMHEARDPersistence) < 30000)
             return;
 
         lastsaveMHEARDPersistence = millis();
@@ -191,7 +191,7 @@ void savePathPersistence()
         }
 
         // check to save to SD only every 30 sec
-        if(lastsavePATHPersistence + 30000 > millis())
+        if((uint32_t)(millis() - lastsavePATHPersistence) < 30000)
             return;
 
         lastsavePATHPersistence = millis();
@@ -530,19 +530,24 @@ void updateHeyPath(struct mheardLine &mheardLine)
     int ipc = mheardLine.mh_sourcepath.length() - ips;
     if(ipc > 37)
         ipc = 37;
+    if(ipc < 0)
+        ipc = 0;
 
-    
+
     // only MHEARD HEY
     if(ips <= 0)
         return;
 
     memset(mheardPathCalls[ipos], 0x00, sizeof(mheardPathCalls[ipos]));
-    memcpy(mheardPathCalls[ipos], mheardLine.mh_sourcecallsign.c_str(), sizeof(mheardPathCalls[ipos]));
+    int icallsize = mheardLine.mh_sourcecallsign.length();
+    if(icallsize > (int)sizeof(mheardPathCalls[ipos])-1)
+        icallsize = (int)sizeof(mheardPathCalls[ipos])-1;
+    memcpy(mheardPathCalls[ipos], mheardLine.mh_sourcecallsign.c_str(), icallsize);
 
     //printfdeb("PATH:%i <%s> <%s> %i %i\n", ipos,  mheardLine.mh_sourcepath.c_str(), mheardLine.mh_sourcepath.substring(ips).c_str(), ips, ipc);
 
     memset(mheardPathBuffer1[ipos], 0x00, sizeof(mheardPathBuffer1[ipos]));
-    memcpy(mheardPathBuffer1[ipos], mheardLine.mh_sourcepath.substring(ips).c_str(), sizeof(mheardPathBuffer1[ipos]));
+    memcpy(mheardPathBuffer1[ipos], mheardLine.mh_sourcepath.substring(ips).c_str(), ipc);
     mheardPathBuffer1[ipos][49] = 0x00;
     // TODO second 30 chars
 

--- a/src/net_console.cpp
+++ b/src/net_console.cpp
@@ -168,31 +168,23 @@ static void authTask(void* arg)
 
         if (readOk)
         {
-            Serial.printf("[CON ]...s_password:<%s> lng:%i resoBuf:<%s>\n", s_password, strlen(s_password), respBuf);
+            Serial.printf("[CON ]...s_password:<***> lng:%i resoBuf:<***>\n", strlen(s_password));
 
-            // KBC check without SHA256
-            if(memcmp(respBuf, s_password, strlen(s_password)) != 0)
+            // 4. Compute expected HMAC-SHA256(password, nonce)
+            uint8_t expected[32];
+            const mbedtls_md_info_t* md = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
+            if (md && mbedtls_md_hmac(md,
+                                    (const uint8_t*)s_password, strlen(s_password),
+                                    nonce, sizeof(nonce), expected) == 0)
             {
-                // 4. Compute expected HMAC-SHA256(password, nonce)
-                uint8_t expected[32];
-                const mbedtls_md_info_t* md = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
-                if (md && mbedtls_md_hmac(md,
-                                        (const uint8_t*)s_password, strlen(s_password),
-                                        nonce, sizeof(nonce), expected) == 0)
+                // 5. Hex-decode response, constant-time compare
+                uint8_t received[32];
+                if (strlen(respBuf) == 64 &&
+                    hex_to_bytes(respBuf, 64, received, 32) &&
+                    ct_equal(expected, received, 32))
                 {
-                    // 5. Hex-decode response, constant-time compare
-                    uint8_t received[32];
-                    if (strlen(respBuf) == 64 &&
-                        hex_to_bytes(respBuf, 64, received, 32) &&
-                        ct_equal(expected, received, 32))
-                    {
-                        authOk = true;
-                    }
+                    authOk = true;
                 }
-            }
-            else
-            {
-                authOk = true;
             }
         }
     }
@@ -289,14 +281,19 @@ void stopNetConsole()
 {
     if (!s_started) return;
     s_started        = false;
-    s_mutex          = xSemaphoreCreateMutex();
     s_server_pending = false;   // open socket on next loopNetConsole() call
 
     // stop
     if(s_listen_fd >= 0)
-        ::close(s_listen_fd); s_listen_fd = -1;
+    {
+        ::close(s_listen_fd);
+    }
+    s_listen_fd = -1;
 
-    teardownClient();
+    if (s_mutex && xSemaphoreTake(s_mutex, portMAX_DELAY) == pdTRUE)
+    {
+        teardownClient();
+    }
 
     s_hwSerial.println("[CON ]...HMAC console stopped.");
 }

--- a/src/nrf52/WisBlock-API.cpp
+++ b/src/nrf52/WisBlock-API.cpp
@@ -33,6 +33,7 @@ bool g_enable_ble = false;
  */
 void periodic_wakeup(TimerHandle_t unused)
 {
+	(void)unused;
 	// Switch on LED to show we are awake
 	digitalWrite(LED_GREEN, HIGH);
 	api_wake_loop(STATUS);

--- a/src/nrf52/WisBlock-API.h
+++ b/src/nrf52/WisBlock-API.h
@@ -123,6 +123,10 @@ void init_ble_name(void);
 BLEService init_settings_characteristic(void);
 void restart_advertising(uint16_t timeout);
 void stop_advertising();
+// CONC-17: applies a settings write staged by settings_rx_callback() from the
+// Main Loop task, so a concurrent radio/loop read of meshcom_settings never
+// observes a torn struct. Call once per loop iteration.
+void applyPendingBleSettings(void);
 extern BLECharacteristic g_lora_data;
 extern BLEUart g_ble_uart;
 extern bool g_ble_uart_is_connected;

--- a/src/nrf52/at_cmd.h
+++ b/src/nrf52/at_cmd.h
@@ -27,7 +27,7 @@
 	if (g_ble_uart_is_connected)                                        \
 	{                                                                   \
 		char buff[255];                                                 \
-		int len = sprintf(buff, __VA_ARGS__);                           \
+		int len = snprintf(buff, sizeof(buff), __VA_ARGS__);                           \
 		uart_tx_characteristic->setValue((uint8_t *)buff, (size_t)len); \
 		uart_tx_characteristic->notify(true);                           \
 		delay(50);                                                      \

--- a/src/nrf52/nrf52_ble.cpp
+++ b/src/nrf52/nrf52_ble.cpp
@@ -31,6 +31,19 @@ extern uint8_t dmac[6];
 extern bool config_to_phone_prepare;
 extern bool conffin_sent;
 
+// FreeRTOS queue holding raw BLE payloads handed from the BLE stack's
+// RX callback (adafruit_ble_task context) to the Main Loop task, which
+// drains it in nrf52loop() (src/nrf52/nrf52_main.cpp). readPhoneCommand()/
+// commandAction()/save_settings() must not run inline in the BLE callback
+// concurrently with the Main Loop; this mirrors the ESP32 bleQueue design
+// (CONC-14). Non-static: nrf52_main.cpp references it via extern.
+struct BleQueueItem {
+	uint8_t data[MAX_MSG_LEN_PHONE];
+	size_t length;
+};
+
+QueueHandle_t bleQueue = NULL;
+
 // Create device name
 char helper_string[256] = {0};
 
@@ -65,6 +78,10 @@ bool g_ble_uart_is_connected = false;
  */
 void init_ble(void)
 {
+	// Create the BLE RX queue before starting BLE so the RX callback can
+	// enqueue into it as soon as connections are possible (CONC-14).
+	bleQueue = xQueueCreate(5, sizeof(BleQueueItem));
+
 	// Config the peripheral connection with maximum bandwidth
 	// more SRAM required by SoftDevice
 	// Note: All config***() function must be called before begin()
@@ -247,11 +264,12 @@ void bleuart_rx_callback(uint16_t conn_handle)
 	g_task_event_type |= BLE_DATA;
 	xSemaphoreGiveFromISR(g_task_sem, pdFALSE);
 
-	// Forward data from Mobile to our peripheral
-	uint8_t conf_data[MAX_MSG_LEN_PHONE] = {0};
-	g_ble_uart.read(conf_data, MAX_MSG_LEN_PHONE);
-
-	readPhoneCommand(conf_data);
+	// Forward data from Mobile to our peripheral: enqueue for processing
+	// in the Main Loop task instead of calling readPhoneCommand() here,
+	// inline in the BLE stack's callback context (CONC-14).
+	BleQueueItem item = {};
+	item.length = g_ble_uart.read(item.data, MAX_MSG_LEN_PHONE);
+	xQueueSend(bleQueue, &item, 0);  // non-blocking, drop on full queue
 
 	// Disconnect if app-layer auth failed
 	if(ble_disconnect_requested)
@@ -282,6 +300,17 @@ BLEService init_settings_characteristic(void)
 	return lora_service;
 }
 
+// CONC-17: settings_rx_callback() runs in the BLE stack's task context, which
+// can be preempted mid-memcpy by the FreeRTOS timer-service task that drives
+// OnRxDone (priority 2) — a torn copy of
+// meshcom_settings could put a beacon on the air with a spliced callsign or
+// frequency. The callback stages the incoming struct into this private
+// buffer (no shared state touched) and only sets a flag; applyPendingBleSettings(),
+// called once per Main Loop iteration, does the actual copy into
+// meshcom_settings under a short critical section.
+static s_meshcom_settings s_pendingBleSettings;
+static volatile bool s_bBleSettingsPending = false;
+
 /**
  * Callback if data has been sent from the connected client
  * @param conn_hdl
@@ -295,6 +324,7 @@ BLEService init_settings_characteristic(void)
  */
 void settings_rx_callback(uint16_t conn_hdl, BLECharacteristic *chr, uint8_t *data, uint16_t len)
 {
+	(void)conn_hdl;
 	API_LOG("SETT", "Settings received");
 
 	delay(1000);
@@ -315,26 +345,10 @@ void settings_rx_callback(uint16_t conn_hdl, BLECharacteristic *chr, uint8_t *da
 			return;
 		}
 
-		// Save new LoRa settings
-		memcpy((void *)&meshcom_settings, data, sizeof(s_meshcom_settings));
-
-		// Save new settings
-		save_settings();
-
-		// Update settings
-		g_lora_data.write((void *)&meshcom_settings, sizeof(s_meshcom_settings));
-
-		// Inform connected device about new settings
-		g_lora_data.notify((void *)&meshcom_settings, sizeof(s_meshcom_settings));
-
-        /*KBC
-        if (meshcom_settings.resetRequest)
-		{
-			API_LOG("SETT", "Initiate reset");
-			delay(1000);
-			sd_nvic_SystemReset();
-		}
-        */
+		// CONC-17: stage only, apply from the Main Loop (see comment above
+		// s_pendingBleSettings)
+		memcpy((void *)&s_pendingBleSettings, data, sizeof(s_meshcom_settings));
+		s_bBleSettingsPending = true;
 
 		// Notify task about the event
 		if (g_task_sem != NULL)
@@ -344,6 +358,41 @@ void settings_rx_callback(uint16_t conn_hdl, BLECharacteristic *chr, uint8_t *da
 			xSemaphoreGive(g_task_sem);
 		}
 	}
+}
+
+/**
+ * @brief Apply a settings write staged by settings_rx_callback(), if any.
+ * Must be called from the Main Loop task only (CONC-17).
+ */
+void applyPendingBleSettings(void)
+{
+	if (!s_bBleSettingsPending)
+		return;
+	s_bBleSettingsPending = false;
+
+	// Short, non-blocking copy — safe to run with interrupts masked, unlike
+	// the delay()-based patterns fixed under N-16.
+	taskENTER_CRITICAL();
+	memcpy((void *)&meshcom_settings, &s_pendingBleSettings, sizeof(s_meshcom_settings));
+	taskEXIT_CRITICAL();
+
+	// Save new settings
+	save_settings();
+
+	// Update settings
+	g_lora_data.write((void *)&meshcom_settings, sizeof(s_meshcom_settings));
+
+	// Inform connected device about new settings
+	g_lora_data.notify((void *)&meshcom_settings, sizeof(s_meshcom_settings));
+
+	/*KBC
+	if (meshcom_settings.resetRequest)
+	{
+		API_LOG("SETT", "Initiate reset");
+		delay(1000);
+		sd_nvic_SystemReset();
+	}
+	*/
 }
 
 #endif

--- a/src/nrf52/nrf52_flash.cpp
+++ b/src/nrf52/nrf52_flash.cpp
@@ -260,19 +260,33 @@ void init_flash(void)
 		// Found new structure
 		lora_file.close();
 		lora_file.open(settings_name, FILE_O_READ);
+		// Groesse VOR dem Lesen sichern -- close() unten macht sie nicht mehr abfragbar.
+		uint32_t stored_size = lora_file.size();
 		lora_file.read((uint8_t *)&meshcom_settings, sizeof(s_meshcom_settings));
 		lora_file.close();
 
 		//printf("meshcom_settings%s\n", meshcom_settings.node_call);
 
 		// Check if it is LPWAN settings^
-		if ((meshcom_settings.valid_mark_1 != 0xAA) || (meshcom_settings.valid_mark_2 != MESHCOM_DATA_MARKER))
+		// Groessen-Check (N-12): eine Struktur-Layout-Aenderung faellt hier auf, wenn die abgelegte
+		// Datei nicht mehr sizeof(s_meshcom_settings) gross ist -- sonst wuerde stillschweigend mit
+		// verschobenen/fehlinterpretierten Feldern weitergearbeitet. Padding-neutrale Feldvertauschungen,
+		// die sizeof unveraendert lassen, bleiben davon unentdeckt -- Layout-Aenderungen muessen daher
+		// FLASH_VERSION erhoehen. Der 0x57-Kompat-Pfad oben bekommt bewusst KEINE Groessenpruefung,
+		// da alte Dateien diesem Schema vorausgehen.
+		if ((meshcom_settings.valid_mark_1 != 0xAA) || (meshcom_settings.valid_mark_2 != MESHCOM_DATA_MARKER) ||
+			(stored_size != sizeof(s_meshcom_settings)))
 		{
-			// Data is not valid, reset to defaults
-			DEBUG_MSG("FLASH", "Invalid data set, deleting and restart node");
-			InternalFS.format();
-			delay(1000);
-			sd_nvic_SystemReset();
+			// Daten sind ungueltig oder die Dateigroesse passt nicht mehr zur aktuellen Struktur:
+			// sauberer Reset auf Defaults statt stillem Weiterlaufen mit Datenmuell (N-12).
+			// flash_reset() invalidiert dabei init_flash_done, ein erneuter Aufruf hier ist daher
+			// nicht noetig und wuerde auch keine Rekursion ausloesen -- wir lesen direkt die frisch
+			// geschriebene Default-Datei zurueck (einmaliger Reset, kein Retry-Loop).
+			DEBUG_MSG("FLASH", "Invalid data set or size mismatch, resetting to defaults");
+			flash_reset();
+			lora_file.open(settings_name, FILE_O_READ);
+			lora_file.read((uint8_t *)&meshcom_settings, sizeof(s_meshcom_settings));
+			lora_file.close();
 		}
 		log_settings();
 		init_flash_done = true;
@@ -341,11 +355,19 @@ void flash_reset(void)
 	InternalFS.format();
 	if (lora_file.open(settings_name, FILE_O_WRITE))
 	{
+		// default_settings ist default-konstruiert -> die Member-Initializer in s_meshcom_settings
+		// setzen gueltige Marker (0xAA/MESHCOM_DATA_MARKER) sowie alle Default-Werte.
 		s_meshcom_settings default_settings;
 		lora_file.write((uint8_t *)&default_settings, sizeof(s_meshcom_settings));
 		lora_file.flush();
 		lora_file.close();
 	}
+
+	// Cache invalidieren: ohne dies ist der naechste init_flash()-Aufruf ein No-Op (Guard oben),
+	// und save_settings() wuerde die alte RAM-Kopie zurueckschreiben, obwohl das Log einen
+	// sauberen Reset meldet (N-12). flash_reset() muss also erzwingen, dass frisch von Flash
+	// gelesen wird.
+	init_flash_done = false;
 }
 
 /**

--- a/src/nrf52/nrf52_main.cpp
+++ b/src/nrf52/nrf52_main.cpp
@@ -3,6 +3,7 @@
 // 20230326: Version 4.00: START
 
 #include "configuration.h"
+#include "capture_functions.h"
 
 #include <Arduino.h>
 #include <SPI.h>
@@ -118,6 +119,7 @@ void sendHeartbeat();
 #include <lora_setchip.h>
 #include <loop_functions.h>
 #include <loop_functions_extern.h>
+#include "dedup_functions.h"
 #include <command_functions.h>
 #include <aprs_functions.h>
 #include <batt_functions.h>
@@ -235,14 +237,25 @@ static RadioEvents_t RadioEvents;
 unsigned long iReceiveTimeOutTime = 0;
 
 // CSMA/CA async CAD state
-volatile bool cad_done_flag = false;
-volatile bool cad_channel_busy = false;
-volatile bool cad_in_progress = false;
-volatile bool cad_double_check = false;
+std::atomic<bool> cad_done_flag{false};
+std::atomic<bool> cad_channel_busy{false};
+std::atomic<bool> cad_in_progress{false};
+std::atomic<bool> cad_double_check{false};
 unsigned long cad_start_time = 0;
 
 bool g_meshcom_initialized;
 bool init_flash_done=false;
+
+// FreeRTOS queue of raw BLE payloads, filled by bleuart_rx_callback() in
+// nrf52_ble.cpp (BLE task context) and drained below in nrf52loop() so
+// readPhoneCommand()/commandAction()/save_settings() run in the Main Loop
+// task instead of inline in the BLE callback (CONC-14). Struct layout must
+// stay in sync with the definition in nrf52_ble.cpp.
+struct BleQueueItem {
+    uint8_t data[MAX_MSG_LEN_PHONE];
+    size_t length;
+};
+extern QueueHandle_t bleQueue;
 
 bool bPosFirst = true;
 bool bHeyFirst = true;
@@ -394,7 +407,7 @@ void OnCadDone(bool channelActivityDetected)
     // RACE-05 fix: atomic flag update under critical section
     taskENTER_CRITICAL();
     cad_channel_busy = channelActivityDetected;
-    cad_done_flag = true;
+    cad_done_flag.store(true, std::memory_order_release);
     taskEXIT_CRITICAL();
 }
 
@@ -500,21 +513,25 @@ void nrf52setup()
     if(meshcom_settings.node_cleanflash == 1)
         bClear = true;
 
-    if(meshcom_settings.node_fversion != FLASH_VERSION || bClear)
+    // Geloescht wird nur bei echter Layout-Aenderung, nicht bei jedem neuen
+    // Build-Datum. Siehe configuration_global.h.
+    if(!flashLayoutCompatible(meshcom_settings.node_fversion) || bClear)
     {
-        Serial.printf("[INIT]...FLASH cleared new version %i\n", FLASH_VERSION);
+        Serial.printf("[INIT]...FLASH cleared, Settings-Layout %i -> %i\n",
+                      meshcom_settings.node_fversion, FLASH_STRUCT_VERSION);
 
         flash_reset();
     }
     else
     {
-        Serial.printf("[INIT]...FLASH version %i\n", meshcom_settings.node_fversion);
+        Serial.printf("[INIT]...FLASH layout %i ok, build %i\n",
+                      meshcom_settings.node_fversion, FLASH_VERSION);
     }
 
     if(bClear)
         init_flash();
 
-    meshcom_settings.node_fversion = FLASH_VERSION;
+    meshcom_settings.node_fversion = FLASH_STRUCT_VERSION;
     meshcom_settings.node_mversion = MODUL_HARDWARE;
     meshcom_settings.node_cleanflash = 0;
     snprintf(meshcom_settings.node_fwversion, sizeof(meshcom_settings.node_fwversion), "%-4.4s%-1.1s", SOURCE_VERSION, SOURCE_VERSION_SUB);
@@ -572,6 +589,7 @@ void nrf52setup()
     bDEBUGCSV = meshcom_settings.node_sset4 & 0x0001;
     bDEBUGEN = meshcom_settings.node_sset4 & 0x0002;
     bDisplayLog = meshcom_settings.node_sset4 & 0x0004;
+    bTXCAPTURE = meshcom_settings.node_sset4 & 0x0008;
 
     bDisplayInfo = bLORADEBUG;
 
@@ -592,7 +610,7 @@ void nrf52setup()
 
     // if Node not set --> WifiAP Mode on
     /* NRF52 no WiFi
-    if(memcmp(meshcom_settings.node_call, "XX0XXX", 6) == 0 || meshcom_settings.node_call[0] == 0x00 || memcmp(meshcom_settings.node_call, "none", 4) == 0)
+    if(isNodeUnconfigured(meshcom_settings.node_call))
     {
         bWIFIAP = true;
         bWEBSERVER = true;
@@ -775,8 +793,7 @@ void nrf52setup()
 
     posinfo_fix = false;
     posinfo_satcount = 0;
-    posinfo_hdop = 0;
-    fposinfo_hdop = 0;
+    fposinfo_hdop = 0.0;
 
     // Try to initialize!
     #if defined(LPS33)
@@ -938,6 +955,17 @@ void nrf52setup()
     meshcom_settings.node_date_hundredths = 0;
 
     Serial.println("[INIT]...CLIENT STARTED");
+
+    // Reset-Ursache loggen (POWER->RESETREAS, vom Core beim Start gesichert):
+    // 0x1 Reset-Pin, 0x2 Watchdog, 0x4 Soft-Reset (SREQ — auch der Weg, den
+    // der SoftDevice-Fault-Handler nach einem App-Absturz nimmt), 0x8 Lockup.
+    // Unterscheidet nach einem unerwarteten Reboot sofort Absturz von
+    // Spannungsproblem — haette die N-22-Diagnose erheblich verkuerzt.
+    {
+        extern uint32_t readResetReason(void);
+        Serial.printf("[BOOT] RESETREAS=0x%08lX\n", (unsigned long)readResetReason());
+    }
+
 
     Radio.SetModem(MODEM_LORA);
 
@@ -1165,7 +1193,7 @@ void nrf52loop()
         // every 15 minutes
         if(btimeClient)
         {
-            if((updateTimeClient + 1000 * 60 * 15) < millis() || updateTimeClient == 0)
+            if((uint32_t)(millis() - updateTimeClient) >= (uint32_t)(1000 * 60 * 15) || updateTimeClient == 0)
             {
                 strTime = neth.udpUpdateTimeClient();
 
@@ -1229,7 +1257,7 @@ void nrf52loop()
     // Retransmission status must tick on ALL nodes (including gateways).
     // Without this, gateway text messages stay stuck at RING_STATUS_SENT
     // forever if no echo is received via LoRa (RING_ZOMBIE).
-    if ((retransmit_timer + (1000 * 2)) < millis())
+    if ((uint32_t)(millis() - retransmit_timer) >= (1000 * 2))
     {
         updateRetransmissionStatus();
 
@@ -1302,7 +1330,7 @@ void nrf52loop()
 
     if(iReceiveTimeOutTime > 0)
     {
-        if((iReceiveTimeOutTime + csma_timeout) < millis())
+        if((uint32_t)(millis() - iReceiveTimeOutTime) >= (uint32_t)csma_timeout)
         {
             if(bLORADEBUG)
                 Serial.printf("[MC-DBG] RX_TIMEOUT_FIRE ts=%lu wait=%lu delta=%lu\n",
@@ -1481,7 +1509,7 @@ void nrf52loop()
     if(bSOFTSERON)
     {
         // check every 5 seconds to ready next telemetry via serial interface
-        if ((softser_refresh_timer + 5000) < millis() && softserFunktion == 0)
+        if ((uint32_t)(millis() - softser_refresh_timer) >= 5000 && softserFunktion == 0)
         {
             if(lastSOFTSER_MINUTE != meshcom_settings.node_date_minute)
             {
@@ -1517,6 +1545,17 @@ void nrf52loop()
 
     btn.tick();
 
+    // BLE Queue: process data from the BLE task in Main Loop context (CONC-14)
+    {
+        BleQueueItem bleItem;
+        while (xQueueReceive(bleQueue, &bleItem, 0) == pdTRUE) {
+            readPhoneCommand(bleItem.data);
+        }
+    }
+
+    // Apply a settings write staged by settings_rx_callback(), if any (CONC-17)
+    applyPendingBleSettings();
+
     // check if message from phone to send
     if(hasMsgFromPhone)
     {
@@ -1531,7 +1570,7 @@ void nrf52loop()
 
     #if defined(ENABLE_MCP23017)
     // 5 sec
-    if ((mcp_refresh_timer + 5000) < millis())
+    if ((uint32_t)(millis() - mcp_refresh_timer) >= 5000)
     {
         // get i/o state
         if(loopMCP23017())
@@ -1566,7 +1605,7 @@ void nrf52loop()
         if(bGPSON)
         {
             // gps refresh every 10 sec
-            if ((gps_refresh_timer + (GPS_REFRESH_INTERVAL * 1000)) < millis())
+            if ((uint32_t)(millis() - gps_refresh_timer) >= (uint32_t)(GPS_REFRESH_INTERVAL * 1000))
             {
                 unsigned int igps = getGPS();
 
@@ -1591,7 +1630,7 @@ void nrf52loop()
         if(bGPSON)
         {
             // gps refresh every sec
-            if ((gps_refresh_timer + 1000) < millis())
+            if ((uint32_t)(millis() - gps_refresh_timer) >= 1000)
             {
                 unsigned int igps = POSINFO_INTERVAL;
 
@@ -1651,12 +1690,11 @@ void nrf52loop()
         if(bGPSON)
         {
             // check GPS ON and activ --> <gKeyNum == 2> the signal must be active
-            if ((gps_refresh_timer + (5 * (GPS_REFRESH_INTERVAL * 1000))) < millis())
+            if ((uint32_t)(millis() - gps_refresh_timer) >= (uint32_t)(5 * (GPS_REFRESH_INTERVAL * 1000)))
             {
                 posinfo_fix = false;
                 posinfo_satcount = 0;
-                posinfo_hdop = 0;
-                fposinfo_hdop = 0;
+                fposinfo_hdop = 0.0;
                 posinfo_interval = POSINFO_INTERVAL;
             }
         }
@@ -1691,7 +1729,7 @@ void nrf52loop()
         else
         {
             // wait after BLE Connect 3 sec.
-            if(millis() < config_to_phone_prepare_timer + 3000)
+            if((uint32_t)(millis() - config_to_phone_prepare_timer) < 3000)
                 iPhoneState = 0;
 
             if (iPhoneState > 3)   // only every 6 times of mainloop send to phone  RAK 2 x ESP
@@ -1722,7 +1760,7 @@ void nrf52loop()
         }
 
         // 5 minuten
-        if((config_to_phone_datetime_timer + (5 * 60 * 1000)) < millis())
+        if((uint32_t)(millis() - config_to_phone_datetime_timer) >= (5 * 60 * 1000))
         {
             bNTPDateTimeValid=false;
 
@@ -1735,7 +1773,7 @@ void nrf52loop()
     if(ncnt_hold != incnt)
     {
         // minimal alle 60 sec
-        if((posinfo_timer_min + 60000) < millis())
+        if((uint32_t)(millis() - posinfo_timer_min) >= 60000)
         {
             posinfo_shot = true;
             ncnt_hold = incnt;
@@ -1747,10 +1785,10 @@ void nrf52loop()
     //Serial.printf(" posinfo_timer:%ld posinfo_interval:%ld timer:%ld millis:%ld\n", posinfo_timer, posinfo_interval, (posinfo_timer + (posinfo_interval * 1000)), millis());
 
     // posinfo_interval in Seconds
-    if (((posinfo_timer + (posinfo_interval * 1000)) < millis()) || (millis() > 100000 && millis() < 130000 && bPosFirst) || posinfo_shot)
+    if (((uint32_t)(millis() - posinfo_timer) >= (uint32_t)(posinfo_interval * 1000)) || (millis() > 100000 && millis() < 130000 && bPosFirst) || posinfo_shot)
     {
         // minimal transmit time only max 30 sec
-        if((posinfo_timer_min + 30000) < millis())
+        if((uint32_t)(millis() - posinfo_timer_min) >= 30000)
         {
             if(bDisplayInfo)
             {
@@ -1826,7 +1864,7 @@ void nrf52loop()
     }
 
     // Trickle-HEY: adaptive interval (RFC 6206)
-    if (((heyinfo_timer + trickle_interval_ms) < millis()) || bHeyFirst)
+    if (((uint32_t)(millis() - heyinfo_timer) >= trickle_interval_ms) || bHeyFirst)
     {
         bHeyFirst = false;
 
@@ -1869,7 +1907,7 @@ void nrf52loop()
     if(iNextTelemetry < 5)
         akt_timer= 15 * 1000; // 15 Seconds PARM, UNIT, EQNS and 1st T-Message
 
-    if (((telemetry_timer + akt_timer) < millis()) || bHeyFirst)
+    if (((uint32_t)(millis() - telemetry_timer) >= (uint32_t)akt_timer) || bHeyFirst)
     {
         bHeyFirst = false;
         
@@ -1913,7 +1951,7 @@ void nrf52loop()
             meshcom_settings.node_last_upd_timer = neth.last_upd_timer;
             
             // check HB response (we also check successful sending KEEP. check if they work together!)
-            if((neth.last_upd_timer + (MAX_HB_RX_TIME * 1000)) < millis())
+            if((uint32_t)(millis() - neth.last_upd_timer) >= (uint32_t)(MAX_HB_RX_TIME * 1000))
             {
                 if(bDEBUG)
                     Serial.println("LOOP GATEWAY last_upd_timer actions");
@@ -1939,15 +1977,25 @@ void nrf52loop()
                     else
                     {
                         Serial.print(getTimeString());
-                        Serial.println(" [MAIN] initethDHCP");
+                        Serial.println(" [MAIN] resetDHCP (retry)");
 
-                        neth.initethDHCP();
+                        // N-20: initethDHCP() wuerde den W5100S bei jedem
+                        // Retry per initETH_HW() hardware-resetten — danach
+                        // braucht die PHY-Aushandlung mehrere Sekunden und der
+                        // Link-Check in startETH() sieht dauerhaft LinkOFF:
+                        // ein einmal gezogenes Kabel verbindet nie wieder (auf
+                        // Hardware beobachtet). Das volle HW-Init ist nur beim
+                        // Boot noetig (Setup); hier reicht resetDHCP() ohne
+                        // PHY-Reset — der Link-Zustand ist dann echt, und bei
+                        // LinkOFF bricht startETH() sofort ab statt 10 s zu
+                        // blocken.
+                        neth.resetDHCP();
                     }
                 }
             }
             
             // DHCP refresh
-            if ((dhcp_timer + (DHCP_REFRESH * 60000)) < millis())
+            if ((uint32_t)(millis() - dhcp_timer) >= (uint32_t)(DHCP_REFRESH * 60000))
             {
                 if(neth.hasETHHardware)
                 {
@@ -1972,7 +2020,7 @@ void nrf52loop()
     #if defined(SHTC3)
 
     // TEMP/HUM
-    if (((temphum_timer + TEMPHUM_INTERVAL) < millis()))
+    if (((uint32_t)(millis() - temphum_timer) >= TEMPHUM_INTERVAL))
     {
         if(shtc3_found)
             getTEMP();
@@ -1987,7 +2035,7 @@ void nrf52loop()
     if(bLPS33)
     {
         // DRUCK
-        if (((druck_timer + DRUCK_INTERVAL) < millis()))
+        if (((uint32_t)(millis() - druck_timer) >= DRUCK_INTERVAL))
         {
             getPRESSURE();
 
@@ -2007,7 +2055,7 @@ void nrf52loop()
 
     if(DisplayOffWait > 0)
     {
-        if (millis() > DisplayOffWait)
+        if ((int32_t)(millis() - DisplayOffWait) > 0)
         {
             DisplayOffWait = 0;
             if(bDisplayOff)
@@ -2026,15 +2074,47 @@ void nrf52loop()
     // rebootAuto
     if(rebootAuto > 0)
     {
-        if (millis() > rebootAuto)
+        if ((int32_t)(millis() - rebootAuto) > 0)
         {
             rebootAuto = 0;
 
             #ifdef ESP32
                 ESP.restart();
             #endif
-            
+
             #if defined NRF52_SERIES
+                // dfuAuto: --dfu will den UF2-Bootloader statt eines normalen
+                // Neustarts. Beides laeuft ueber denselben verzoegerten Pfad, damit
+                // die Quittung noch ueber BLE bzw. Seriell rausgeht, bevor der Reset
+                // kommt -- ein Reset direkt in commandAction() verschluckt sie.
+                //
+                // N-19: enterUf2Dfu() (reset_mcu() in cores/nRF5/wiring.c) haengt
+                // aus diesem Loop-Task -- auf Hardware reproduziert: --dfu liess das
+                // Board mit stehender CPU zurueck (USB-Deskriptor blieb App-PID, kein
+                // Reset). Derselbe reset_mcu()-Pfad funktioniert aus dem TinyUSB-Task
+                // (1200-Baud-Touch), und NVIC_SystemReset() funktioniert aus genau
+                // diesem Loop-Pfad (--reboot) -- verdaechtig ist sd_softdevice_disable()
+                // im Loop-Kontext. Deshalb hier ohne SD-Disable: GPREGRET per
+                // SoftDevice-SVC setzen (bei aktivem SoftDevice erlaubt, das BLE-Init
+                // laeuft auf nRF52 immer) und den bewaehrten NVIC_SystemReset()
+                // nehmen; der Bootloader liest GPREGRET beim Start und bleibt im
+                // UF2-Modus (USB-Laufwerk).
+                if(bEnterDfu)
+                {
+                    bEnterDfu = false;
+                    sd_power_gpregret_clr(0, 0xFF);
+                    sd_power_gpregret_set(0, 0x57);   // DFU_MAGIC_UF2_RESET (cores/nRF5/wiring.c)
+                    uint32_t gpr = 0;
+                    sd_power_gpregret_get(0, &gpr);
+                    printfdeb("...GPREGRET=0x%02lX (0x57 -> UF2-Bootloader)\n", (unsigned long)gpr);
+                    // Ack/Log noch ueber die CDC rausschreiben, bevor der Reset die
+                    // USB-Verbindung kappt. Ohne flush+Wartezeit kam das Board in
+                    // einem Hardware-Test trotz korrekt gesetztem GPREGRET als App
+                    // statt als Bootloader zurueck.
+                    Serial.flush();
+                    delay(300);
+                }
+
                 NVIC_SystemReset();     // resets the device
             #endif
         }
@@ -2045,7 +2125,7 @@ void nrf52loop()
     if(BattTimeWait == 0)
         BattTimeWait = millis() - 31000;
 
-    if ((BattTimeWait + 30000) < millis())
+    if ((uint32_t)(millis() - BattTimeWait) >= 30000)
     {
         if (tx_is_active == false && is_receiving == false)
         {
@@ -2063,7 +2143,7 @@ void nrf52loop()
         if (heapMonTimer == 0)
             heapMonTimer = millis();
 
-        if ((heapMonTimer + 60000) < millis())
+        if ((uint32_t)(millis() - heapMonTimer) >= 60000)
         {
             uint32_t freeHeap = nrf52_getFreeHeap();
 
@@ -2091,7 +2171,7 @@ void nrf52loop()
             onewireTimeWait = millis() - 10000;
 
 
-        if ((onewireTimeWait + 30000) < millis())  // 30 sec
+        if ((uint32_t)(millis() - onewireTimeWait) >= 30000)  // 30 sec
         {
             //if (tx_is_active == false && is_receiving == false)
             {
@@ -2119,7 +2199,7 @@ void nrf52loop()
     {
         unsigned long lreduction = 0;
 
-        if ((BMXTimeWait + 60000) < millis())   // 60 sec
+        if ((uint32_t)(millis() - BMXTimeWait) >= 60000)   // 60 sec
         {
             #if defined(ENABLE_BMX280)
                 if(loopBMX280())
@@ -2174,7 +2254,7 @@ void nrf52loop()
     #if defined(ENABLE_BMP390)
     if((bBMP3ON && bmp3_found))
     {
-        if ((BMP3TimeWait + 60000) < millis())   // 60 sec
+        if ((uint32_t)(millis() - BMP3TimeWait) >= 60000)   // 60 sec
         {
             if(loopBMP390())
             {
@@ -2198,7 +2278,7 @@ void nrf52loop()
         if(MCU811TimeWait == 0)
             MCU811TimeWait = millis() - 10000;
 
-        if ((MCU811TimeWait + 60000) < millis())   // 60 sec
+        if ((uint32_t)(millis() - MCU811TimeWait) >= 60000)   // 60 sec
         {
             // read MCU-811 Sensor
             if(loopMCU811())
@@ -2223,7 +2303,7 @@ void nrf52loop()
         if(INA226TimeWait == 0)
             INA226TimeWait = millis() - 10000;
 
-        if ((INA226TimeWait + 60000) < millis())   // 60 sec
+        if ((uint32_t)(millis() - INA226TimeWait) >= 60000)   // 60 sec
         {
             // read INA Sensor
             if(loopINA226())
@@ -2243,7 +2323,7 @@ void nrf52loop()
     #if defined(ENABLE_BMX680)
     if(bBME680ON && bme680_found)
     {
-        if ((bme680_timer + 60000) < millis() || delay_bme680 <= 0)
+        if ((uint32_t)(millis() - bme680_timer) >= 60000 || delay_bme680 <= 0)
         {
             if (delay_bme680 <= 0)
             {
@@ -2268,7 +2348,7 @@ void nrf52loop()
     // heartbeat
     if (bGATEWAY)
     {
-        if ((hb_timer + (HEARTBEAT_INTERVAL * 1000)) < millis())
+        if ((uint32_t)(millis() - hb_timer) >= (uint32_t)(HEARTBEAT_INTERVAL * 1000))
         {
             if(bDisplayCont)
             {
@@ -2293,7 +2373,7 @@ void nrf52loop()
 
     if(bWEBSERVER || bEXTUDP)
     {
-        if (web_timer == 0 || ((web_timer + (HEARTBEAT_INTERVAL * 1000 * 30)) < millis()))   // repeat 15 minutes
+        if (web_timer == 0 || ((uint32_t)(millis() - web_timer) >= (uint32_t)(HEARTBEAT_INTERVAL * 1000 * 30)))   // repeat 15 minutes
         {
             meshcom_settings.node_hasIPaddress = neth.hasIPaddress;
 
@@ -2307,7 +2387,15 @@ void nrf52loop()
                     startWIFI();
             #endif
 
-            if(bWEBSERVER)
+            // N-20-Falle: ohne initialisiertes Ethernet (Setup ueberspringt die
+            // HW-Initialisierung, wenn weder Gateway noch Webserver aktiv sind,
+            // oder es ist keine RAK13800 gesteckt) blockieren W5100S-Socket-Ops
+            // (UdpExtern.begin()/sendExternHeartbeat()) den Loop-Task unbegrenzt
+            // -- Node wirkt tot, Konsole ohne Echo, nur 1200-Baud-Touch hilft.
+            // Reproduziert 2026-08-22: --extudp on bei Gateway/Webserver off
+            // friert den Loop ab dem naechsten Durchlauf dauerhaft ein (auch
+            // nach jedem Reboot, da gespeichert). Deshalb: Start nur mit IP.
+            if(bWEBSERVER && neth.hasIPaddress)
             {
                 bSPI_ETH_Active = true;
                 startWebserver();
@@ -2315,7 +2403,7 @@ void nrf52loop()
                 if(bPendingRadioRx) { bPendingRadioRx = false; startRadioReceive(); }
             }
 
-            if(bEXTUDP)
+            if(bEXTUDP && neth.hasIPaddress)
             {
                 bSPI_ETH_Active = true;
                 startExternUDP();
@@ -2339,7 +2427,7 @@ void nrf52loop()
 
     if(meshcom_settings.node_pingtime > 29)
     {
-        if((resendPing + meshcom_settings.node_pingtime * 1000) < millis())
+        if((int32_t)(millis() - (resendPing + meshcom_settings.node_pingtime * 1000)) > 0)
         {
             resendPing = millis();
 
@@ -2478,14 +2566,14 @@ String ver = "";
 void WaitPause() {
   startTimeout = millis() + 1000;
   #if defined(USE_HELTEC_T114) or defined(BOARD_T_ECHO)
-  while ((!Serial1.available()) && (millis() < startTimeout)) { delay(5); } // auf Block von Zeichen warten
+  while ((!Serial1.available()) && ((int32_t)(millis() - startTimeout) < 0)) { delay(5); } // auf Block von Zeichen warten
   #else
-  while ((!Serial1.available()) && (millis() < startTimeout)) { delay(5); } // auf Block von Zeichen warten
+  while ((!Serial1.available()) && ((int32_t)(millis() - startTimeout) < 0)) { delay(5); } // auf Block von Zeichen warten
   #endif
   if(iGPSDEBUG >= 2)
     Serial.printf("[GPS ]...wait");
   startTimeout = millis() + 50;  // für Serial Sync Zeichenblock lesen und Pause von 50ms abwarten
-  while (millis() < startTimeout) {
+  while ((int32_t)(millis() - startTimeout) < 0) {
     #if defined(USE_HELTEC_T114) or defined(BOARD_T_ECHO)
     if (Serial1.available()) {
       Serial1.read();
@@ -2522,7 +2610,7 @@ void sendUBX_MON_VER() {  // Binäres Paket senden
   if(iGPSDEBUG >= 2)
     Serial.println("[GPS ]...Sende UBX_MON_VER");
 
-  for (int i = 0; i < sizeof(UBX_MON_VER_RAK); i++)
+  for (size_t i = 0; i < sizeof(UBX_MON_VER_RAK); i++)
   {
     Serial1.write(UBX_MON_VER_RAK[i]);
   }
@@ -2535,7 +2623,7 @@ void sendUBX_SET_GNSS() {  // Binäres Paket senden
   if(iGPSDEBUG >= 2)
     Serial.println("[GPS ]...Sende UBX_SET_GNSS");
 
-  for (int i = 0; i < sizeof(ubx_cfg_gnss); i++)
+  for (size_t i = 0; i < sizeof(ubx_cfg_gnss); i++)
   {
     Serial1.write(ubx_cfg_gnss[i]);
   }
@@ -2546,7 +2634,7 @@ void sendUBX_SET_GNSS() {  // Binäres Paket senden
 String readUBXbin() {
   startTimeout = millis() + 500;
   ver = "";
-    while (millis() < startTimeout) {
+    while ((int32_t)(millis() - startTimeout) < 0) {
     #if defined(USE_HELTEC_T114) or defined(BOARD_T_ECHO)
     while (Serial1.available()) {
       int c = Serial1.read();
@@ -2614,8 +2702,7 @@ unsigned int getGPS(void)
         Serial.printf("newData:%i SAT:%d Fix:%d UPD:%d VAL:%d HDOP:%i\n", newData, tinyGPSPlus.satellites.value(), tinyGPSPlus.sentencesWithFix(), tinyGPSPlus.location.isUpdated(), tinyGPSPlus.location.isValid(), tinyGPSPlus.hdop.value());
 
     posinfo_satcount = tinyGPSPlus.satellites.value();
-    posinfo_hdop = tinyGPSPlus.hdop.value();
-    fposinfo_hdop = tinyGPSPlus.hdop.value();;
+    fposinfo_hdop = tinyGPSPlus.hdop.value();
 
     bool has_gnss_location=false;
 
@@ -2677,16 +2764,34 @@ void checkSerialCommand(void)
         if(Serial.available() > 0)
         {
             char rd = (char)Serial.read();
-            printdeb(rd);   // echo to USB + net console via MSerial
-            strText[iTxtPos] = rd;
-            if(iTxtPos < (int)sizeof(strText) - 1)
+            // Drop NUL bytes: UART RX noise (e.g. unpowered USB-UART bridge on battery
+            // supply) delivers 0x00 which strlen() cannot see and wedges the parser
+            // (DRY-22 — ported from the ESP32 copy of this function).
+            if(rd != 0x00)
             {
-                iTxtPos++;
+                printdeb(rd);   // echo to USB + net console via MSerial
+                strText[iTxtPos] = rd;
+                if(iTxtPos < (int)sizeof(strText) - 1)
+                {
+                    iTxtPos++;
+                }
             }
         }
     }
 
     iTxtLen = strlen(strText);
+
+    // Self-healing: normally every stored byte is non-NUL, so strlen == iTxtPos.
+    // A stray NUL in the buffer breaks that invariant and would block command
+    // processing forever (early return below never reaches the memset). Discard.
+    // (DRY-22 — ported from the ESP32 copy of this function.)
+    if(iTxtLen != iTxtPos)
+    {
+        memset(strText, 0x00, sizeof(strText));
+        iTxtPos = 0;
+        return;
+    }
+
     if(iTxtLen == 0)
         return;
 
@@ -2702,7 +2807,11 @@ void checkSerialCommand(void)
             msg_text[sizeof(msg_text) - 1] = '\0';
 
             int inext=0;
-            char msg_buffer[600];
+            // N-22: 600 B vom knappen 4-KB-Loop-Task-Stack in BSS verlagert —
+            // checkSerialCommand() laeuft nur im Loop-Task, und der Pfad
+            // ueber sendMessage() -> sendExtern() lief mit Watermark 0
+            // (Details: STATUS-Box N-22 im Defektkatalog).
+            static char msg_buffer[600];
             iTxtLen = strlen(strText);
             for(int itx=0; itx<iTxtLen; itx++)
             {
@@ -2766,19 +2875,23 @@ void sendUDP()
 
         if(!neth.udp_is_busy)
         {
-            uint16_t msg_len = ringBufferUDPout[udpRead][0];
-            
-            
-            if(msg_len != 23)
-            {
-                //Serial.printf("UDP TX out:%i len:%i\n", udpRead, msg_len);
-                //DEBUG_MSG_VAL("UDP", udpRead, "UDP TX out:");
-                //printBuffer(ringBufferUDPout[udpRead] + 1, msg_len);
-            }
-            
+            // CONC-16 (nRF52-Leser): der Schreiber addUdpOutBuffer() laeuft
+            // ueber addNodeData() im Timer-Service-Task (OnRxDone, siehe
+            // C-01) und kann diesen Slot per Ring-voll-Eviction ueberholen,
+            // waehrend hier gesendet wird. Laenge und Payload deshalb als
+            // Snapshot unter kurzem Lock lesen und den Index-Advance unten
+            // gegen ein zwischenzeitliches Vorruecken sichern — gleiche
+            // Behandlung wie sendMeshComUDP() in udp_functions.cpp (ESP32).
+            // Snapshot bewusst groesser als der Quell-Slot und nullgefuellt
+            // (siehe dortige Begruendung).
+            static uint8_t udpSnapshot[UDP_TX_BUF_SIZE+64] = {0};
+            int mySlot = udpRead;
+            /*BISECT*/ memcpy(udpSnapshot, ringBufferUDPout[mySlot], sizeof(ringBufferUDPout[0]));
+
+            uint16_t msg_len = udpSnapshot[0];
 
             // send it over UDP
-            if (!neth.sendUDP(ringBufferUDPout[udpRead] + 1, msg_len))
+            if (!neth.sendUDP(udpSnapshot + 1, msg_len))
             {
                 Serial.printf("Sending UDP Packet failed <%i>!\n", msg_len);
 
@@ -2800,15 +2913,23 @@ void sendUDP()
             }
             else
             {
-                // UDP DATA Header 36 byte
-                memcpy(convBuffer, ringBufferUDPout[udpRead] + 1 + 36, msg_len);
+                // UDP DATA Header 36 byte. Der Slot enthaelt msg_len Bytes ab
+                // Offset 1 (Header + APRS-Frame); msg_len Bytes ab Offset 1+36
+                // zu kopieren las 36 Bytes ueber das Geschriebene hinaus — bei
+                // msg_len > 239 sogar ueber das Slot-Ende (Slot ist
+                // UDP_TX_BUF_SIZE+20). Wahre APRS-Laenge ist msg_len-36.
+                // (Nebenbefund aus dem CONC-16-Commit; auf nRF52-Gateways
+                // aktiv — Schreiber ist addUdpOutBuffer() via addNodeData(),
+                // auf Hardware am TX-UDP-Log verifiziert.)
+                uint16_t aprs_len = (msg_len > 36) ? (uint16_t)(msg_len - 36) : 0;
+                memcpy(convBuffer, udpSnapshot + 1 + 36, aprs_len);
 
-                if(convBuffer[0] == 0x3A || convBuffer[0] == 0x21 || convBuffer[0] == 0x40)
+                if(aprs_len > 0 && (convBuffer[0] == 0x3A || convBuffer[0] == 0x21 || convBuffer[0] == 0x40))
                 {
                     struct aprsMessage aprsmsg;
-                    
+
                     // print which message type we got
-                    decodeAPRS(convBuffer, msg_len, aprsmsg);
+                    decodeAPRS(convBuffer, aprs_len, aprsmsg);
 
                     // print aprs message
                     if(bDisplayVia)
@@ -2825,12 +2946,17 @@ void sendUDP()
                 }
             }
 
-            // zero out sent buffer
-            memset(ringBufferUDPout[udpRead], 0, UDP_TX_BUF_SIZE);
-
-            udpRead++;
-            if (udpRead >= MAX_RING_UDP) 
-                udpRead = 0;
+            // zero out sent buffer and advance the read pointer under the same
+            // lock as the writer's addRingPointer() (CONC-16). Guard against a
+            // writer having already force-advanced udpRead past us via the
+            // ring-full eviction path while we were sending.
+            /*BISECT*/ if (udpRead == mySlot)
+            {
+                memset(ringBufferUDPout[mySlot], 0, UDP_TX_BUF_SIZE);
+                udpRead++;
+                if (udpRead >= MAX_RING_UDP)
+                    udpRead = 0;
+            }
 
         }
         else

--- a/src/nrf52/nrf_eth.cpp
+++ b/src/nrf52/nrf_eth.cpp
@@ -9,6 +9,7 @@
 #include <debugconf.h>
 #include <loop_functions.h>
 #include <loop_functions_extern.h>
+#include "dedup_functions.h"
 #include <command_functions.h>
 #include <time_functions.h>
 #include <lora_setchip.h>
@@ -383,15 +384,23 @@ int NrfETH::getUDP()
                       print_buff[4]=(msg_counter >> 24) & 0xFF;
                       print_buff[5]=0x01;  // ACK
                       print_buff[6]=0x00;
-                      
-                      if(bDisplayInfo)
-                          printfdeb("\n[UDP-MSGID] ack_msg_id:%02X%02X%02X%02X\n", print_buff[1], print_buff[2], print_buff[3], print_buff[4]);
 
                       int iackcheck = checkOwnTx(msg_counter);
                       if(iackcheck >= 0)
                       {
                           own_msg_id[iackcheck][4] = 0x02;   // 02...ACK
+                          // DRY-21: von der ESP32-Kopie (udp_functions.cpp) abgedriftet —
+                          // dort bekommt die App fuer die eigene Nachricht den ACK-Level
+                          // 0x02 ("eigene Nachricht bestaetigt"); hier blieb es bei 0x01,
+                          // die App zeigte auf nRF52-Gateways nie den vollen ACK-Status.
+                          print_buff[5]=0x02;  // 02...ACK
                       }
+
+                      // DRY-21: Debug-Ausgabe wie in der ESP32-Kopie — nach dem
+                      // checkOwnTx (damit der ACK-Level stimmt) und mit der msg_id in
+                      // MSB-Reihenfolge statt verdreht.
+                      if(bDisplayInfo)
+                          printfdeb("[UDP-MSGID] ack_msg_id:%02X%02X%02X%02X ACK...%02X\n", print_buff[4], print_buff[3], print_buff[2], print_buff[1], print_buff[5]);
 
                       addBLEOutBuffer(print_buff, 7);
 
@@ -460,12 +469,7 @@ int NrfETH::getUDP()
                   // store last message to compare later on
                   insertOwnTx(aprsmsg.msg_id);
 
-                  ringBuffer[iWrite][0] = size;
-                  ringBuffer[iWrite][1] = RING_STATUS_DONE; // fire-and-forget, no retransmission for UDP relay
-                  memcpy(ringBuffer[iWrite] + 2, convBuffer, size);
-
-                  retryCount[iWrite] = 0;
-                  addTxRingEntry("udp_rx");
+                  addTxRingEntry(convBuffer, size, RING_STATUS_DONE, "udp_rx", 0); // fire-and-forget, no retransmission for UDP relay
 
                   addLoraRxBuffer(aprsmsg.msg_id, true);
 
@@ -512,9 +516,14 @@ int NrfETH::getUDP()
         {
           memcpy(config_buf, inc_udp_buffer + UDP_MSG_INDICATOR_LEN, packetSize - UDP_MSG_INDICATOR_LEN);
           // fill rest of buffer with 0
-          for (int i = 0; i < UDP_CONF_BUFF_SIZE; i++)
+          // N-03: Laufindex startet beim Ende der Nutzdaten und laeuft bis zum
+          // Pufferende. Vorher lief i von 0..UDP_CONF_BUFF_SIZE-1 und wurde
+          // zusaetzlich um die Paketlaenge versetzt -> Schreibzugriff bis
+          // config_buf[packetSize-4+254], bei packetSize=255 also 251 Bytes
+          // hinter dem 255-Byte-Stackpuffer.
+          for (int i = packetSize - UDP_MSG_INDICATOR_LEN; i < UDP_CONF_BUFF_SIZE; i++)
           {
-            config_buf[packetSize - UDP_MSG_INDICATOR_LEN + i] = 0x00;
+            config_buf[i] = 0x00;
           }
 
           // print the message
@@ -636,7 +645,7 @@ void NrfETH::fillUDP_RING_BUFFER(uint8_t buffer [UDP_TX_BUF_SIZE], uint16_t rx_b
   ringBuffer[iWrite][1] = 0xFF;
   memcpy(ringBuffer[iWrite] + 2, buffer, rx_buf_size);
 
-  DEBUG_MSG_VAL("RADIO", iWrite, "fill LORA Send:");
+  DEBUG_MSG_VAL("RADIO", (int)iWrite, "fill LORA Send:");
 
   iWrite++;
   if (iWrite >= MAX_RING) // if the buffer is full we start at index 0 -> take care of overwriting!
@@ -773,6 +782,34 @@ int NrfETH::startETH()
 
   printlndeb("\nInitialize Ethernet"); // start the Ethernet connection.
 
+  // N-20: Ohne Link ist Ethernet.begin() ein blockierender DHCP-Versuch gegen
+  // ein totes Kabel (10 s Timeout, in der W5100S-Bibliothek nichtdeterministisch
+  // auch deutlich laenger) — und dieser Pfad laeuft nicht nur im Setup, sondern
+  // periodisch aus nrf52loop() (initethDHCP/resetDHCP alle MAX_HB_RX_TIME).
+  // Der Link-Status ist ein einzelnes SPI-Registerlesen: erst pruefen und nur
+  // bei vorhandenem Link den blockierenden Teil starten.
+  //
+  // Wichtig: die Aufrufer laufen ueber initETH_HW(), das den W5100S per
+  // Hardware-Reset neu startet — die PHY-Aushandlung braucht danach 1–3 s.
+  // Deshalb begrenzt auf LinkON warten (max. 3 s in 100-ms-Schritten) statt
+  // sofort abzubrechen; ein Sofort-Check meldet nach dem Reset immer LinkOFF
+  // und wuerde die Wiederverbindung dauerhaft verhindern (auf Hardware
+  // beobachtet). Nur das explizite LinkOFF bricht ab — Unknown (z.B. Modul
+  // fehlt/liefert Muell) laeuft in den bestehenden Pfad samt
+  // EthernetNoHardware-Erkennung.
+  EthernetLinkStatus elink = Ethernet.linkStatus();
+  uint32_t linkWait = millis();
+  while (elink == LinkOFF && (uint32_t)(millis() - linkWait) < 3000)
+  {
+    delay(100);
+    elink = Ethernet.linkStatus();
+  }
+  if (elink == LinkOFF)
+  {
+    printlndeb("Ethernet link OFF - skip DHCP");
+    return 2;
+  }
+
   if (Ethernet.begin(macaddr, 10000UL) == 0)
   {
     printlndeb("Failed to configure Ethernet using FIX/DHCP");
@@ -791,8 +828,12 @@ int NrfETH::startETH()
     return 2;
   }
 
-  printdeb("Ethernet.localIP(): ");
-  printlndeb(Ethernet.localIP());
+  // IPAddress dezimal ausgeben — printlndeb(Ethernet.localIP()) lief ueber die
+  // implizite uint32_t-Konvertierung in die int-Ueberladung und druckte den
+  // Roh-Integer (z.B. "1145350336" statt "192.168.68.68").
+  printfdeb("Ethernet.localIP(): %i.%i.%i.%i\n",
+            Ethernet.localIP()[0], Ethernet.localIP()[1],
+            Ethernet.localIP()[2], Ethernet.localIP()[3]);
 
   if (Ethernet.localIP() != IPAddress(0, 0, 0, 0))
   {

--- a/src/phone_commands.cpp
+++ b/src/phone_commands.cpp
@@ -64,24 +64,58 @@ void sendToPhone()
 		// we need to insert the first byte text msg flag
 		uint8_t toPhoneBuff [MAX_MSG_LEN_PHONE] = {0};
 		// MAXIMUM PACKET Length over BLE is 245 (MTU=247 bytes), two get lost, otherwise we need to split it up!
-		uint8_t blelen = BLEtoPhoneBuff[toPhoneRead][0];
+		uint8_t blelen;
+		uint8_t statusByte;
+		// CONC-18: snapshot the slot's length/status/payload bytes under a
+		// single lock, instead of reading blelen here and memcpy-ing from the
+		// live ring further down. addBLEOutBuffer() (CONC-15) can wrap the
+		// ring and overwrite this exact slot from OnRxDone (nRF52 timer-
+		// service task, see C-01) in the gap between the two; a snapshot
+		// buffer makes what follows immune to that regardless of timing.
+		uint8_t ringSnapshot[MAX_MSG_LEN_PHONE];
+#if defined(NRF52_SERIES)
+		taskENTER_CRITICAL();
+#endif
+		blelen = BLEtoPhoneBuff[toPhoneRead][0];
+		statusByte = BLEtoPhoneBuff[toPhoneRead][1];
+		if(blelen > 0)
+			memcpy(ringSnapshot, BLEtoPhoneBuff[toPhoneRead]+1, blelen);
+		// Advance the read pointer here, still under the lock: the slot's
+		// content is already captured above, and this keeps the index update
+		// atomic with addBLEOutBuffer()'s writer-side overflow check
+		// (addRingPointer(), CONC-15) instead of racing it later.
+		toPhoneRead++;
+		if (toPhoneRead >= MAX_RING)
+			toPhoneRead = 0;
+#if defined(NRF52_SERIES)
+		taskEXIT_CRITICAL();
+#endif
+
+		// N-04 residual: the producer clamp only closed the RF-reachable path;
+		// blelen==0 here would underflow to 255 below and memcpy past the
+		// actual payload.
+		if(blelen == 0)
+		{
+			ble_busy_flag = false;
+			return;
+		}
 
 		//Mheard
-		if(BLEtoPhoneBuff[toPhoneRead][1] == 0x91)
+		if(statusByte == 0x91)
 		{
-			memcpy(toPhoneBuff, BLEtoPhoneBuff[toPhoneRead]+1, blelen-1);
+			memcpy(toPhoneBuff, ringSnapshot, blelen-1);
 		}
-		else 
+		else
 		// Data Message (JSON)
-		if(BLEtoPhoneBuff[toPhoneRead][1] == 0x44)
-		{		
-			memcpy(toPhoneBuff, BLEtoPhoneBuff[toPhoneRead]+1, blelen);	
-		} 
+		if(statusByte == 0x44)
+		{
+			memcpy(toPhoneBuff, ringSnapshot, blelen);
+		}
 		else
 		// Text Message and Position
 		{
 			toPhoneBuff[0] = 0x40;
-			memcpy(toPhoneBuff+1, BLEtoPhoneBuff[toPhoneRead]+1, blelen);
+			memcpy(toPhoneBuff+1, ringSnapshot, blelen);
 		}
 
 		// send to phone
@@ -94,10 +128,6 @@ void sendToPhone()
 		#else
 			g_ble_uart.write(toPhoneBuff, blelen + 2);
 		#endif
-
-		toPhoneRead++;
-		if (toPhoneRead >= MAX_RING)
-			toPhoneRead = 0;
 
 		if(bBLEDEBUG)
 		{
@@ -134,11 +164,21 @@ void sendComToPhone()
 		// MAXIMUM PACKET Length over BLE is 245 (MTU=247 bytes), two get lost, otherwise we need to split it up!
 		uint8_t blelen = BLEComToPhoneBuff[ComToPhoneRead][0];
 
+		// N-04 residual: see sendToPhone() above.
+		if(blelen == 0)
+		{
+			ComToPhoneRead++;
+			if (ComToPhoneRead >= MAX_RING)
+				ComToPhoneRead = 0;
+			ble_busy_flag = false;
+			return;
+		}
+
 		//Mheard
 		if(BLEComToPhoneBuff[ComToPhoneRead][1] == 0x91)
 		{
 			memcpy(ComToPhoneBuff, BLEComToPhoneBuff[ComToPhoneRead]+1, blelen-1);
-		} else 
+		} else
 		// Data Message (JSON)
 		if(BLEComToPhoneBuff[ComToPhoneRead][1] == 0x44)
 		{
@@ -523,6 +563,13 @@ void readPhoneCommand(uint8_t conf_data[MAX_MSG_LEN_PHONE])
 		case 0xA0: {
 			// length 1B - Msg ID 1B - Text
 
+			if(msg_len < 2)
+			{
+				// malformed frame: declared length too short for the length+type
+				// header, avoid unsigned underflow of txt_msg_len_phone below
+				break;
+			}
+
 			txt_msg_len_phone = msg_len - 2;	// now zero escape for lora TX
 
 			// Spin-wait removed: readPhoneCommand now runs in Main Loop,
@@ -550,17 +597,38 @@ void readPhoneCommand(uint8_t conf_data[MAX_MSG_LEN_PHONE])
 			// 1B - SSID Length - SSID - 1B PWD Length - PWD
 
 			DEBUG_MSG("BLE", "Wifi Setting from phone");
-			
+
 			uint8_t ssid_len = conf_data[2];
+
+			// bound ssid_len against the declared frame length before reading
+			// the pwd length byte that follows the SSID field
+			if((unsigned)(4 + ssid_len) > msg_len)
+			{
+				break;
+			}
+
 			uint8_t pwd_len = conf_data[ssid_len + 3];
+
+			// bound the full frame (len+type+ssid_len+SSID+pwd_len+PWD) against
+			// the declared frame length before touching the password bytes
+			if((unsigned)(4 + ssid_len + pwd_len) > msg_len)
+			{
+				break;
+			}
 
 			if(ssid_len > 0 && pwd_len > 0)
 			{
-				char ssid_arr [ssid_len +1] = {0};
-				char pwd_arr [pwd_len +1] = {0};
+				// fixed-size buffers matching meshcom_settings.node_ssid/node_pwd;
+				// avoids VLAs sized directly from untrusted input and clamps the
+				// copy length to the destination capacity
+				char ssid_arr [sizeof(meshcom_settings.node_ssid)] = {0};
+				char pwd_arr [sizeof(meshcom_settings.node_pwd)] = {0};
 
-				memcpy(ssid_arr, conf_data + 3, ssid_len);
-				memcpy(pwd_arr, conf_data + (4 + ssid_len), pwd_len);
+				uint8_t ssid_copy_len = (ssid_len < sizeof(ssid_arr) - 1) ? ssid_len : (sizeof(ssid_arr) - 1);
+				uint8_t pwd_copy_len = (pwd_len < sizeof(pwd_arr) - 1) ? pwd_len : (sizeof(pwd_arr) - 1);
+
+				memcpy(ssid_arr, conf_data + 3, ssid_copy_len);
+				memcpy(pwd_arr, conf_data + (4 + ssid_len), pwd_copy_len);
 
 				String s_SSID = ssid_arr;
 				String s_PWD = pwd_arr;

--- a/src/printfdeb_format.h
+++ b/src/printfdeb_format.h
@@ -1,0 +1,82 @@
+#pragma once
+
+// Format-Vorverarbeitung fuer printfdeb().
+//
+// printfdeb() schreibt den Format-String nicht direkt an vsnprintf, sondern
+// baut ihn vorher um: im Nicht-CSV-Modus verschwinden Semikolons (sie trennen
+// im CSV-Modus die Spalten), und '%%' muss diesen Durchlauf unbeschadet
+// ueberstehen.
+//
+// Warum als eigener Header und nicht inline in printfdeb_functions.cpp: nur so
+// laesst sich der Umbau ohne Arduino pruefen -- dieselbe Trennung wie bei
+// isPlausibleAckFrame() in ack_functions.h.
+
+#include <stddef.h>
+
+/**
+ * @brief Baut den Format-String fuer vsnprintf um.
+ *
+ * @param uformat  Eingabe-Format, NUL-terminiert.
+ * @param nformat  Ziel-Puffer, wird NUL-terminiert.
+ * @param nsize    Groesse von @p nformat in Byte.
+ * @param csv      true = CSV-Modus, Semikolons bleiben stehen.
+ * @return Anzahl geschriebener Zeichen ohne die abschliessende NUL.
+ */
+static inline size_t printfdebRewriteFormat(const char *uformat, char *nformat, size_t nsize, bool csv)
+{
+    size_t inn = 0;
+
+    if(nformat == NULL || nsize == 0)
+        return 0;
+
+    nformat[0] = 0x00;
+
+    if(uformat == NULL)
+        return 0;
+
+    for(size_t in = 0; uformat[in] != 0x00; in++)
+    {
+        // '%%' ist die Escape-Sequenz fuer ein einzelnes Prozentzeichen und muss
+        // als GENAU zwei Zeichen durchgereicht werden -- danach ist das zweite
+        // '%' mitverbraucht.
+        //
+        // Frueher schrieb dieser Zweig die zwei Zeichen und fiel anschliessend in
+        // die allgemeine Kopie, die dasselbe '%' noch einmal anhaengte; der
+        // naechste Schleifendurchlauf fuegte das zweite '%' erneut hinzu. Aus
+        // '%%' wurden '%%%%', und vsnprintf machte daraus zwei Prozentzeichen --
+        // sichtbar in jeder Zeile, die ein Prozentzeichen ausgab
+        // ("util=18%%", "BATT 100 %%").
+        if(uformat[in] == '%' && uformat[in+1] == '%')
+        {
+            if(inn + 2 < nsize)
+            {
+                nformat[inn++] = '%';
+                nformat[inn++] = '%';
+            }
+
+            in++;
+            continue;
+        }
+
+        if(!csv && uformat[in] == ';')
+        {
+            // in > 0 absichern: bei fuehrendem ';' laege uformat[in-1] vor dem
+            // Puffer.
+            if((in > 0 && uformat[in-1] == ' ') || uformat[in+1] == ' ')
+                continue;
+
+            if(inn + 1 < nsize)
+            {
+                nformat[inn++] = ' ';
+                continue;
+            }
+        }
+
+        if(inn + 1 < nsize)
+            nformat[inn++] = uformat[in];
+    }
+
+    nformat[inn] = 0x00;
+
+    return inn;
+}

--- a/src/printfdeb_functions.cpp
+++ b/src/printfdeb_functions.cpp
@@ -25,6 +25,7 @@
 static auto& s_hwSerial = Serial;
 
 #include "printfdeb_functions.h"
+#include "printfdeb_format.h"
 
 #include "loop_functions.h"
 #include "loop_functions_extern.h"
@@ -36,56 +37,51 @@ static auto& s_hwSerial = Serial;
 #include "net_console.h"
 #endif
 
+#if defined(NRF52_SERIES)
+// N-21: Bei totem Bulk-IN-Endpoint (DTR bleibt gesetzt, EP0 lebt) blockiert
+// Adafruit_USBD_CDC::write() endlos (while(remain && connected) { yield(); }) —
+// das friert den Task ein, der zuerst druckt (Loop-Task oder ueber OnRxDone
+// sogar den Timer-Task). Deshalb: kurz auf FIFO-Platz warten (max. 20 ms),
+// dann verwerfen statt blockieren. g_cdcTxDropped zaehlt verworfene Bytes
+// fuer die [CDC]-Telemetrie in nrf52_main.cpp.
+volatile unsigned long g_cdcTxDropped = 0;
+
+// true = Platz vorhanden, Ausgabe darf raus; false = verworfen (gezaehlt).
+static bool cdcReady(size_t need)
+{
+    if (!(bool)Serial)
+        return true;   // nicht verbunden: write() verwirft selbst, blockiert nie
+    if (need > 128) need = 128;
+    uint32_t t0 = millis();
+    while ((size_t)Serial.availableForWrite() < need)
+    {
+        if (millis() - t0 > 20)
+        {
+            g_cdcTxDropped += need;
+            return false;
+        }
+        yield();
+    }
+    return true;
+}
+#else
+static inline bool cdcReady(size_t) { return true; }
+#endif
+
+unsigned long printfdebDroppedBytes(void)
+{
+#if defined(NRF52_SERIES)
+    return g_cdcTxDropped;
+#else
+    return 0;   // kein verwerfender Pfad -- cdcReady() ist hier immer true
+#endif
+}
+
 int printfdeb(const char *uformat, ...)
 {
     char nformat[300];
-    memset(nformat,0x00, sizeof(nformat));
 
-    int inn=0;
-
-    for(int in=0; in<(int)strlen(uformat); in++)
-    {
-        if(uformat[in] == '%')
-        {
-            if(uformat[in+1] == '%')
-            {
-                if(inn < (int)sizeof(nformat)-3)
-                {
-                    nformat[inn] = '%';
-                    inn++;
-                    nformat[inn] = '%';
-                    inn++;
-                }
-            }
-        }
-
-        if(!bDEBUGCSV)
-        {
-            if(uformat[in] == ';')
-            {
-                if(uformat[in-1] == ' ' || uformat[in+1] == ' ')
-                {
-                    continue;
-                }
-                else
-                {
-                    if(inn < (int)sizeof(nformat)-2)
-                    {
-                        nformat[inn] = ' ';
-                        inn++;
-                        continue;
-                    }
-                }
-            }
-        }
-        
-
-        if(inn < (int)sizeof(nformat)-2)
-        {
-            nformat[inn] = uformat[in];
-            inn++;
-        }
-    }
+    printfdebRewriteFormat(uformat, nformat, sizeof(nformat), bDEBUGCSV);
 
     char loc_buf[600];
     char * temp = loc_buf;
@@ -114,8 +110,46 @@ int printfdeb(const char *uformat, ...)
         for (int i = 0; temp[i] != '\0'; i++) { if (temp[i] == '.') { temp[i] = ','; } }
 
     bDEBUGLNG = false; // wieder deaktivieren
-    
-    Serial.printf(temp);
+
+    // SEC-02: temp enthaelt bereits substituierten Text — u.a. ueber Funk empfangene
+    // Nutzdaten, die per %s eingesetzt wurden. Diese duerfen NICHT erneut als
+    // Format-String geparst werden (%s/%n ohne passende varargs -> Stack-Lesezugriffe
+    // bzw. Schreibzugriff).
+    //
+    // Serial.printf("%s", temp) waere dagegen ebenfalls sicher, formatiert den fertigen
+    // String aber ein zweites Mal: Print::printf nutzt intern nur 64 Byte Stack und
+    // malloc()t fuer alles Darueber — also bei fast jeder Log-Zeile. Dieser Heap-Churn
+    // liess NimBLE (MSYS1_BLOCK_COUNT=4) keine mbufs mehr fuer den Verbindungsaufbau
+    // finden: der Node beantwortete CONNECT_IND nicht mehr, der Central brach den
+    // Verbindungsaufbau mit 0x3e ab. Direkt schreiben ist sicher UND allokationsfrei.
+#if defined(NRF52_SERIES)
+    // N-21: nie mehr an write() uebergeben, als der TX-FIFO frei hat — sonst
+    // blockiert der Aufruf bei totem Endpoint endlos (s. cdcReady()-Kommentar).
+    {
+        size_t off = 0;
+        uint32_t tw0 = millis();
+        while (off < (size_t)len && (bool)Serial)
+        {
+            size_t canw = (size_t)Serial.availableForWrite();
+            if (canw == 0)
+            {
+                if (millis() - tw0 > 20)
+                {
+                    g_cdcTxDropped += (unsigned long)((size_t)len - off);
+                    break;
+                }
+                yield();
+                continue;
+            }
+            size_t n = (size_t)len - off;
+            if (n > canw) n = canw;
+            Serial.write((const uint8_t*)temp + off, n);
+            off += n;
+        }
+    }
+#else
+    Serial.write((const uint8_t*)temp, (size_t)len);
+#endif
 
     if(temp != loc_buf){
         free(temp);
@@ -125,66 +159,77 @@ int printfdeb(const char *uformat, ...)
 
 int printlndeb(const char *buff)
 {
+    if (!cdcReady(strlen(buff) + 2)) return 0;
     int len = Serial.println(buff);
     return len;
 }
 
 int printdeb(const char *buff)
 {
+    if (!cdcReady(strlen(buff))) return 0;
     int len = Serial.print(buff);
     return len;
 }
 
 int printlndeb(int iVar)
 {
+    if (!cdcReady(14)) return 0;
     int len = Serial.println(iVar);
     return len;
 }
 
 int printdeb(int iVar)
 {
+    if (!cdcReady(12)) return 0;
     int len = Serial.print(iVar);
     return len;
 }
 
 int printfdeb(unsigned int iVar)
 {
+    if (!cdcReady(12)) return 0;
     int len = Serial.print(iVar);
     return len;
 }
 
 int printfdeb(short iVar)
 {
+    if (!cdcReady(8)) return 0;
     int len = Serial.print(iVar);
     return len;
 }
 
 int printdeb(float fVar)
 {
+    if (!cdcReady(16)) return 0;
     int len = Serial.print(fVar);
     return len;
 }
 
 int printdeb(char c)
 {
+    if (!cdcReady(1)) return 0;
     int len = Serial.print(c);
     return len;
 }
 
 int printdeb(unsigned char c)
 {
+    if (!cdcReady(4)) return 0;
     int len = Serial.print(c);
     return len;
 }
 
 int printlndeb(String str)
 {
+    if (!cdcReady(str.length() + 2)) return 0;
     int len = Serial.println(str);
     return len;
 }
 
 int printdeb(String str)
 {
+    if (!cdcReady(str.length())) return 0;
     int len = Serial.print(str);
     return len;
 }

--- a/src/printfdeb_functions.h
+++ b/src/printfdeb_functions.h
@@ -18,3 +18,17 @@ int printlndeb(String str);
 int printdeb(String str);
 
 int printfdeb(const char *format, ...);
+
+/**
+ * @brief Bytes, die printfdeb() seit dem Start verworfen hat (kumulativ).
+ *
+ * Auf nRF52 verwirft printfdeb() Ausgabe, wenn der USB-CDC-Sendepuffer voll
+ * bleibt (N-21: sonst blockiert write() bei totem Endpoint endlos). Auf allen
+ * anderen Plattformen gibt es diesen Pfad nicht, der Zaehler ist dort 0.
+ *
+ * Wichtig fuer den Rohframe-Mitschnitt: eine Logdatei wird genau dann
+ * loechrig, wenn der Kanal ausgelastet ist -- also in den Lagen, um
+ * derentwillen man mitschneidet. Ohne diese Zahl behauptet ein Mitschnitt
+ * Vollstaendigkeit, die er nicht hat.
+ */
+unsigned long printfdebDroppedBytes(void);

--- a/src/ring_index.h
+++ b/src/ring_index.h
@@ -1,0 +1,34 @@
+#pragma once
+
+// Ring-Indextyp, aus loop_functions_extern.h herausgeloest (reine
+// Verschiebung, Definition unveraendert). Eigener Header, damit einzelne
+// Ringe in eigene Uebersetzungseinheiten wandern koennen, ohne den kompletten
+// Loop-Header mitzuziehen -- Voraussetzung dafuer, dass sie nativ testbar
+// sind (siehe dedup_functions.h, txring_functions.h).
+
+#include <stdint.h>
+#include <atomic>
+
+// Ring-Indizes: gleiche Begruendung wie bei is_receiving_t/ch_util_ulong_t.
+// Auf ESP32 laufen alle Schreiber und Leser dieser Indizes in loopTask --
+// lora_functions ueber OnRxDone()/checkRX() aus esp32loop(), udp_functions und
+// web_functions gepollt aus derselben Schleife. Die beiden ESP32-ISRs
+// (setFlagReceive/setFlagSent) fassen ausschliesslich receiveFlag/transmittedFlag
+// an, keinen Ring-Index. Damit ist hier nichts zu synchronisieren.
+// nRF52 erreicht OnRxDone ueber die FreeRTOS-Timer-Task (Prio 2) -- echte
+// Nebenlaeufigkeit, dort bleibt std::atomic. Fortsetzung von N-13.
+#if defined(ESP32)
+struct ring_index_t {
+    uint8_t v = 0;
+    ring_index_t() = default;
+    ring_index_t(uint8_t nv) : v(nv) {}
+    ring_index_t &operator=(uint8_t nv) { v = nv; return *this; }
+    operator uint8_t() const { return v; }
+    ring_index_t &operator++() { ++v; return *this; }
+    ring_index_t operator++(int) { ring_index_t t = *this; ++v; return t; }
+    uint8_t load() const { return v; }
+    void store(uint8_t nv) { v = nv; }
+};
+#else
+using ring_index_t = std::atomic<uint8_t>;
+#endif

--- a/src/rtc_functions.cpp
+++ b/src/rtc_functions.cpp
@@ -25,7 +25,7 @@ DateTime now;
 
 bool setupRTC()
 {  
-    #if defined(BOARD_TBEAM_V3) || (BOARD_E22_S3)
+    #if defined(BOARD_TBEAM_V3) || defined(BOARD_E22_S3)
         Wire.end();
         Wire.begin(I2C_SDA, I2C_SCL);
     #endif
@@ -68,7 +68,7 @@ bool loopRTC()
     if(!bRTCON)
         return false;
 
-    #if defined(BOARD_TBEAM_V3) || (BOARD_E22_S3)
+    #if defined(BOARD_TBEAM_V3) || defined(BOARD_E22_S3)
         Wire.end();
         Wire.begin(I2C_SDA, I2C_SCL);
     #endif
@@ -80,7 +80,7 @@ bool loopRTC()
 
 void setRTCNow(String strDate)
 {
-    #if defined(BOARD_TBEAM_V3) || (BOARD_E22_S3)
+    #if defined(BOARD_TBEAM_V3) || defined(BOARD_E22_S3)
         Wire.end();
         Wire.begin(I2C_SDA, I2C_SCL);
     #endif
@@ -96,7 +96,7 @@ void setRTCNow(String strDate)
 
 void setRTCNow(int year, int month, int day, int hour, int minute, int second)
 {
-    #if defined(BOARD_TBEAM_V3) || (BOARD_E22_S3)
+    #if defined(BOARD_TBEAM_V3) || defined(BOARD_E22_S3)
         Wire.end();
         Wire.begin(I2C_SDA, I2C_SCL);
     #endif

--- a/src/safeboot/main.cpp
+++ b/src/safeboot/main.cpp
@@ -13,6 +13,7 @@
 #include <esp_partition.h>
  
 #include <Preferences.h>
+#include "../configuration_global.h"
 #include "../esp32/esp32_flash.h"
  
 #define TAG "SafeBoot"
@@ -55,7 +56,7 @@ void wifiConnect() {
   
 
   // Set the hostname from the callsign. If the callsign is not set, use the default hostname
-  if (!((meshcom_settings.node_call[0] == 0x00) || (memcmp(meshcom_settings.node_call, "none", 4) == 0) || (memcmp(meshcom_settings.node_call, "XX0XXX", 6) == 0) || (memcmp(meshcom_settings.node_call, "XX0XXX-00", 9) == 0)))
+  if (!isNodeUnconfigured(meshcom_settings.node_call))
   {
     hostname = meshcom_settings.node_call;
   }

--- a/src/sht21.cpp
+++ b/src/sht21.cpp
@@ -38,7 +38,7 @@ void setupSHT21(bool bInit)
     if(!bSHT21ON)
 		return;
 		
-    #if defined(BOARD_TBEAM_V3) || (BOARD_E22_S3)
+    #if MC_I2C_NEEDS_BUS_RESET
         Wire.end();
         Wire.begin(I2C_SDA, I2C_SCL);
     #endif
@@ -65,7 +65,7 @@ bool loopSHT21()
 	if(!sht21_found)
 		return false;
 
-    #if defined(BOARD_TBEAM_V3) || (BOARD_E22_S3)
+    #if MC_I2C_NEEDS_BUS_RESET
         Wire.end();
         Wire.begin(I2C_SDA, I2C_SCL);
     #endif

--- a/src/t-deck-pro/peri_gps.cpp
+++ b/src/t-deck-pro/peri_gps.cpp
@@ -283,7 +283,7 @@ bool setupGPS()
         while (SerialGPS.available()) {
             Serial.print(".");
             SerialGPS.readString();
-            if (millis() > startTimeout) {
+            if ((int32_t)(millis() - startTimeout) > 0) {
                 Serial.println("Wait L76K stop NMEA timeout!");
                 return false;
             }
@@ -296,7 +296,7 @@ bool setupGPS()
         startTimeout = millis() + 500;
         String ver = "";
         while (!SerialGPS.available()) {
-            if (millis() > startTimeout) {
+            if ((int32_t)(millis() - startTimeout) > 0) {
                 Serial.println("Get L76K timeout!");
                 return false;
             }

--- a/src/t-deck-pro/tdeck_pro.cpp
+++ b/src/t-deck-pro/tdeck_pro.cpp
@@ -649,7 +649,7 @@ unsigned int tdeck_get_gps()
         posinfo_fix = false;
 
         posinfo_satcount = 0;
-        posinfo_hdop = 0;
+        fposinfo_hdop = 0.0;
         posinfo_direction = 0;
         posinfo_distance = 0;
         posinfo_age = 0;
@@ -695,7 +695,7 @@ unsigned int tdeck_get_gps()
             meshcom_settings.node_alt = (int)(alt + 0.5);
 
         posinfo_satcount = vsat;
-        posinfo_hdop = hdop;
+        fposinfo_hdop = hdop;
         
 
         posinfo_age = 0;

--- a/src/t-deck-pro/ui_deckpro.cpp
+++ b/src/t-deck-pro/ui_deckpro.cpp
@@ -2132,7 +2132,7 @@ void ui_track_disp(bool bSend)
             {
                 snprintf(ctrack, sizeof(ctrack), "TRACK:on %s %i\nDATE :%s\nTIME :%s\nLAT  :%08.4lf %c\nLON  :%08.4lf %c\nDIST :%.0lf m\nDIR  :old %.0lf\nDIR  :new %.0lf\nRATE :%4lisec\nNEXT :%isec",
                 (posinfo_fix ? "fix" : "nofix"), 
-                posinfo_hdop, 
+                (int)fposinfo_hdop, 
                 cDatum, 
                 cZeit, 
                 meshcom_settings.node_lat, 
@@ -2149,7 +2149,7 @@ void ui_track_disp(bool bSend)
             {
                 snprintf(ctrack, sizeof(ctrack), "GPS  :on %s %i\nDATE :%s\nTIME :%s\nLAT  :%08.4lf %c\nLON  :%08.4lf %c\nALT  :%i\nSAT  :%u\nDIR  :%.0lf\nRATE :%4lisec\nNEXT :%isec",
                 (posinfo_fix ? "fix" : "nofix"), 
-                posinfo_hdop, 
+                (int)fposinfo_hdop, 
                 cDatum, 
                 cZeit, 
                 meshcom_settings.node_lat, 
@@ -2187,7 +2187,7 @@ void ui_track_disp(bool bSend)
         snprintf(ctrack, sizeof(ctrack), "%s %s %i\n%s\nDATE :%s\nTIME :%s\nLAT  :%08.4lf %c\nLON  :%08.4lf %c\nALT  :%i m\nAGE  :%u\nSAT  :%u",
             ctypegps,
             (posinfo_fix ? "fix" : "nofix"),
-            posinfo_hdop,
+            (int)fposinfo_hdop,
             ctypetrack,
             cDatum,
             cZeit,

--- a/src/t-deck/lv_obj_functions.cpp
+++ b/src/t-deck/lv_obj_functions.cpp
@@ -4081,7 +4081,7 @@ void tdeck_refresh_track_view()
             {
                 snprintf(ctrack, sizeof(ctrack), "TRACK:on %s %i\nDATE :%s\nTIME :%s\nLAT  :%08.4lf %c\nLON  :%08.4lf %c\nDIST :%.0lf m\nRATE :%4li %4isec\nDIR  :old %.0lf\nDIR  :new %.0lf",
                 (posinfo_fix ? "fix" : "nofix"), 
-                posinfo_hdop, 
+                (int)fposinfo_hdop, 
                 cDatum, 
                 cZeit, 
                 meshcom_settings.node_lat, 
@@ -4098,7 +4098,7 @@ void tdeck_refresh_track_view()
             {
                 snprintf(ctrack, sizeof(ctrack), "GPS  :on %s %i\nDATE :%s\nTIME :%s\nLAT  :%08.4lf %c\nLON  :%08.4lf %c\nALT  :%i\nRATE :%4li %isec\nSAT  :%u\nDIR  :%.0lf",
                 (posinfo_fix ? "fix" : "nofix"), 
-                posinfo_hdop, 
+                (int)fposinfo_hdop, 
                 cDatum, 
                 cZeit, 
                 meshcom_settings.node_lat, 
@@ -4136,7 +4136,7 @@ void tdeck_refresh_track_view()
         snprintf(ctrack, sizeof(ctrack), "%s %s %i\n%s\nDATE :%s\nTIME :%s\nLAT  :%08.4lf %c\nLON  :%08.4lf %c\nALT  :%i m\nAGE  :%u\nSAT  :%u",
             ctypegps,
             (posinfo_fix ? "fix" : "nofix"),
-            posinfo_hdop,
+            (int)fposinfo_hdop,
             ctypetrack,
             cDatum,
             cZeit,

--- a/src/t-deck/tdeck_main.cpp
+++ b/src/t-deck/tdeck_main.cpp
@@ -260,7 +260,7 @@ void addMessage(const char *str)
 {
     tdeck_add_system_message(str);
     uint32_t run = millis() + 2000;
-    while (millis() < run)
+    while ((int32_t)(millis() - run) < 0)
     {
         lv_task_handler();
         delay(5);

--- a/src/t5-epaper/peri_gps.cpp
+++ b/src/t5-epaper/peri_gps.cpp
@@ -246,7 +246,7 @@ bool setupGPS()
         while (SerialGPS.available()) {
             Serial.print(".");
             SerialGPS.readString();
-            if (millis() > startTimeout) {
+            if ((int32_t)(millis() - startTimeout) > 0) {
                 Serial.println("Wait L76K stop NMEA timeout!");
                 return false;
             }
@@ -259,7 +259,7 @@ bool setupGPS()
         startTimeout = millis() + 500;
         String ver = "";
         while (!SerialGPS.available()) {
-            if (millis() > startTimeout) {
+            if ((int32_t)(millis() - startTimeout) > 0) {
                 Serial.println("Get L76K timeout!");
                 return false;
             }

--- a/src/txring_functions.cpp
+++ b/src/txring_functions.cpp
@@ -1,0 +1,380 @@
+#include "txring_functions.h"
+
+// Spitze Klammern (nicht Anfuehrungszeichen) fuer printfdeb_functions.h:
+// Anfuehrungszeichen-Includes suchen zuerst im Verzeichnis der einschliessenden
+// Datei und umgehen damit die -I-Reihenfolge aus platformio.ini. Die
+// Spitzklammer-Form haelt sich daran, so wie es
+// <configuration.h>/<debugconf.h>/<nrf52/WisBlock-API.h> in loop_functions.h
+// bereits vormachen.
+#include <printfdeb_functions.h>
+
+#include <loop_functions.h>
+#include <loop_functions_extern.h>
+#include <aprs_functions.h>
+
+//////////////////////////////////////////////////////////////////////////
+// LoRa TX functions
+
+/**
+ * Determine message priority from ring buffer slot content.
+ * Ring buffer layout: [0]=len, [1]=status, [2]=payload_type, [3-6]=msg_id, [7]=flags, [8+]=path
+ * Encoded path format: "SOURCE>DEST:" starting at offset 8 (relative to ringBuffer[slot]+2)
+ * i.e. ringBuffer[slot][8] is the first char of the source callsign.
+ */
+uint8_t getMessagePriority(int slot)
+{
+    uint8_t msg_type = ringBuffer[slot][2];
+
+    if(msg_type == MSG_TYPE_ACK)
+        return MSG_PRIO_CRITICAL;
+
+    if(msg_type == MSG_TYPE_POSITION)
+        return MSG_PRIO_LOW;
+
+    if(msg_type == MSG_TYPE_HEY)
+        return MSG_PRIO_BACKGROUND;
+
+    if(msg_type == MSG_TYPE_TEXT)
+    {
+        // Relay detection: OnRxDone sets RING_STATUS_DONE for relayed packets
+        if(ringBuffer[slot][1] == RING_STATUS_DONE)
+            return MSG_PRIO_NORMAL; // Relay
+
+        // User-originated text: parse destination from encoded APRS path
+        // Path starts at ringBuffer[slot][8] (offset 6 in encoded data = after type+id+flags)
+        // Format: "SOURCE>DEST:" — find '>' then read until payload_type char
+        int len = ringBuffer[slot][0];
+        int path_start = 8; // slot[2] + 6 bytes header = slot[8]
+        int dest_start = -1;
+        int dest_end = -1;
+
+        for(int i = path_start; i < len + 2 && i < (UDP_TX_BUF_SIZE + 4); i++)
+        {
+            if(ringBuffer[slot][i] == '>' && dest_start < 0)
+            {
+                dest_start = i + 1;
+            }
+            else if(dest_start >= 0 && (ringBuffer[slot][i] == ':' || ringBuffer[slot][i] == MSG_TYPE_TEXT))
+            {
+                dest_end = i;
+                break;
+            }
+        }
+
+        if(dest_start >= 0 && dest_end > dest_start)
+        {
+            char dest[12] = {0};
+            int dlen = dest_end - dest_start;
+            if(dlen > 10) dlen = 10;
+            memcpy(dest, &ringBuffer[slot][dest_start], dlen);
+            dest[dlen] = 0;
+
+            if(strcmp(dest, "*") == 0)
+                return MSG_PRIO_HIGH; // Broadcast
+
+            if(CheckGroup(String(dest)) != 0)
+                return MSG_PRIO_HIGH; // Group message
+
+            return MSG_PRIO_CRITICAL; // Personal DM
+        }
+
+        // Fallback: treat as high priority if parsing fails
+        return MSG_PRIO_HIGH;
+    }
+
+    // Unknown type: normal priority
+    return MSG_PRIO_NORMAL;
+}
+
+/**
+ * Find the next slot to transmit from the ring buffer, based on priority.
+ * Scans all occupied slots between iRead and iWrite.
+ * Returns slot index, or -1 if empty.
+ * Within same priority, oldest entry (closest to iRead) wins (FIFO).
+ */
+int getNextTxSlot(void)
+{
+    if(iWrite == iRead)
+        return -1;
+
+    int best_slot = -1;
+    uint8_t best_prio = 255;
+
+    int pos = iRead;
+    while(pos != iWrite)
+    {
+#if defined(EXTERNAL_RADIO)
+        // owned-slot status invariant: a slot owned by an in-flight external TX must never be
+        // reselected. RING_STATUS_EXT_PENDING is neither READY nor DONE, so the
+        // test below already skips it; this explicit skip states the intent.
+        if(ringBuffer[pos][1] == RING_STATUS_EXT_PENDING)
+        {
+            pos++;
+            if(pos >= MAX_RING)
+                pos = 0;
+            continue;
+        }
+#endif
+        // Only consider slots with data that are ready to send (READY or DONE/fire-and-forget).
+        // Skip slots with status SENT..threshold (awaiting retransmission timer).
+        if(ringBuffer[pos][0] > 0 &&
+           (ringBuffer[pos][1] == RING_STATUS_READY || ringBuffer[pos][1] == RING_STATUS_DONE))
+        {
+            uint8_t prio = ringPriority[pos];
+            if(prio < best_prio)
+            {
+                best_prio = prio;
+                best_slot = pos;
+            }
+            // Same prio: keep first found (= oldest = FIFO)
+        }
+
+        pos++;
+        if(pos >= MAX_RING)
+            pos = 0;
+    }
+
+    return best_slot;
+}
+
+/**
+ * Advance iRead past any empty (already-transmitted) slots at the front.
+ *
+ * Abweichung vom reinen Verschieben: im Original war diese Funktion `static`
+ * (TU-lokal). doTX() in lora_functions.cpp ruft sie jedoch ebenfalls auf
+ * (dortiger Aufruf blieb beim Extrahieren an Ort und Stelle stehen) -- eine
+ * TU-lokale Funktion kann von dort nicht mehr erreicht werden. Daher hier
+ * externe Sichtbarkeit (Deklaration in txring_functions.h), Koerper sonst
+ * unveraendert.
+ */
+void advanceIReadPastEmpty(void)
+{
+    int localRead = iRead;
+    int localWrite = iWrite;
+    while(localRead != localWrite && ringBuffer[localRead][0] == 0)
+    {
+        localRead++;
+        if(localRead >= MAX_RING)
+            localRead = 0;
+    }
+    iRead = localRead;
+}
+
+/**
+ * TX-Ring: kompletter Enqueue-Vorgang (Slot-Wahl, Payload-Kopie, Prio/Overflow,
+ * iWrite/iRead-Fortschritt) in EINER Funktion unter EINEM Lock.
+ * N-14: bisher schrieb der Aufrufer selbst nach ringBuffer[iWrite][...] und
+ * rief danach diese Funktion auf, die iWrite erneut gelesen hat — zwei
+ * gleichzeitige Schreiber (Main-Loop und, auf nRF52, der FreeRTOS-Timer-
+ * Service-Task via OnRxDone) konnten sich denselben Slot teilen und ein
+ * zusammengewuerfelter Frame ging auf Sendung. Jetzt liefert der Aufrufer nur
+ * noch den fertigen Frame; Slot-Wahl und -Schreiben passieren atomar hier.
+ *
+ * Lock nur auf nRF52 (taskENTER_CRITICAL/EXIT_CRITICAL, siehe
+ * phone_commands.cpp:76-92): auf ESP32 laeuft dieser Pfad ausschliesslich im
+ * Main-Loop-Kontext (kein zweiter Schreiber, C-01) und portENTER_CRITICAL
+ * braucht ohnehin einen portMUX_TYPE, den es hier nicht gibt — deshalb bleibt
+ * ESP32 lock-frei. Innerhalb der kritischen Sektion: keine printfdeb/Serial-
+ * Aufrufe, kein Yield (printfdeb mallociert oberhalb 64B, siehe
+ * printf-malloc-starves-nimble) — alle Debug-Werte werden hier nur
+ * eingesammelt, die Ausgabe erfolgt erst nach taskEXIT_CRITICAL().
+ *
+ * @param frame          Fertig kodierter Frame (ohne Laenge-/Status-Byte)
+ * @param len            Frame-Laenge in Byte
+ * @param ring_status    Status-Byte fuer den Slot (RING_STATUS_*)
+ * @param source         Kurzes Label fuer Debug-Ausgabe (z.B. "rx_relay")
+ * @param retryCountIn   retryCount[Slot] setzen; -1 (Default) = unangetastet
+ *                        lassen (manche Aufrufstellen haben retryCount nie
+ *                        zurueckgesetzt — Alt-Verhalten bewusst beibehalten)
+ * @param clearSlotFirst true = Slot vor dem Schreiben komplett nullen (nur
+ *                        der rx_relay-Aufruf tat das bisher selbst)
+ * @return Slot-Index (>=0) oder -1, wenn die Overflow-Logik den neuen
+ *         Eintrag verworfen hat (Ring voll, keine niedrigere Prio zum
+ *         Verdraengen vorhanden)
+ */
+int addTxRingEntry(const uint8_t* frame, uint16_t len, uint8_t ring_status,
+                    const char* source, int retryCountIn, bool clearSlotFirst)
+{
+    // Verdict Finding 3: defensive Invariante. Alle heutigen Aufrufer sind auf
+    // <=255 begrenzt -- encodeAPRS() klemmt intern auf UDP_TX_BUF_SIZE, der
+    // Radio-Empfang liefert hoechstens die Modul-Obergrenze von 255 Byte, und
+    // der Retransmit-Pfad liest die Laenge aus einem uint8 -- aber diese
+    // Grenze lebt bislang ausschliesslich in den Aufrufern und wird am
+    // einzigen Engpass (hier) nicht erzwungen. Ein kuenftiger Aufrufer mit
+    // len > UDP_TX_BUF_SIZE wuerde per memcpy in den Nachbarslot schreiben,
+    // und die Kuerzung auf (uint8_t)len beim Ablegen in ringBuffer[w][0]
+    // koennte den Eintrag zusaetzlich als kurz/leer tarnen. len==0 waere ein
+    // funktionsloser Ring-Eintrag. Beides wird hier abgewiesen, bevor der Ring
+    // ueberhaupt beruehrt wird.
+    if(len == 0 || len > UDP_TX_BUF_SIZE)
+    {
+        // Advisory-Punkt aus dem Testsuite-Audit: nicht stumm verwerfen --
+        // wir stehen hier VOR dem Lock, printfdeb ist erlaubt. Faellt diese
+        // Zeile je im Feld, hat ein neuer Aufrufer die Invariante verletzt.
+        if(bLORADEBUG)
+            printfdeb("[MC-DBG] RING_REJECT len=%u src=%s (0 oder > %d)\n",
+                      (unsigned)len, source, UDP_TX_BUF_SIZE);
+        return -1;
+    }
+
+    int w, r, queued;
+    uint8_t msgType, prio;
+    uint32_t mid;
+    bool droppedNew = false, droppedOld = false, ringOverflowAdvance = false;
+    int dropSlot = -1;
+    uint8_t dropPrio = 0, dropType = 0;
+    uint32_t dropId = 0, newLostId = 0;
+
+#if defined(NRF52_SERIES)
+    taskENTER_CRITICAL();
+#endif
+
+    w = iWrite;
+    r = iRead;
+
+    if(clearSlotFirst)
+        // sizeof statt UDP_TX_BUF_SIZE+1: der Slot ist UDP_TX_BUF_SIZE+5 Byte
+        // gross -- das alte Limit liess die letzten 4 Byte ungeputzt
+        // (TXRING-CLEARSLOT-GAP, von test_txring gefunden).
+        memset(ringBuffer[w], 0x00, sizeof(ringBuffer[0]));
+
+    ringBuffer[w][0] = (uint8_t)len;
+    ringBuffer[w][1] = ring_status;
+    memcpy(ringBuffer[w]+2, frame, len);
+
+    if(retryCountIn >= 0)
+        retryCount[w] = (uint8_t)retryCountIn;
+
+    msgType = ringBuffer[w][2];
+    mid = ((uint32_t)ringBuffer[w][6] << 24) | ((uint32_t)ringBuffer[w][5] << 16) |
+          ((uint32_t)ringBuffer[w][4] << 8)  |  (uint32_t)ringBuffer[w][3];
+    queued = (w >= r) ? (w - r) : (MAX_RING - r + w);
+
+    // Assign priority and enqueue timestamp
+    ringPriority[w] = getMessagePriority(w);
+    ringEnqueueTime[w] = millis();
+    prio = ringPriority[w];
+
+    // Track queue depth for high-water mark
+    if(queued + 1 > stat_queue_hwm)
+        stat_queue_hwm = queued + 1;
+
+    // Priority-aware overflow: when queue is full, drop lowest-priority oldest entry
+    int nextWrite = w + 1;
+    if(nextWrite >= MAX_RING) nextWrite = 0;
+    if(nextWrite == r && ringBuffer[r][0] > 0)
+    {
+        // Find the oldest entry of the lowest priority in the queue
+        int worst_slot = -1;
+        uint8_t worst_prio = 0;
+        int scan = r;
+        while(scan != w)
+        {
+            bool evictable = ringBuffer[scan][0] > 0;
+#if defined(EXTERNAL_RADIO)
+            // Never evict an in-flight external-TX slot: its length must stay
+            // valid until the bridge result resolves it, and the ownership record
+            // is not notified by this overflow path. Dropping it here would lose a
+            // pending TX or let a late result corrupt the reused slot.
+            if(ringBuffer[scan][1] == RING_STATUS_EXT_PENDING)
+                evictable = false;
+#endif
+            if(evictable && ringPriority[scan] > worst_prio)
+            {
+                worst_prio = ringPriority[scan];
+                worst_slot = scan;
+            }
+            scan++;
+            if(scan >= MAX_RING) scan = 0;
+        }
+
+        if(worst_slot >= 0 && prio < worst_prio)
+        {
+            // Drop the lowest-priority entry to make room
+            droppedOld = true;
+            dropSlot = worst_slot;
+            dropPrio = worst_prio;
+            dropType = ringBuffer[worst_slot][2];
+            dropId = ((uint32_t)ringBuffer[worst_slot][6] << 24) | ((uint32_t)ringBuffer[worst_slot][5] << 16) |
+                     ((uint32_t)ringBuffer[worst_slot][4] << 8)  |  (uint32_t)ringBuffer[worst_slot][3];
+            stat_drop_count[worst_prio]++;
+            ringBuffer[worst_slot][0] = 0; // Mark as empty
+
+            // N-24 (TXRING-ORPHAN-SLOT): liegt der geraeumte Slot NICHT am
+            // Lesezeiger, bleibt der Slot an iRead belegt -- der unbedingte
+            // Ueberlauf-Fortschalter unten schoebe iRead trotzdem darueber
+            // hinweg, und der Eintrag (moeglicherweise CRITICAL, nie
+            // gesendet) waere dauerhaft unsichtbar und unbilanziert.
+            // Fix: den Eintrag von iRead in den soeben freigewordenen Slot
+            // umziehen (Payload + Seitenarrays), iRead-Slot leeren -- danach
+            // raeumt advanceIReadPastEmpty() den Lesezeiger regulaer weiter
+            // und der Fortschalter unten trifft keinen belegten Slot mehr.
+            // Preis: der umgezogene Eintrag verliert seinen FIFO-Rang
+            // innerhalb gleicher Prioritaet (getNextTxSlot tie-breakt nach
+            // Scan-Reihenfolge ab iRead) -- akzeptiert gegen Totalverlust.
+            if (worst_slot != r && ringBuffer[r][0] > 0)
+            {
+                memcpy(ringBuffer[worst_slot], ringBuffer[r], sizeof(ringBuffer[0]));
+                ringPriority[worst_slot]    = ringPriority[r];
+                ringEnqueueTime[worst_slot] = ringEnqueueTime[r];
+                retryCount[worst_slot]      = retryCount[r];
+                ringBuffer[r][0] = 0;
+            }
+            advanceIReadPastEmpty();
+        }
+        else
+        {
+            // New packet is same or lower priority than everything in queue — drop it
+            droppedNew = true;
+            newLostId = mid;
+            stat_drop_count[prio]++;
+            ringBuffer[w][0] = 0; // Don't enqueue
+        }
+    }
+
+    int resultSlot = -1;
+    if(!droppedNew)
+    {
+        // advance tx ring write pointer — inlined addRingPointer (C1): the helper
+        // takes volatile int& and cannot bind to the now-atomic iWrite/iRead.
+        uint8_t txWnext = (uint8_t)(iWrite + 1);
+        if (txWnext >= MAX_RING)
+            txWnext = 0;
+        iWrite = txWnext;
+        if (iRead == txWnext)   // ring full: advance read pointer past the overwritten slot
+        {
+            uint8_t txRnext = (uint8_t)(txWnext + 1);
+            if (txRnext >= MAX_RING)
+                txRnext = 0;
+            iRead = txRnext;
+            ringOverflowAdvance = true;
+        }
+        resultSlot = w;
+    }
+
+#if defined(NRF52_SERIES)
+    taskEXIT_CRITICAL();
+#endif
+
+    // ---- Ab hier ausserhalb des Locks: nur noch Debug-Ausgabe ----
+    if(bLORADEBUG)
+    {
+        printfdeb("[MC-DBG] RING_WRITE slot=%d type=%02X status=%02X "
+                  "len=%d msg_id=%08X queued=%d/%d src=%s\n",
+                  w, msgType, ring_status, (int)len, mid, queued, MAX_RING, source);
+        printfdeb("[MC-DBG] RING_PRIO slot=%d prio=%d\n", w, prio);
+
+        if(droppedOld)
+            printfdeb("[MC-DBG] RING_DROP_PRIO slot=%d prio=%d type=%02X "
+                      "msg_id=%08X replaced_by_prio=%d src=%s\n",
+                      dropSlot, dropPrio, dropType, dropId, prio, source);
+        if(droppedNew)
+            printfdeb("[MC-DBG] RING_DROP_NEW slot=%d prio=%d type=%02X "
+                      "msg_id=%08X (queue full, no lower prio to evict)\n",
+                      w, prio, msgType, newLostId);
+        if(ringOverflowAdvance)
+            printfdeb("[MC-DBG] RING_OVERFLOW buf=tx\n");
+    }
+
+    return resultSlot;
+}

--- a/src/txring_functions.h
+++ b/src/txring_functions.h
@@ -1,0 +1,19 @@
+#ifndef _TXRING_FUNCTIONS_H_
+#define _TXRING_FUNCTIONS_H_
+
+// TX-Ring-Kern (Prio-Klassifizierung, Slot-Auswahl, Enqueue/Overflow):
+// aus lora_functions.cpp in eine eigene Uebersetzungseinheit extrahiert.
+// Logik unveraendert — reine Verschiebung.
+//
+// advanceIReadPastEmpty() ist hier zusaetzlich deklariert (nicht mehr rein
+// TU-lokal wie im Original): doTX() in lora_functions.cpp ruft sie ebenfalls
+// auf und braucht daher externe Sichtbarkeit.
+
+#include <Arduino.h>
+#include <configuration.h>
+
+uint8_t getMessagePriority(int slot);
+int getNextTxSlot(void);
+void advanceIReadPastEmpty(void);
+
+#endif // _TXRING_FUNCTIONS_H_

--- a/src/udp_functions.cpp
+++ b/src/udp_functions.cpp
@@ -10,6 +10,7 @@
 #include <batt_functions.h>
 #include <command_functions.h>
 #include <loop_functions_extern.h>
+#include <dedup_functions.h>
 #include <lora_functions.h>
 #include <time_functions.h>
 #include <lora_setchip.h>
@@ -20,6 +21,10 @@
 #include "printfdeb_functions.h"
 
 #include "via_functions.h"
+
+#if defined(ESP32)
+#include "esp_task_wdt.h"
+#endif
 
 #if defined(BOARD_T_ETH_ELITE) || defined(BOARD_T_CONNECT_PRO)
 #include "esp32/esp32_eth.h"
@@ -97,7 +102,7 @@ void getMeshComUDP()
   
   if (packetSize > 0)
   {
-    int len = Udp.read(incomingPacket, UDP_TX_BUF_SIZE);
+    int len = Udp.read(incomingPacket, UDP_TX_BUF_SIZE - 1);
 
     if (len > 0)
     {
@@ -118,7 +123,7 @@ void getMeshComUDPpacket(unsigned char inc_udp_buffer[UDP_TX_BUF_SIZE], int pack
     // if more than n values are 00 we might have received a faulty message
     uint8_t zerocount = 0;
 
-    for (int i = 0; i < packetSize; i+=2)
+    for (int i = 0; i + 1 < packetSize; i+=2)
     {
       if (inc_udp_buffer[i] == 0x00 && inc_udp_buffer[i + 1] == 0x00)
       {
@@ -347,12 +352,7 @@ void getMeshComUDPpacket(unsigned char inc_udp_buffer[UDP_TX_BUF_SIZE], int pack
                 // store last message to compare later on
                 insertOwnTx(aprsmsg.msg_id);
 
-                ringBuffer[iWrite][0] = size;
-                ringBuffer[iWrite][1] = 0xFF; // no retransmission for UDP relay messages
-                memcpy(ringBuffer[iWrite] + 2, convBuffer, size);
-
-                retryCount[iWrite] = 0;
-                addTxRingEntry("udp_rx");
+                addTxRingEntry(convBuffer, (uint16_t)size, 0xFF, "udp_rx", 0); // 0xFF no retransmission for UDP relay messages
 
                 addLoraRxBuffer(aprsmsg.msg_id, true);
 
@@ -420,13 +420,35 @@ void sendMeshComUDP()
     {
         if(!udp_is_busy)
         {
-            uint16_t msg_len = (uint16_t)ringBufferUDPout[udpRead][0];
+            // CONC-16: snapshot the slot before the (comparatively slow) UDP
+            // send touches it. addUdpOutBuffer() (CONC-16) can wrap the ring
+            // and overwrite this exact slot from OnRxDone (nRF52 timer-
+            // service task, see C-01) while Udp.write()/endPacket() below are
+            // still running; everything from here on reads udpSnapshot, never
+            // the live ring again.
+            //
+            // Sized past the source slot (UDP_TX_BUF_SIZE+20): the convBuffer
+            // copy below reads from offset 1+36 for msg_len bytes, which can
+            // run past what the producer actually wrote for a large msg_len
+            // (pre-existing in ringBufferUDPout too, not introduced here) --
+            // zero-filled so that tail is deterministic instead of reading
+            // adjacent stack memory.
+            static uint8_t udpSnapshot[UDP_TX_BUF_SIZE+64] = {0};
+            int mySlot = udpRead;
+#if defined(NRF52_SERIES)
+            taskENTER_CRITICAL();
+#endif
+            memcpy(udpSnapshot, ringBufferUDPout[mySlot], sizeof(ringBufferUDPout[0]));
+#if defined(NRF52_SERIES)
+            taskEXIT_CRITICAL();
+#endif
+            uint16_t msg_len = (uint16_t)udpSnapshot[0];
 
             // send it over UDP
 
             Udp.beginPacket(node_hostip , UDP_PORT);
 
-            if (!Udp.write(ringBufferUDPout[udpRead] + 1, msg_len))
+            if (!Udp.write(udpSnapshot + 1, msg_len))
             {
                 if(bDisplayCont)
                   printlndeb("[ERROR]...Sending UDP Packet failed");
@@ -451,14 +473,21 @@ void sendMeshComUDP()
 
             Udp.endPacket();
 
-            memcpy(convBuffer, ringBufferUDPout[udpRead] + 1 + 36, msg_len);
+            // Der Slot enthaelt msg_len Bytes ab Offset 1: 36 Byte UDP-Header,
+            // danach der APRS-Frame. msg_len Bytes ab Offset 1+36 zu kopieren
+            // las immer 36 Bytes ueber das tatsaechlich Geschriebene hinaus
+            // und gab decodeAPRS() eine um 36 zu grosse Laenge (der im
+            // CONC-16-Commit dokumentierte Nebenbefund). Die wahre
+            // APRS-Laenge ist msg_len-36.
+            uint16_t aprs_len = (msg_len > 36) ? (uint16_t)(msg_len - 36) : 0;
+            memcpy(convBuffer, udpSnapshot + 1 + 36, aprs_len);
 
-            if(convBuffer[0] == 0x3A || convBuffer[0] == 0x21 || convBuffer[0] == 0x40)
+            if(aprs_len > 0 && (convBuffer[0] == 0x3A || convBuffer[0] == 0x21 || convBuffer[0] == 0x40))
             {
               struct aprsMessage aprsmsg;
-              
+
               // print which message type we got
-              decodeAPRS(convBuffer, msg_len, aprsmsg);
+              decodeAPRS(convBuffer, aprs_len, aprsmsg);
 
               // print aprs message
               if(bDisplayInfo)
@@ -467,12 +496,26 @@ void sendMeshComUDP()
               }
             }
 
-            // zero out sent buffer
-            memset(ringBufferUDPout[udpRead], 0, UDP_TX_BUF_SIZE);
-
-            udpRead++;
-            if (udpRead >= MAX_RING_UDP) 
-                udpRead = 0;
+            // zero out sent buffer and advance the read pointer under the same
+            // lock as the writer's addRingPointer() (CONC-16). Guard against a
+            // writer having already force-advanced udpRead past us via the
+            // ring-full eviction path in addRingPointer() while we were
+            // sending — extremely narrow (needs the ring to wrap completely
+            // during one synchronous Udp.write()/endPacket()), but skipping
+            // the advance in that case avoids a double-advance.
+#if defined(NRF52_SERIES)
+            taskENTER_CRITICAL();
+#endif
+            if (udpRead == mySlot)
+            {
+                memset(ringBufferUDPout[mySlot], 0, UDP_TX_BUF_SIZE);
+                udpRead++;
+                if (udpRead >= MAX_RING_UDP)
+                    udpRead = 0;
+            }
+#if defined(NRF52_SERIES)
+            taskEXIT_CRITICAL();
+#endif
 
         }
         else
@@ -557,13 +600,17 @@ void sendMeshComUDP()
 
     if(strcmp(meshcom_settings.node_ssid, "none") == 0)
     {
-      printfdeb("[WIFI]...ST no ssid<%s> pwd<%s> not connected\n", meshcom_settings.node_ssid, meshcom_settings.node_pwd);
+      printfdeb("[WIFI]...ST no ssid<%s> pwd<%s> not connected\n", meshcom_settings.node_ssid, maskSecret(meshcom_settings.node_pwd));
       return false;
     }
   }
 
   if (bDEBUG)
       printlndeb("[WIFI]...WiFi full radio reset");
+
+  #if defined(ESP32)
+  esp_task_wdt_reset();   // about to block on mode transitions + a full-channel scan below
+  #endif
 
   WiFi.disconnect(true, true);
   WiFi.mode(WIFI_OFF);
@@ -574,8 +621,16 @@ void sendMeshComUDP()
   hasIPaddress=false;
   meshcom_settings.node_hasIPaddress = hasIPaddress;
 
+  #if defined(ESP32)
+  esp_task_wdt_reset();   // WiFi.scanNetworks() below is a blocking, unbounded all-channel scan
+  #endif
+
   // Scan for AP with best RSSI
 	int nrAps = WiFi.scanNetworks();
+
+  #if defined(ESP32)
+  esp_task_wdt_reset();
+  #endif
   int best_rssi = -200;
   int best_idx = -1;
   for (int i = 0; i < nrAps; ++i)
@@ -642,7 +697,10 @@ void sendMeshComUDP()
     else
       WiFi.begin(meshcom_settings.node_ssid, meshcom_settings.node_pwd, WiFi.channel(best_idx), WiFi.BSSID(best_idx),true);
   }
-  
+
+  #if defined(ESP32)
+  esp_task_wdt_reset();
+  #endif
   delay(500);
 
   printfdeb("[WIFI]...power: %i RSSI:%i\n", WiFi.getTxPower(), WiFi.RSSI());
@@ -1035,6 +1093,14 @@ void addUdpOutBuffer(uint8_t* buffer, uint16_t len)
     if (len > UDP_TX_BUF_SIZE)
         len = UDP_TX_BUF_SIZE; // just for safety
 
+    // CONC-16: udpWrite/udpRead are plain ints, same class as CONC-15.
+    // addUdpOutBuffer() is reachable from OnRxDone via addNodeData()
+    // (lora_functions.cpp) — the FreeRTOS timer-service task on nRF52,
+    // priority 2, see C-01 — while sendMeshComUDP() drains the same ring
+    // from the Main Loop task.
+#if defined(NRF52_SERIES)
+    taskENTER_CRITICAL();
+#endif
     // first byte is always the message length
     // LoRa/Internal messages send to UDP TX
     ringBufferUDPout[udpWrite][0] = len;
@@ -1044,7 +1110,10 @@ void addUdpOutBuffer(uint8_t* buffer, uint16_t len)
     //DEBUG_MSG_VAL("UDP", udpWrite, "UDP Ringbuf added El.:");
     //neth.printBuffer(ringBufferUDPout[udpWrite], len + 1);
 
-    addRingPointer(udpWrite, udpRead, MAX_RING_UDP);
+    addRingPointer(udpWrite, udpRead, MAX_RING_UDP, "udp");
+#if defined(NRF52_SERIES)
+    taskEXIT_CRITICAL();
+#endif
 }
 
 void sendKEEP()

--- a/src/watchdog_feed.h
+++ b/src/watchdog_feed.h
@@ -1,0 +1,44 @@
+#ifndef _WATCHDOG_FEED_H_
+#define _WATCHDOG_FEED_H_
+
+/**
+ * @file watchdog_feed.h
+ * @brief Ein einziger, greppbarer Einstiegspunkt zum Füttern des Task-Watchdogs.
+ *
+ * Hintergrund (N-25): der Task-Watchdog wird ausschließlich auf ESP32 scharf
+ * geschaltet (esp32_main.cpp, am Ende von esp32setup()). Dateien wie
+ * gps_functions.cpp werden aber von beiden MCU-Familien übersetzt. Würde jede
+ * Fundstelle ihr eigenes `#if defined(ESP32)` + esp_task_wdt_reset() tragen,
+ * driften die Zweige auseinander -- genau so sind die beiden
+ * detectBaudrate()-Implementierungen entstanden.
+ *
+ * Deshalb: EIN Helfer, auf nRF52 ein No-op, und alle Fundstellen sind über
+ * `grep -rn meshcom_wdt_feed src/` vollständig auffindbar.
+ *
+ * Wichtig -- was NICHT füttert: delay(), yield(), vTaskDelay(). Nur
+ * esp_task_wdt_reset() setzt den Task-Watchdog zurück.
+ *
+ * Der Helfer ist KEIN Ersatz dafür, unbegrenzte Schleifen zu begrenzen. In
+ * einer Schleife ohne Abbruchbedingung verwandelt Füttern einen Panic-Reboot
+ * in ein dauerhaftes stilles Einfrieren -- für einen Mesh-Knoten schlechter.
+ * Nur an nachweislich endlich begrenzten Stellen einsetzen.
+ */
+
+#if defined(ESP32)
+
+#include "esp_task_wdt.h"
+
+static inline void meshcom_wdt_feed(void)
+{
+    // Liefert ESP_ERR_NOT_FOUND, solange der Task nicht angemeldet ist
+    // (z.B. während esp32setup()). Das ist der harmlose Normalfall.
+    esp_task_wdt_reset();
+}
+
+#else
+
+static inline void meshcom_wdt_feed(void) {}
+
+#endif
+
+#endif  // _WATCHDOG_FEED_H_

--- a/src/web_functions/web_functions.cpp
+++ b/src/web_functions/web_functions.cpp
@@ -237,7 +237,7 @@ void web_client_html(CommonWebClient web_client)
         for (int iwid = 0; iwid < 10; iwid++)
         {
             // check passwort Time expired 4h
-            if((ulong)(web_ip_passwd_time[iwid] + (1000 * 60 * 60 * 4)) < millis())
+            if((uint32_t)(millis() - (uint32_t)web_ip_passwd_time[iwid]) >= (1000U * 60 * 60 * 4))
             {
                 web_ip_passwd_time[iwid] = 0;
                 memset(web_ip[iwid], 0x00, sizeof(web_ip[iwid]));
@@ -896,7 +896,7 @@ void sub_page_position()
     web_client.printf("<tr><td>Latitude</td><td>%.4lf %c</td></tr>\n", meshcom_settings.node_lat, meshcom_settings.node_lat_c);
     web_client.printf("<tr><td>Longitude</td><td>%.4lf %c</td></tr>\n", meshcom_settings.node_lon, meshcom_settings.node_lon_c);
     web_client.printf("<tr><td>Altitude</td><td>%i</td></tr>\n", meshcom_settings.node_alt);
-    web_client.printf("<tr><td>Satellites</td><td>%i - %s - HDOP %i</td></tr>\n", (int)posinfo_satcount, (posinfo_fix ? "fix" : "nofix"), posinfo_hdop);
+    web_client.printf("<tr><td>Satellites</td><td>%i - %s - HDOP %i</td></tr>\n", (int)posinfo_satcount, (posinfo_fix ? "fix" : "nofix"), (int)fposinfo_hdop);
     web_client.printf("<tr><td>Rate</td><td>%i</td></tr>\n", (int)posinfo_interval);
     web_client.printf("<tr><td>Next</td><td>%i sec</td></tr>\n", (int)(((posinfo_timer + (posinfo_interval * 1000)) - millis()) / 1000));
     web_client.printf("<tr><td>Distance</td><td>%.0lf m</td></tr>\n", posinfo_distance);
@@ -1286,7 +1286,7 @@ void sub_content_messages()
         { // Data Message (JSON)
           // memcpy(toPhoneBuff, BLEtoPhoneBuff[iRead]+1, blelen);
         }
-        else
+        else if (blelen >= 4 && (size_t)(blelen - 4) <= sizeof(toPhoneBuff))
         { // Text Message and Position
             uint8_t tbuffer[5];
             unsigned long unix_time = 0;

--- a/src/web_functions/web_setup.cpp
+++ b/src/web_functions/web_setup.cpp
@@ -496,7 +496,11 @@ void webSetup_setParam(setupStruct *setupData){
         commandAction(message_text, bPhoneReady);
         
         //MCP Module has 16 IO Ports named A0...7 and B0...7 ... but internally they are 0....15
-        uint8_t t_io = (uint8_t)port.charAt(1) - 48;            //ASCII '0' is numarically 48 
+        if((port.charAt(0)!='A' && port.charAt(0)!='B') || port.charAt(1)<'0' || port.charAt(1)>'7') {
+            setupData->returnCode = WS_RETURNCODE_FAIL;
+            return;
+        }
+        uint8_t t_io = (uint8_t)port.charAt(1) - 48;            //ASCII '0' is numarically 48
         if(port.charAt(0)=='B') t_io+=8;
 
         uint16_t bitmask = 1 << t_io;
@@ -523,7 +527,11 @@ void webSetup_setParam(setupStruct *setupData){
         commandAction(message_text, bPhoneReady);
         
         //MCP Module has 16 IO Ports named A0...7 and B0...7 ... but internally they are 0....15
-        uint8_t t_io = (uint8_t)port.charAt(1) - 48;            //ASCII '0' is numarically 48 
+        if((port.charAt(0)!='A' && port.charAt(0)!='B') || port.charAt(1)<'0' || port.charAt(1)>'7') {
+            setupData->returnCode = WS_RETURNCODE_FAIL;
+            return;
+        }
+        uint8_t t_io = (uint8_t)port.charAt(1) - 48;            //ASCII '0' is numarically 48
         if(port.charAt(0)=='B') t_io+=8;
 
         uint16_t bitmask = 1 << t_io;
@@ -546,6 +554,10 @@ void webSetup_setParam(setupStruct *setupData){
         }
 
         //MCP Module has 16 IO Ports named A0...7 and B0...7 ... but internally they are 0....15
+        if((port.charAt(0)!='A' && port.charAt(0)!='B') || port.charAt(1)<'0' || port.charAt(1)>'7') {
+            setupData->returnCode = WS_RETURNCODE_FAIL;
+            return;
+        }
         uint8_t t_io = (uint8_t)port.charAt(1) - 48;            //ASCII '0' is numarically 48
         if(port.charAt(0)=='B') t_io+=8;
 

--- a/variants/heltec_t114/platformio.ini
+++ b/variants/heltec_t114/platformio.ini
@@ -1,9 +1,5 @@
-[nrf52]
-platform = nordicnrf52
-framework = arduino
-
 [env:heltec_t114]
-extends = nrf52
+extends = nrf52_base
 board = heltec_t114
 debug_tool = jlink
 upload_protocol = nrfutil
@@ -30,8 +26,8 @@ lib_deps =
 	https://github.com/adafruit/Adafruit-ST7735-Library
 
 lib_archive = no
-build_flags = 
-	${nrf52.build_flags}
+build_flags =
+	${nrf52_base.build_flags}
 	${common.build_flags}
 
 	-I src/nrf52

--- a/variants/t_echo/platformio.ini
+++ b/variants/t_echo/platformio.ini
@@ -1,9 +1,5 @@
-[nrf52]
-platform = nordicnrf52
-framework = arduino
-
 [env:t_echo]
-extends = nrf52
+extends = nrf52_base
 board = nrf52840_dk_adafruit
 debug_tool = jlink
 upload_protocol = nrfutil
@@ -30,8 +26,8 @@ lib_deps =
 	https://github.com/ZinggJM/GxEPD
 
 lib_archive = no
-build_flags = 
-	${nrf52.build_flags}
+build_flags =
+	${nrf52_base.build_flags}
 	${common.build_flags}
 
 	-I src/nrf52

--- a/variants/wiscore_rak4631/platformio.ini
+++ b/variants/wiscore_rak4631/platformio.ini
@@ -1,29 +1,5 @@
-[nrf52]
-platform = nordicnrf52
-framework = arduino
-extends = upload_settings
-build_src_filter = 
-	+<*>
-	-<esp32/*>
-	-<Displays/*>
-	-<Fonts/*>
-	-<GFX_Root/*>
-	-<Platforms/*>
-	-<safeboot/*>
-	-<t-deck/*>
-	-<t-deck-pro/*>
-	-<t5-epaper/*>
-	-<tinyxml_function.cpp>
-	+<../variants/wiscore_rak4631/*>
-build_flags = 
-	${common.build_flags}
-	-D BOARD_RAK4630="RAK4630"
-	-D MONITOR_SPEED=${upload_settings.monitor_speed}
-	-D SERIAL_BUFFER_SIZE=250
-	-Isrc/nrf52
-
 [env:wiscore_rak4631]
-extends = nrf52
+extends = nrf52_base
 board = rak4630
 
 lib_ignore =
@@ -47,7 +23,7 @@ lib_deps =
 	olikraus/U8g2@^2.36.5
 	
 lib_archive = no
-build_flags = 
-	${nrf52.build_flags}
+build_flags =
+	${nrf52_base.build_flags}
 	-I variants/${this.__env__}
 	-D DISABLE_NET_CONSOLE


### PR DESCRIPTION
Diese Aenderungen sind ueber fuenf Monate Dauerbetrieb an OE/DL-Knoten entstanden (Heltec V3 als Gateway, RAK4631 mit RAK13800-Ethernet, T-Beam). Ausgangspunkt waren reproduzierbare Ausfaelle im Feld -- Boot-Schleifen an Gateways, einfrierende RAK4631-Knoten, ACK-Stuerme -- und ein anschliessender systematischer Durchgang durch die betroffenen Pfade.

Der PR enthaelt **ausschliesslich Firmware-Code**: keine Doku, keine Tests, keine Werkzeuge, keine Binaerdateien.

**Umfang:** 64 Dateien, +3.213 / -1.113. Davon 60 in `src/`, 3 in `variants/`, 1x `platformio.ini`. 11 neue Dateien, keine geloeschten. Alle 7 Standard-Targets bauen sauber.

Unten sind alle 82 Einzelaenderungen aufgefuehrt, thematisch gruppiert. Jede Zeile nennt, was angefasst wurde und warum.

---

## 1. Speichersicherheit im Empfangs- und Kommandopfad

Alle Fundstellen liegen auf Pfaden, die von aussen erreichbar sind -- ueber HF, UDP, BLE oder den Webserver.

**1.1 Format-String aus Nutzdaten** (`printfdeb_functions.cpp`)
`printfdeb()` setzte seine varargs per `vsnprintf` in einen Puffer und gab diesen anschliessend mit `Serial.printf(temp)` aus -- also als *neuen* Format-String ohne zugehoerige varargs. Der `%%`-Escaping-Durchlauf davor neutralisiert nur Prozentzeichen aus dem Entwickler-Format, nicht solche, die ueber ein `%s` aus den Daten eingesetzt wurden. `aprsmsg.msg_payload` ist der dekodierte Text eines empfangenen Frames -- ein Absender konnte damit beliebige Direktiven in `vsnprintf` schieben.

**1.2 Heap-Churn als Folge von 1.1** (`printfdeb_functions.cpp`)
Der Fix aus 1.1 (`Serial.printf("%s", temp)`) ist korrekt, hat aber einen teuren Nebeneffekt: `Serial` ist auf ESP32 `Print::printf`, das in einen 64-Byte-Stackpuffer formatiert und fuer jede laengere Ausgabe `malloc()`t -- also bei nahezu jeder Log-Zeile. Der Heap-Verschleiss verhinderte den BLE-Verbindungsaufbau (0x3e, `le-connection-abort-by-local`). Jetzt ohne Reformatierung ausgegeben.

**1.3 BLE 0x55, WLAN-Zugangsdaten** (`phone_commands.cpp`)
`ssid_len = conf_data[2]` und `pwd_len = conf_data[ssid_len+3]` kamen unveraendert von der App, die einzige Pruefung war `> 0` ohne Obergrenze. `memcpy(pwd_arr, conf_data+(4+ssid_len), pwd_len)` konnte bis zu ~214 Byte hinter dem 300-Byte-Puffer lesen. Zusaetzlich waren `ssid_arr`/`pwd_arr` VLAs mit angreifergesteuerter Groesse.

**1.4 BLE 0xA0, Textnachricht** (`phone_commands.cpp`)
`txt_msg_len_phone = msg_len - 2` als `uint8_t`, mit `msg_len = conf_data[0]` von der App. Ohne Pruefung auf `>= 2` wrappen die Werte 0 und 1 auf 254/255; das folgende `memcpy` kopierte dann 254-255 Byte.

**1.5 Laengenbyte-Ueberlauf im Phone-Ringpuffer, N-04** (`loop_functions.cpp`, `web_functions/web_functions.cpp`)
`addBLEOutBuffer()` klemmte gegen `UDP_TX_BUF_SIZE` (255), haengt im Nicht-'D'-Zweig aber noch 4 Byte Zeitstempel an und legt `len+4` in einem `uint8_t` ab. Laengen 252..255 passierten den Clamp, das Laengenbyte lief auf 0..3 ueber. Der Konsument rechnet `blelen-4`, was ueber `int` nach `size_t` zu etwa `SIZE_MAX` wird -- `memcpy`, Hard Fault. Ausloeser: ein LoRa-Textframe mit 252..255 Byte und gueltiger FCS, danach ein Aufruf der Web-Nachrichtenseite.

**1.6 Restbefund zu N-04** (`phone_commands.cpp`)
`sendToPhone()` und `sendComToPhone()` lasen dasselbe Laengenbyte weiterhin ungeprueft und rechneten `blelen-1` als `uint8_t`. `blelen == 0` wrappt zu 255.

**1.7 URL-Decode ueberschreibt `msg_text_checked[200]`, SEC-04** (`loop_functions.cpp`)
Die Schleife in `sendMessage()` lief ueber einen Zaehler, der im Rumpf nirgends zum Indizieren benutzt wurde. Die tatsaechliche Quellposition sprang bei Mehrbyte-`%`-Escapes (z.B. Emoji wie `%F0%9F%98%80`) um bis zu 12 pro Escape vorwaerts -- die Iterationszahl war davon entkoppelt, das Ziel lief ueber.

**1.8 UDP-Empfang, Off-by-one und Zero-Scan, SEC-05/SEC-06/BUG-12** (`udp_functions.cpp`, `extudp_functions.cpp`)
`incomingPacket`/`incomingExtPacket` sind `unsigned char[255]`, gueltige Indizes 0..254. `Udp.read(buf, UDP_TX_BUF_SIZE)` kann bei einem vollen Datagramm 255 liefern, das abschliessende NUL landete auf Index 255. Dazu ein Zero-Scan, der ein Byte zu weit las.

**1.9 `convBuffer`-Ueberlesen im UDP-TX-Decode** (`udp_functions.cpp`, `nrf52/nrf52_main.cpp`)
Der Ring-Slot enthaelt `msg_len` Bytes ab Offset 1, als Grenze diente aber die Gesamtlaenge des Slots. An beiden Fundstellen behoben (ESP32 `sendMeshComUDP`, nRF52 `sendUDP`).

**1.10 `handleACK()` ohne Mindestlaenge vor 12-Byte-`memcpy`, BUG-10** (`lora_functions.cpp`)
Einzige Eingangspruefung war `payload[0] != MSG_TYPE_ACK`. Bei einem verkuerzten ACK-Frame sind die Bytes hinter `size` veraltete Daten aus dem wiederverwendeten RX-Puffer; eine daraus gebildete `msg_id` kann zufaellig mit einer eigenen in-flight-Nachricht uebereinstimmen.

**1.11 `handleACK()` akzeptiert Textbruchstuecke als ACK** (`lora_functions.cpp`, neu: `ack_functions.h`, `configuration_global.h`)
`0x41` ist als ASCII der Buchstabe 'A'. Jedes Bruchstueck eines Text- oder Positionspakets, das damit beginnt, lief durch die ACK-Verarbeitung: Bytes 1..4 galten als `msg_id`, es landete im Dedup-Ring, wurde mit Prioritaet 1 in die Sendequeue geschrieben (dabei ein Heartbeat aus der vollen Queue geworfen) und ins Mesh geflutet. Das ist die Quelle der beobachteten ACK-Stuerme. Die Pruefung liegt jetzt als reine Funktion `isPlausibleAckFrame()` in einem eigenen Header.

**1.12 APRS-Trailer/FCS ohne Grenzpruefung, BUG-13** (`aprs_functions.cpp`)
`decodeAPRS()` liest nach dem Payload-Decode 4 Trailer-Bytes (hw, mod, FCS) an festen Offsets. Die vorhandene Pruefung belegte nur, dass ein NUL-Byte im gueltigen Bereich existiert -- nicht, dass danach noch vier Bytes innerhalb `rsize` folgen. Der Ruecklagepuffer `RcvBuffer[510]` ist deutlich groesser als `rsize`.

**1.13 `cnewMsg[10]` zu klein fuer `{mcp}`-Reformatierung, BUG-11** (`loop_functions.cpp`)
`"{mcp}"` + drei Einzelzeichen + zwei 2-Zeichen-Substrings sind schon 12 Zeichen; realistische Kommandos liegen bei 17-18. Der 10-Byte-Puffer schnitt ab.

**1.14 Heap-Over-Read in `updateHeyPath()` wird ueber HF verteilt, N-05** (`mheard_functions.cpp`)
Beide `memcpy` nahmen die Laenge aus `sizeof(Ziel)` statt aus der Quelle. Bei `mheardPathBuffer1` sind das 50 Byte aus einem oft nur wenige Byte langen String -- bis zu ~44 Byte Fremdspeicher landeten in der Anzeige, im JSON-Export zur App und in ausgehenden HEY-Pfaden, also zurueck auf HF. Das korrekt berechnete `ipc` war vorhanden, wurde aber nie benutzt.

**1.15 Unbegrenzter Array-Index aus Web-Parameter, N-06** (`web_functions/web_setup.cpp`)
An drei Stellen (`mcpio`, `mcpout`, `mcpname`) wurde der MCP-Portname nur auf Laenge 2 geprueft und direkt zu einem Index verrechnet. Ein Byte 0xFF an Position 1 ergibt Index 215: `1 << t_io` ist ab 32 undefiniert, und `node_mcp17t[t_io]` schreibt 16 Byte rund 3,4 kB hinter ein `char[16][16]` mitten in `meshcom_settings` -- mit anschliessendem `save_settings()`. Erreichbar aus dem LAN.

**1.16 Klartext-Bypass in der Authentisierung, Passwortmaskierung, APRS-Rahmengrenze, D1/D2/D5** (`net_console.cpp`, `aprs_functions.cpp`, `web_functions/web_functions.cpp`, `mheard_functions.cpp`, `adc_functions.cpp`, `batt_functions.cpp`)
Ein Klartext-Bypass in der Authentisierung ist entfernt, Passwoerter werden im Log maskiert statt unmaskiert gedruckt, und die APRS-Rahmenlaenge hat eine Obergrenze bekommen.

**1.17 `{SET}` uebernimmt `max_hop` ohne Bereichspruefung** (`loop_functions.cpp`)
`sscanf` schrieb die Werte direkt in `meshcom_settings`. Ein Tippfehler wie `{SET}44;2;` landete ungeprueft im Hop-Feld jedes ausgesendeten Pakets. Byte 5 einer ACK fuehrt `max_hop` in 7 Bit, und der Weiterleitungspfad prueft nur `(byte5 & 0x7F) > 0` und dekrementiert -- nach oben begrenzt ihn nichts. Ein so verstellter Knoten erzeugt Pakete, die 44 statt 4 Relaissprunge weit laufen.

**1.18 `--symid`-Validierung wiederhergestellt** (`command_functions.cpp`, `loop_functions.cpp`)
Die Klausel lautete `node_symid == '/' || node_symid != '\''`. Der zweite Operand ist ein Apostroph und der Operator negiert -- der Ausdruck war fuer jedes Byte ausser 0x27 wahr. `bSymbolTable` wurde unbedingt gesetzt, die Pruefung war ein No-Op und die '0'-'9'/'A'-'Z'-Overlay-Zweige darunter unerreichbar.

---

## 2. `millis()`-Ueberlauf

**2.1 Deadline-Vergleiche ueberlaufsicher, N-08** (`clock.cpp`, `esp32/esp32_main.cpp`, `gps_functions.cpp`, `nrf52/nrf52_main.cpp`, `t-deck/tdeck_main.cpp`, `t-deck-pro/peri_gps.cpp`, `t5-epaper/peri_gps.cpp`)
25 direkte Vergleiche `millis() <op> X` gegen eine gespeicherte Deadline (`rebootAuto`, `DisplayOffWait`, `startTimeout`, `check_temperature`, `run`, `u32Next_m`, `lTELE_TIMER`, `resendPing`, `retransmit_timer`) brechen, sobald `millis()` nach ca. 49,7 Tagen ueberlaeuft: der Vergleich wird fuer den gesamten naechsten Zyklus falsch ausgewertet. Betroffen unter anderem der automatische Reboot. Auf Differenzform umgestellt.

**2.2 ESP32-Hauptschleife, A1** (`esp32/esp32_main.cpp`)
**2.3 nRF52-Hauptschleife, A1** (`nrf52/nrf52_main.cpp`, `nrf52/at_cmd.h`)
**2.4 LoRa-, Ring- und GPS-Pfade, A1** (`lora_functions.cpp`, `loop_functions.cpp`, `gps_functions.cpp`)
Dieselbe Klasse in den drei Modulen, die die Dauerlaeufer betrifft.

**2.5 `AT_PRINTF` begrenzt, D3** (`nrf52/at_cmd.h`)
Unbegrenztes `sprintf` durch `snprintf` mit Zielgroesse ersetzt.

**2.6 GPS-ISR Off-by-one, B5; ISR-Logs hinter `LORA_ISR_DEBUG`, B1; Ring-Overflow-Log, C2** (`gps_functions.cpp`, `lora_functions.cpp`, `loop_functions.cpp`)
`OnRxDone` loggte im ISR-Kontext; das ist jetzt hinter ein Build-Flag gelegt.

---

## 3. Nebenlaeufigkeit und Ringpuffer

**3.1 `externQueue`: SPSC-Memory-Ordering und Grenzpruefung, RACE-01/BND-02** (`extudp_functions.cpp`)
`externQueueEntry::used` war ein `bool` ohne Barriere. Auf dem dual-core ESP32 kann der Store `used=true` am anderen Core sichtbar werden, bevor `memcpy`/`buflen`/`rssi`/`snr` sichtbar sind. Jetzt `std::atomic<bool>` mit release-Store im Producer und acquire-Load im Consumer.

**3.2 Atomare Ring-Indizes und CAD-Flags, C1/B3** (`loop_functions.cpp`, `loop_functions_extern.h`, `lora_functions.cpp`, `nrf52/nrf52_main.cpp`, `nrf52/nrf_eth.cpp`)
`iWrite`/`iRead` von `volatile int` auf `std::atomic<uint8_t>`, konsistent mit `loraWrite`. nRF52-CAD-Flags von `volatile bool` auf `std::atomic<bool>`, Publish in `OnCadDone` mit `memory_order_release`.

**3.3 Ueberfluessige Synchronisation auf ESP32 entfernt, N-13** (`esp32/esp32_main.cpp`, `loop_functions.cpp`, `loop_functions_extern.h`, `lora_functions.cpp`)
`OnRxDone` laeuft auf ESP32 nie im Interrupt-Kontext -- es wird synchron ueber `esp32loop() -> checkRX() -> OnRxDone()` im Main-Loop-Task aufgerufen. Drei Synchronisationsstellen schuetzten dort Zustand, den nichts nebenlaeufig veraendert. nRF52 hat echte Preemption und ist von keiner dieser Aenderungen betroffen.

**3.4 N-13 fortgesetzt: vier weitere Objekte** (`loop_functions.cpp`, `loop_functions_extern.h`)
`is_receiving`, `ch_util_tx_start`, `ch_util_rx_accum`, `ch_util_tx_accum` waren auf beiden Plattformen `std::atomic`, werden auf ESP32 aber ausschliesslich ueber dieselbe synchrone Kette angefasst.

**3.5 N-13 fortgesetzt: Ring-Indizes auf ESP32** (`loop_functions.cpp`, `loop_functions_extern.h`, neu: `ring_index.h`)
`iWrite`/`iRead`/`loraWrite` ebenfalls. Der gemeinsame Typ liegt jetzt in `ring_index.h` -- auf nRF52 atomar, auf ESP32 einfach.

**3.6 Telefon-Kommandos nicht mehr inline im BLE-Callback, CONC-14** (`nrf52/nrf52_ble.cpp`, `nrf52/nrf52_main.cpp`)
`bleuart_rx_callback()` rief `readPhoneCommand()` synchron im Bluefruit-BLE-Task-Kontext. Diese Funktion ruft weiter `commandAction()`, `save_settings()` und schreibt in geteilte Ringpuffer -- alles nebenlaeufig zum Main-Loop-Task, ohne Sperre.

**3.7 `settings_rx_callback()` staged statt live zu kopieren, CONC-17** (`nrf52/nrf52_ble.cpp`, `nrf52/nrf52_main.cpp`, `nrf52/WisBlock-API.h`)
Die Funktion lief in der BLE-Stack-Task und kopierte den gesamten `meshcom_settings`-Struct per `memcpy` direkt ins globale Objekt, gefolgt von `save_settings()`. Der FreeRTOS-Timer-Service-Task (Prio 2), der `OnRxDone` treibt, kann diese Kopie mittendrin unterbrechen -- ein Beacon-Build liest dann einen zerrissenen Struct, etwa neues Rufzeichen mit altem Suffix. Jetzt staged in einen privaten Puffer, Uebernahme einmal pro Loop unter kurzem Lock.

**3.8 `toPhoneWrite`/`toPhoneRead` unter Lock, CONC-15/CONC-18** (`loop_functions.cpp`, `phone_commands.cpp`)
Der Schreiber `addBLEOutBuffer()` wird auf nRF52 aus dem Timer-Service-Task erreicht, waehrend `sendToPhone()` denselben Ring aus dem Main Loop drainiert.

**3.9 `udpWrite`/`udpRead` unter Lock, CONC-16** (`loop_functions.cpp`, `udp_functions.cpp`)
Gleiche Klasse, andere Ringe: `addUdpOutBuffer()` wird ueber `addNodeData()` aus `OnRxDone` erreicht, `sendMeshComUDP()` drainiert aus dem Main Loop.

**3.10 CONC-16-Rest: `sendUDP()` liest den Ring als Snapshot** (`nrf52/nrf52_main.cpp`)
Die urspruengliche Verifikationsnotiz "auf wiscore_rak4631 nicht gelinkt" war falsch -- `addUdpOutBuffer()` laeuft via `addNodeData()` auch auf nRF52, und der dortige Leser `sendUDP()` las bis dahin ungeschuetzt aus dem lebenden Ring.

**3.11 `net_console`-Mutex wurde ohne Besitz neu erzeugt, CONC-19** (`net_console.cpp`)
`stopNetConsole()` ueberschrieb den lebenden Handle mit einem frisch erzeugten Mutex, ohne den alten zu halten. Der alte Handle wurde geleakt, und schlimmer: `authTask` konnte noch den alten Mutex halten, waehrend `teardownClient()` bereits gegen den neuen lief.

**3.12 TX-Ring-Enqueue komplett unter einem Lock, N-14** (`loop_functions.cpp`, `loop_functions.h`, `loop_functions_extern.h`, `lora_functions.cpp`, `nrf52/nrf_eth.cpp`, `udp_functions.cpp`)
Der TX-Ring war auf nRF52 multi-writer ohne wechselseitigen Ausschluss: jeder der 16 Aufrufer schrieb `ringBuffer[iWrite][...]` selbst (Laenge, Status, Payload-`memcpy`) und rief **danach** `addTxRingEntry()`, das `iWrite` erneut las. Preemptet der Timer-Service-Task den Loop-Task zwischen Payload-Schreiben und Fortschalten, fuellen zwei Schreiber denselben Slot -- ein zusammengespleisster Frame geht auf die Luft. Die Aufrufer schreiben jetzt nicht mehr selbst in den Ring.

**3.13 TX-Ring-Kern in eigene Uebersetzungseinheit** (neu: `txring_functions.cpp` / `.h`, `lora_functions.cpp`, `lora_functions.h`)
`getMessagePriority`, `getNextTxSlot`, `advanceIReadPastEmpty` und `addTxRingEntry` verbatim aus `lora_functions.cpp` extrahiert -- Logik unveraendert, per Diff verifiziert. Einzige Abweichung: `advanceIReadPastEmpty` verliert sein `static`, weil `doTX()` es weiter aufruft.

**3.14 Indirekte Eviction verwaist keinen belegten Slot mehr, N-24** (`txring_functions.cpp`)
Die beiden Ueberlauf-Pfade in `addTxRingEntry()` stimmten sich nicht ab. Die Prio-Eviction waehlt den Slot mit der schlechtesten Prioritaet irgendwo im Fenster -- nicht zwingend den an `iRead`. Wurde ein Mittel-Slot geraeumt, blieb der Slot an `iRead` belegt, der unbedingte "ring full"-Block schob `iRead` aber trotzdem weiter.

**3.15 `clearSlotFirst()` putzt den ganzen Slot** (`txring_functions.cpp`)
Das `memset`-Limit `UDP_TX_BUF_SIZE+1` liess die letzten 4 der `UDP_TX_BUF_SIZE+5` Slot-Bytes ungeputzt.

**3.16 Laengen-Invariante weist nicht mehr stumm ab** (`txring_functions.cpp`)
Verletzt ein Aufrufer die 255-Byte-Grenze, gibt es jetzt eine `RING_REJECT`-Zeile hinter `bLORADEBUG` statt einer stillen Ablehnung.

**3.17 Haertung aus dem Testsuite-Audit** (`txring_functions.cpp`)
Kleinere Korrekturen an den Ring-Invarianten aus einem Audit der eigenen Testsuite.

---

## 4. nRF52 / RAK4631

Diese Plattform hatte die haerteste Fehlerklasse: der Knoten war seriell scheinbar tot, tatsaechlich stand die Hauptschleife.

**4.1 Stack-Overflow in `sendExtern()` bei Positions-Sends** (`extudp_functions.cpp`)
`sendExtern()` legte ~2000 Byte auf dem Stack an (`c_json[500]`, `c_tjson[500]`, `u_json[500]`, `t_json[500]`) -- der FreeRTOS-Loop-Task hat 4096 Byte. Ueber die Kette `nrf52loop -> sendPosition -> sendExtern` fuehrte das zu Speicherkorruption, sichtbar als Muell in der seriellen Ausgabe, danach Absturz. `u_json`/`t_json` waren 1:1-Kopien und sind entfallen.

**4.2 Plattformbedingte Pufferbelegung fuer 4.1** (`extudp_functions.cpp`)
nRF52 bekommt `static char[500]` im BSS (4-KB-Stack), ESP32 behaelt den Stack-Puffer (verifiziert gegen `CONFIG_ARDUINO_LOOP_STACK_SIZE`).

**4.3 Stack-Overflow beim Nullen des CONF-Puffers, N-03** (`nrf52/nrf_eth.cpp`)
Im CONF-Zweig von `getUDP()` lief eine Nullungs-Schleife mit Laufindex ab 0, waehrend der Schreibindex zusaetzlich um die Paketlaenge versetzt war -- der Zugriff reichte bis `config_buf[packetSize-4+254]`.

**4.4 Stack-Overflow im Loop-Task auf dem Nachrichtenpfad, N-22** (`loop_functions.cpp`, `nrf52/nrf52_main.cpp`)
Der Loop-Task hat 4 KB (`LOOP_STACK_SZ`, hart im Adafruit-Core, nicht per Build-Flag ueberschreibbar). Der Pfad `checkSerialCommand() -> sendMessage() -> sendExtern()` erreichte mit aktivem EXTUDP `uxTaskGetStackHighWaterMark(NULL) == 0` -- Nachbar-RAM wurde ueberschrieben.

**4.5 `Radio.Send()` nicht mehr in `taskENTER_CRITICAL()`, N-16** (`lora_functions.cpp`)
Alle drei RAK4630-Sendepfade in `doTX()` umschlossen `Radio.Send()` kritisch. `Radio.Send()` ruft `SX126xWaitOnBusy()`, das bei `busy=HIGH` bis zu 1000x `delay(1)` aufruft. `delay()` haengt am FreeRTOS-Tick; `taskENTER_CRITICAL()` maskiert auf nRF52 Interrupts global, also auch den Tick -- die Schleife konnte nie ablaufen.

**4.6 Ethernet-Pfade blockieren den Loop nicht mehr ohne Link, N-20** (`nrf52/nrf52_main.cpp`, `nrf52/nrf_eth.cpp`)
`startETH()` prueft den Link jetzt **vor** dem blockierenden `Ethernet.begin(mac, 10000UL)`. Ohne Link war das ein 10-Sekunden-DHCP-Versuch gegen totes Kabel (in der W5100S-Bibliothek nichtdeterministisch auch minutenlang) -- und lief nicht nur im Setup, sondern wiederkehrend im Loop.

**4.7 EXTUDP/Webserver-Start ohne initialisiertes Ethernet, N-23** (`nrf52/nrf52_main.cpp`)
`--extudp on` bei Gateway **und** Webserver off brickt den Node ab dem naechsten Loop-Durchlauf -- dauerhaft, da gespeichert. Setup initialisiert die Ethernet-Hardware nur bei `bGATEWAY || bWEBSERVER`; der 15-Minuten-Restart-Block im Loop feuert wegen `web_timer == 0` aber sofort und ruft `startExternUDP()` auf dem nicht initialisierten W5100S.

**4.8 `printfdeb`-Familie blockiert nicht mehr auf vollem CDC-TX-FIFO** (`printfdeb_functions.cpp`)
`Adafruit_USBD_CDC::write()` spinnt in `while(remain && tud_cdc_n_connected()) { yield(); }` endlos, solange DTR gesetzt ist und der 256-Byte-TX-FIFO nicht abfliesst. Jeder Log-Aufruf fror dann den Loop ein. Jetzt wird verworfen statt gewartet, mit Zaehler.

**4.9 Flash-Reset wirkt jetzt wirklich, N-12** (`nrf52/nrf52_flash.cpp`)
`flash_reset()` liess `init_flash_done` stehen -- der zweite `init_flash()`-Aufruf nach `--cleanflash` war ein No-Op und `save_settings()` schrieb die alte RAM-Kopie zurueck, waehrend das Log "FLASH cleared new version" meldete. Dazu ein Groessen-Check gegen Layout-Drift.

**4.10 `--dfu` startet in den UF2-Bootloader** (`command_functions.cpp`, `loop_functions.cpp`, `loop_functions_extern.h`, `nrf52/nrf52_main.cpp`)
Der UF2-Bootloader war bisher nur ueber Doppeldruck auf Reset oder 1200-Baud-Touch erreichbar. Beides faellt aus, sobald die CDC-Verbindung haengt -- genau der beobachtete Fall: Board lief (BLE erreichbar, LoRa sendet und empfaengt), serielle Konsole tot, DFU-Upload mit `PortNotOpenError`. Uebrig blieb der physische Griff zum Geraet.

**4.11 `--dfu` haengt nicht mehr, N-19** (`nrf52/nrf52_main.cpp`)
`enterUf2Dfu()` rief `reset_mcu()` im Adafruit-Core, das zuerst `sd_softdevice_disable()` ausfuehrt. Aus dem Loop-Task gerufen blieb das Board mit stehender CPU zurueck. Jetzt ueber GPREGRET.

**4.12 Reset-Ursache beim Boot loggen** (`nrf52/nrf52_main.cpp`)
Eine Zeile: `[BOOT] RESETREAS=0x....` (0x1 Reset-Pin, 0x2 Watchdog, 0x4 Soft-Reset/SREQ -- auch der Weg des SoftDevice-Fault-Handlers nach einem App-Absturz, 0x8 Lockup). Unterscheidet nach einem unerwarteten Reboot sofort Absturz von Spannungsproblem. Bei der N-22-Diagnose war genau das der Schluessel.

**4.13 IP-Adresse dezimal statt als Roh-Integer** (`nrf52/nrf_eth.cpp`)
`printlndeb(Ethernet.localIP())` nahm die implizite `uint32_t`-Konvertierung und landete in der `int`-Ueberladung: das Log zeigte `1145350336` statt `192.168.68.68`.

**4.14 Abgedrifteter ACK-Level 0x02 aus der ESP32-Kopie portiert, DRY-21** (`nrf52/nrf_eth.cpp`)
Die UDP-Empfangslogik in `nrf_eth.cpp` ist eine Kopie von `udp_functions.cpp` und war beim ACK-Handling abgedriftet: die ESP32-Fassung stuft den ACK-Level an die App auf 0x02 hoch, wenn das ACK die eigene Nachricht bestaetigt; die nRF52-Kopie sendete weiterhin 0x01.

**4.15 `checkSerialCommand()`: NUL-Byte-Schutz und Self-Healing nachgezogen, DRY-22** (`nrf52/nrf52_main.cpp`)
Die Funktion existiert doppelt (ESP32/nRF52) und war auseinandergelaufen -- die ESP32-Fassung hatte zwei Fixes, die nRF52 nie bekam. UART-Rauschen (etwa eine unversorgte USB-UART-Bruecke im Batteriebetrieb) liefert 0x00, das `strlen()` nicht sieht.

**4.16 ADC-/Batterie-Guards von "nicht RAK4630" auf echte Plattform** (`adc_functions.cpp`, `batt_function_old.cpp`, `batt_functions.h`)
Drei Stellen nutzten `#ifndef BOARD_RAK4630` als Proxy fuer "ist ESP32" -- unter anderem der `#include <esp_adc_cal.h>`, also ESP-IDF-only Code hinter einem nRF52-Negativtest.

**4.17 20 Compiler-Warnungen in `src/` behoben** (`Regexp.cpp`, `aht20.cpp`, `aprs_functions.cpp`, `bmp390.cpp`, `extudp_functions.cpp`, `loop_functions.cpp`, `lora_functions.cpp`, `lora_setchip.cpp`, `nrf52/WisBlock-API.cpp`, `nrf52/nrf52_ble.cpp`, `nrf52/nrf52_main.cpp`)
Aufgeraeumt beim Durchgang mit `-Wall -Wextra` auf der nRF52-Seite. Die `-Werror`-Aktivierung selbst ist **nicht** Teil dieses PRs, die behobenen Warnungen schon.

---

## 5. ESP32: Boot, Watchdog, GPS

**5.1 Boot-Schleife an aktiven Gateways, WDT-01** (`udp_functions.cpp`)
Ein Heltec V3 mit Gateway/WebServer/ExtUDP/NetConsole und konfigurierter SSID haengt sich deterministisch ~10 s nach dem Boot auf: `task_wdt: Task watchdog got triggered ... loopTask`, `abort()`, Neustart -- Boot-Schleife. `startNetwork()` blockiert vor dem ersten Watchdog-Feed.

**5.2 Task-Watchdog erst am Ende von `esp32setup()` scharf** (`esp32/esp32_main.cpp`)
Der Watchdog wurde in der ersten Zeile von `esp32setup()` abonniert und ueberwachte damit die gesamte Einmal-Initialisierung, obwohl der urspruengliche Befund nur die Hauptschleife im Blick hatte. `setup()` fuehrt legitim sekundenlange Arbeit aus -- etwa bis zu 5000 ms Warten auf den USB-CDC-Monitor, was alle zwoelf Varianten mit `ARDUINO_USB_CDC_ON_BOOT=1` beim Start ohne Terminal trifft.

**5.3 Watchdog waehrend der GPS-Initialisierung fuettern** (`gps_functions.cpp`, neu: `watchdog_feed.h`)
`WZ_GPS_Init()` wird nicht aus `setup()` gerufen, sondern aus `esp32loop()` -- also aus genau dem Task unter Watchdog. Der Pfad blockierte ohne eine einzige Fuetterung: `detectBaudrate()` acht Baudraten zu je 1500 ms = 12 s, dazu `GPSprobe()` und `WaitPause()`.

**5.4 GPS-Baudscan bei gueltiger NMEA-Pruefsumme abbrechen, B-15** (`gps_functions.cpp`)
Der Scan lief immer alle acht Raten durch und entschied per Argmax ueber die Anzahl "passend aussehender" Zeichen -- ohne Mindestanzahl, also auch bei reinem Rauschen. Jetzt Abbruch bei der ersten gueltigen Pruefsumme.

**5.5 38400 Baud zuerst pruefen** (`gps_functions.cpp`)
Die Reihenfolge war mit der Verbreitung begruendet (9600 ist Werkseinstellung). Massgeblich ist aber der Lebenszyklus: `SetupL76K()` und `SetupUBLOX()` stellen das Modul beim ersten erfolgreichen Init auf 38400 und speichern das im Modul-Flash. 9600 trifft genau einmal zu.

**5.6 Tote ISR-Baudratenerkennung entfernt** (`gps_functions.cpp`, `command_functions.cpp`)
`gps_functions.cpp` trug zwei Implementierungen von `detectBaudrate()`. Die zweite schaetzte die Baudrate aus Flankenabstaenden im Interrupt, war der `#else`-Zweig eines Makros und wurde nie uebersetzt.

**5.7 Reboot bei fehlgeschlagener Radio-Initialisierung, atomares `scanFlag`, Task-Watchdog** (`esp32/esp32_main.cpp`)
Bisher lief der Knoten nach einem Radio-Init-Fehler ohne Funk weiter.

---

## 6. Sensorik, Batterie, Board-Guards

**6.1 `BOARD_*`-Guards testen Definiertheit statt Namensarithmetik, N-10** (`aht20.cpp`, `bmp390.cpp`, `bmx280.cpp`, `rtc_functions.cpp`, `sht21.cpp`)
`platformio.ini` definiert Board-Identitaeten als `-D BOARD_E22_S3="esp32-s3-devkitc-1-n16r8"`. PlatformIO verschluckt die Anfuehrungszeichen, der Compiler bekommt eine Bezeichnerfolge. Zwoelf Guards waren als `#if defined(BOARD_TBEAM_V3) || (BOARD_E22_S3)` geschrieben -- der zweite Operand ist kein `defined()`-Test, der Praeprozessor rechnet ueber die Namensbestandteile: `0-0-0-1-0 = -1`. Der Guard stimmte nur zufaellig, und eine geaenderte Ziffer im Boardnamen haette ihn gekippt.

**6.2 I2C-Bus-Reset-Guard zentralisiert, DRY-25** (`aht20.cpp`, `bmp390.cpp`, `bmx280.cpp`, `sht21.cpp`, `configuration_global.h`)
Die Bedingung fuer den Bus-Reset vor Sensorzugriffen (`Wire.end()` + `Wire.begin()`, sonst haengt der Bus) stand an neun Stellen in vier Dateien einzeln -- und war bereits auseinandergelaufen: `bmx280.cpp` fragte an zwei Stellen nur `BOARD_TBEAM_V3` ab, die anderen sieben zusaetzlich `BOARD_E22_S3`. Jetzt einmal als `MC_I2C_NEEDS_BUS_RESET`.

**6.3 BME680-Erkennung an die Chip-ID binden, N-27** (`bme680.cpp`)
`setupBME680()` prueft mit `Wire.beginTransmission(0x76)`, ob unter der Adresse jemand antwortet, und setzte daraufhin `bme680_found = true`. Der anschliessende `bme.begin()` wurde ohne Auswertung des Rueckgabewerts gerufen -- dabei ist genau das die Stelle, die die Chip-ID liest und einen BME680 von einem BME280/BMP280 unterscheidet. 0x76 und 0x77 teilen sich beide Familien.

**6.4 `--bmx off` vervollstaendigt, N-28** (`command_functions.cpp`)
Das Kommando war unvollstaendig implementiert.

**6.5 ADC_CTRL-Polaritaet beim Boot messen statt raten** (`batt_functions.cpp`, `batt_function_old.cpp`, `batt_functions.h`)
Der Umschalter fuer den Spannungsteiler wurde per `#if defined(BOARD_HELTEC_V31) || defined(BOARD_WIRELESS_PAPER)` gewaehlt. `BOARD_HELTEC_V31` ist im gesamten Baum **nirgends** definiert -- weder in `variants/*/configuration.h` noch in `platformio.ini` noch in `build_flags`. Es wurde ausschliesslich getestet. Der active-LOW-Zweig war damit tot. Jetzt wird die Polaritaet beim Boot einmal gemessen.

**6.6 `/B=` auch bei 0 Prozent senden, "kein Akku" davon trennen** (`batt_function_old.cpp`, `esp32/esp32_main.cpp`, `loop_functions.cpp`)
Befund aus einer Netzmessung ueber 1230 Stationen: "Akku fast leer" und "keine Batteriehardware" waren auf dem Draht nicht unterscheidbar. `mv_to_percent()` klemmt unterhalb `BAT_MIN_VOLTAGE` auf 0, und das `/B=`-Tag wurde nur `if(global_proz > 0)` geschrieben -- ein fast leerer Akku meldete gar nichts. Der Batteriegraph wird also genau dann leer, wenn man ihn braucht.

**6.7 Blockierendes `delay(100)` in `read_batt()`** (`batt_function_old.cpp`)
Der Heltec-V3/V4/Stick-Zweig schaltet den ADC-Spannungsteiler ein und wartet dessen Einschwingzeit mit einem blockierenden `delay(100)` ab. `read_batt()` wird alle ~500 ms aufgerufen -- die Hauptschleife stand damit dauerhaft rund ein Fuenftel der Zeit still. Auf Hardware gemessen: `[DBGSTALL] seg read_batt took 100617 us`.

---

## 7. Settings-Persistenz

**7.1 Settings nur bei echter Layout-Aenderung loeschen** (`configuration_global.h`, `esp32/esp32_main.cpp`, `nrf52/nrf52_main.cpp`)
Die Ruecksetzbedingung war `if(meshcom_settings.node_fversion != FLASH_VERSION || bClear) clear_flash();` -- und `FLASH_VERSION` ist ein Datum, das pro Release hochgezogen wird. Damit hat **jedes** Release die gespeicherte Konfiguration jedes aktualisierenden Knotens verworfen: Rufzeichen, WLAN-Zugangsdaten, Sensor- und Netzeinstellungen. Getrennt in `FLASH_VERSION` (Build-Kennung, rein informativ) und `FLASH_STRUCT_VERSION` (Layout-Generation, allein massgeblich fuer `clear_flash()`). Fuer Knoten, die noch ihr Build-Datum in `node_fversion` stehen haben, ist eine Uebergangsliste hinterlegt; sie waechst nicht weiter.

---

## 8. Diagnose und Mitschnitt

**8.1 Rohframe-Mitschnitt zur Laufzeit** (neu: `capture_functions.cpp` / `.h`, `command_functions.cpp`, `esp32/esp32_main.cpp`, `lora_functions.cpp`, `main.cpp`, `nrf52/nrf52_main.cpp`)
Das Log zeigt Frames nur **dekodiert** (`printBuffer_aprs`) -- also das Ergebnis des eigenen Parsers. Ein Frame, den der Decoder falsch liest, steht falsch geparst im Log; nichts darin verraet, was auf dem Kanal lag. Byte-exakt gab es nur den CRC-Dump der **verworfenen** Frames und einen Hex-Dump hinter `-D MC_TEST_HOOKS`, der in keinem Produktionsbuild einkompiliert war. `--txcapture` / `--rxcapture` legen die Rohbytes in einen Ring. Standardmaessig aus.

**8.2 Echte Paketlaenge auf ESP32, N-29** (`esp32/esp32_main.cpp`, `lora_functions.cpp`, `udp_functions.cpp`)
Vom Mitschnitt aus 8.1 bei seinem allerersten Lauf auf echter Hardware gefunden: `checkRX()` uebergab `size_t ibytes = UDP_TX_BUF_SIZE` (255) an `radio.readData()` und rechnete anschliessend mit 255 statt der tatsaechlichen Laenge. Jedem Empfang wurde die volle Puffergroesse als Airtime angerechnet -- die gemeldete Kanalauslastung lag um Faktor 2-4 zu hoch.

**8.3 `%%`-Verdopplung und Passwortmaskierung** (neu: `printfdeb_format.h`, neu: `mask_secret.h`, `printfdeb_functions.cpp`, `command_functions.cpp`, `command_functions.h`)
Die Formatierung ist in einen eigenen, von Arduino unabhaengigen Header getrennt; `%%` uebersteht den CSV-Durchlauf jetzt korrekt. `--info` druckte WLAN-PSK sowie Node- und Webserver-Passwort im Klartext.

**8.4 Dedup-Kern in eigene Uebersetzungseinheit** (neu: `dedup_functions.cpp` / `.h`, `loop_functions.cpp`, `loop_functions.h`, `loop_functions_extern.h`, `lora_functions.cpp`, `lora_functions.h`, `esp32/esp32_main.cpp`, `nrf52/nrf52_main.cpp`, `nrf52/nrf_eth.cpp`, `udp_functions.cpp`, `printfdeb_functions.cpp`, `printfdeb_functions.h`, `ring_index.h`, `capture_functions.cpp`)
Reine Verschiebung, Logik unveraendert -- gleiche Begruendung wie beim TX-Ring: die Funktionen greifen auf genau ein Array zu und haengen an nichts weiter. Dazu ein Zaehler fuer verlorene serielle Ausgabe (`serial_bytes` neben `CAPTURE_DROPPED`), damit der Mitschnitt sagt, wieviel er verloren hat.

**8.5 Capture-Hook in `OnRxDone()`** (`lora_functions.cpp`)
`OnRxDone()` ist auf beiden Plattformen der erste Punkt, den nur akzeptierte Frames erreichen -- das Gegenstueck zum bestehenden CRC-Dump der verworfenen.

**8.6 HEY-Signal-Report auch per UDP zum Server** (`aprs_functions.cpp`, `aprs_functions.h`, `lora_functions.cpp`)
Gateways laden HEY-Frames trotz `msg_server`-Flag hoch, aber die Payload ging roh raus: der Signal-Report (NCT, RSSI, SNR) wurde erst danach im Relay-Pfad angehaengt und erreichte nur die HF-Seite. Jetzt haengt das Gateway seinen Report vor `addNodeData()` an; der Relay-Pfad ueberspringt sein Append per Flag, der HF-Frame bleibt unveraendert.

**8.7 Sequenz-Heartbeat fuer Soak-Tests** (`extudp_functions.cpp`)
Compile-gateter Heartbeat (`MC_TEST_HOOKS`) in `getExternUDP()`: alle 500 ms ein Datagramm an den EXTUDP-Peer, bewusst aus dem Loop-Task auf genau dem Socket-Pfad, den ein Kabel-Flap trifft. Eine Luecke in der Sequenz zeigt von aussen, wann der Sendepfad stockte. Standardmaessig nicht einkompiliert.

---

## 9. Entdopplung und Aufraeumen

**9.1 HDOP-Zwillinge zusammengelegt, doppeltes `extern` entfernt, SIMP-30** (`loop_functions_extern.h`, `command_functions.cpp`, `esp32/esp32_main.cpp`, `gps_functions.cpp`, `loop_functions.cpp`, `nrf52/nrf52_main.cpp`, `t-deck-pro/tdeck_pro.cpp`, `t-deck-pro/ui_deckpro.cpp`, `t-deck/lv_obj_functions.cpp`, `web_functions/web_functions.cpp`)
`strSOFTSERAPP_ID` war zweimal deklariert. `posinfo_hdop` (int) und `fposinfo_hdop` (float) hielten denselben Wert doppelt -- mehrere Pfade schrieben nur eine der beiden Variablen, die Inkonsistenz war real, nicht theoretisch.

**9.2 Byte-identische Ringgroessen-Zweige zusammengelegt, ALT-33** (`configuration_global.h`)
Die Ringgroessen stehen in einer Leiter aus fuenf `#if`-Zweigen, einer je Speicherklasse. Die ersten beiden (`ENABLE_XML`, `ENABLE_SBUFFER`) waren byte-identisch. Kein Wert geaendert.

**9.3 "Node nicht konfiguriert" einmal definieren, ALT-34** (`configuration_global.h`, `esp32/esp32_main.cpp`, `nrf52/nrf52_main.cpp`, `safeboot/main.cpp`)
Der Test auf die Werkseinstellung des Rufzeichens stand an fuenf Stellen in drei Images -- und wurde unterschiedlich geprueft: Safeboot kannte vier Formen (`0x00`, `"none"`, `"XX0XXX"`, `"XX0XXX-00"`), ESP32 und nRF52 je drei, und eine vierte Stelle schrieb den Default erneut als Literal.

**9.4 `bOneButton` nicht mehr als Display-Invalidierung missbrauchen, ALT-35** (`loop_functions.cpp`, `loop_functions_extern.h`)
`bOneButton` bedeutet "der Benutzer hat die Taste gedrueckt". Zwei Stellen im Wireless-Paper-Track-Pfad setzten das Flag, um einen sofortigen Display-Neuaufbau zu erzwingen und das 15-Sekunden-Raster zu umgehen.

**9.5 Drei Compiler-Warnungen im ESP32-Zweig behoben** (`Regexp.cpp`, `net_console.cpp`)
2x `-Wclobbered` in `Regexp.cpp` und eine in `net_console.cpp`. Wie bei 4.17 ist nur die Warnungsbehebung Teil dieses PRs, nicht das Scharfschalten von `-Werror`.

---

## 10. Build-Konfiguration

**10.1 Kollidierende `[nrf52]`-Sections durch explizite `[nrf52_base]` ersetzt, CFG-01** (`platformio.ini`, `variants/wiscore_rak4631/platformio.ini`, `variants/heltec_t114/platformio.ini`, `variants/t_echo/platformio.ini`)
Alle drei nRF52-Variantendateien deklarierten eine gleichnamige Section `nrf52`. PlatformIO mergt gleichnamige Sections ueber alle `extra_configs` in Glob-Reihenfolge -- die Kopie aus `wiscore_rak4631` gewann und ihre Keys (`build_flags` inklusive `-D BOARD_RAK4630`, `build_src_filter` inklusive des wiscore-Variantenordners) sickerten still in `heltec_t114` und `t_echo`. Jede kuenftige Aenderung an einer dieser Sections haette dasselbe Verhalten gehabt. Der Block liegt jetzt einmal als `[nrf52_base]` in der Wurzel; die drei Varianten erben ihn explizit.

Das faktische Erben von `BOARD_RAK4630` und des Quellfilters durch `heltec_t114` und `t_echo` ist dabei **absichtlich beibehalten** -- das war auch vorher schon der Effekt des Merges. `BOARD_RAK4630` schaltet ueber 60 nRF52-Codestellen frei, und `t_echo` kompiliert dadurch die `variant.cpp` von `wiscore_rak4631` statt der eigenen. Das zu aendern braucht Verifikation auf dieser Hardware, nicht nur eine Config-Aufraeumung.

**10.2 nRF52-Plattform auf 10.12.0 gepinnt** (`variants/wiscore_rak4631/platformio.ini`, `variants/heltec_t114/platformio.ini`, `variants/t_echo/platformio.ini`)
Alle drei Boards hatten `platform = nordicnrf52` ohne Version. Welche Version ein Build tatsaechlich zieht, hing vom Cache- und Installationszustand ab -- CI und lokaler Build konnten gegen unterschiedliche Cores bauen.

---

## Verifikation

Alle 7 Standard-Targets bauen sauber gegen `dev` @ 2228d5ad:
`heltec_wifi_lora_32_V3`, `E22-DevKitC`, `ttgo_tbeam`, `ttgo_tbeam_supreme`, `t_deck`, `t_deck_plus`, `wiscore_rak4631`. Keine neuen Warnungen aus `src/`.

Die Aenderungen laufen seit Wochen auf produktiven Knoten: Heltec V3 als Gateway, RAK4631 mit RAK13800-Ethernet, T-Beam.

## Was bewusst nicht enthalten ist

Aus dem Fork wurden folgende Aenderungen **absichtlich weggelassen**, damit dieser PR nur Firmware anfasst:

- die Test-Infrastruktur und ihre sechs `[env:native*]`-Sections (sie brauchen `test/support/`)
- `-Werror` in `build_src_flags` fuer ESP32 und nRF52 -- die damit gefundenen Warnungen sind behoben, das Scharfschalten selbst ist eine Projektentscheidung
- ein Safeboot-Build-Hook, der ein Skript unter `tools/` referenziert
- `--port "$UPLOAD_PORT"` in 27 `variants/*/platformio.ini` (Entwicklerkomfort beim Flashen mit mehreren angeschlossenen Boards)
- das Loeschen zweier ungenutzter Dateien im Quellbaum (`src/code_review/code-audit-20260508.md`, `src/idf_component.yml.orig`)
- unser `FLASH_VERSION`-Builddatum -- der Wert bleibt auf dem Upstream-Stand, nur die Semantiktrennung aus 7.1 ist enthalten
- Doku, Analysewerkzeuge und Mitschnitte

Gern separat, falls Interesse besteht.
