### PR TITLE
Revert "Mheard-JSON: Puffergroesse an serializeJson uebergeben statt gemessener Laenge"

### DIFF
--- a/src/mheard_functions.cpp
+++ b/src/mheard_functions.cpp
@@ -345,13 +345,10 @@ void updateMheard(struct mheardLine &mheardLine, uint8_t isPhoneReady)
     // send to Phone
     uint8_t bleBuffer[MAX_MSG_LEN_PHONE] = {0};
     bleBuffer[0] = 0x44;
-    // Puffergroesse begrenzen, nicht die gemessene JSON-Laenge: serializeJson schreibt
-    // hoechstens so viele Bytes wie erlaubt und liefert die tatsaechlich geschriebene
-    // Anzahl zurueck. 1 Byte Header + Null-Terminator bleiben reserviert.
-    size_t json_len = serializeJson(mhdoc, bleBuffer+1, sizeof(bleBuffer)-1);
+    serializeJson(mhdoc, bleBuffer+1, measureJson(mhdoc)+1);
 
     if(isPhoneReady == 1)
-        addBLEOutBuffer(bleBuffer, json_len+1);
+        addBLEOutBuffer(bleBuffer, measureJson(mhdoc)+1);
 
     #if defined(BOARD_T_DECK) || defined(BOARD_T_DECK_PLUS)
 
@@ -656,10 +653,9 @@ void sendMheard()
                 // send to Phone
                 uint8_t bleBuffer[MAX_MSG_LEN_PHONE] = {0};
                 bleBuffer[0] = 0x44;
-                // wie oben: Puffergroesse begrenzen statt der gemessenen JSON-Laenge
-                size_t json_len = serializeJson(mhdoc, bleBuffer+1, sizeof(bleBuffer)-1);
+                serializeJson(mhdoc, bleBuffer+1, measureJson(mhdoc)+1);
 
-                addBLEComToOutBuffer(bleBuffer, json_len+1);
+                addBLEComToOutBuffer(bleBuffer, measureJson(mhdoc)+1);
             }
         }
     }


### PR DESCRIPTION
Reverts icssw-org/MeshCom-Firmware#1090