### PR TITLE
fix(ble): FWDATE-Puffer zu klein -- snprintf schneidet die Sekunden ab

### DIFF
--- a/src/command_functions.cpp
+++ b/src/command_functions.cpp
@@ -4869,7 +4869,10 @@ void commandAction(char *umsg_text, bool ble)
             // Build-Datum als eigener Schluessel: FWVER traegt nur "4.35 p", damit sind
             // Sub-Releases fuer die App nicht unterscheidbar. FWVER selbst bleibt
             // unveraendert, damit bestehende Apps weiter damit rechnen koennen.
-            char cfwdate[20];
+            // 21 Byte Minimum: __DATE__ ("Mmm dd yyyy", 11) + ' ' + __TIME__
+            // ("hh:mm:ss", 8) + NUL. Mit [20] schnitt snprintf die letzte
+            // Sekundenstelle ab.
+            char cfwdate[24];
             snprintf(cfwdate, sizeof(cfwdate), "%s %s", __DATE__, __TIME__);
             idoc["FWDATE"] = cfwdate;
             idoc["CALL"] = meshcom_settings.node_call;


### PR DESCRIPTION
## Befund

`command_functions.cpp` legt fuer das mit 82db3d41 eingefuehrte FWDATE-Feld (BLE TYPE 'I') einen 20-Byte-Puffer an:

```c
char cfwdate[20];
snprintf(cfwdate, sizeof(cfwdate), "%s %s", __DATE__, __TIME__);
```

Der Platzbedarf ist aber 21 Byte:

| Bestandteil | Format       | Zeichen |
| ----------- | ------------ | ------: |
| `__DATE__`  | `Mmm dd yyyy`|      11 |
| Trennzeichen| `' '`        |       1 |
| `__TIME__`  | `hh:mm:ss`   |       8 |
| Terminator  | `'\0'`       |       1 |
| **Summe**   |              |  **21** |

`snprintf` kuerzt still auf 19 Zeichen plus NUL -- die letzte Sekundenstelle fehlt. Aus `Aug 27 2026 21:10:58` wird `Aug 27 2026 21:10:5`.

## Aenderung

Puffer auf 24 Byte, mit kurzem Kommentar zur Rechnung. Eine Zeile Code.

## Wie gefunden

Beim Build-Gate mit `-Wformat-truncation`:

```
src/command_functions.cpp:4967:48: warning: 'snprintf' output truncated
before the last format character [-Wformat-truncation=]
```

Auf der Standard-Warnstufe faellt das nicht auf.

## Verifikation

`heltec_wifi_lora_32_V3` und `wiscore_rak4631` bauen sauber, Warnung ist weg.
