### PR TITLE
Fix: ADC_MULTIPLIER des Wireless Stick V3 korrigiert (4.9245 -> 4.13)

### DIFF
--- a/variants/heltec_wireless_stick/configuration.h
+++ b/variants/heltec_wireless_stick/configuration.h
@@ -69,7 +69,15 @@ definitions for HELTEC_V3
 #define BUTTON_PIN 0
 
 #define BATTERY_PIN 1 // A battery voltage measurement pin, voltage divider connected here to measure battery voltage
-#define ADC_MULTIPLIER 4.9245
+// Referenzmessung OE3LCR 2026-09-01 (Metrahit ISO, TRMS) am Wireless Stick V3:
+// Multimeter am Akku 4,093 V (unter Last) / 4,127 V (Leerlauf), Firmware zeigte 4,88 V
+// -> 19 % zu hoch. Am ADC-Pin liegen 991 counts = 798,6 mV, echtes Teilerverhaeltnis 5,125.
+// Korrekter Multiplikator: 4,9245 x 4093/4880 = 4,13. Der bisherige Wert 4,9245 ist identisch
+// mit dem des Vision Master E213 und wurde offenbar beim Anlegen dieser Variante uebernommen.
+// Mit 4,9245 faellt die Messung aus dem Plausibilitaetsband von battDetectUpdate()
+// (1,15 x MAXV) -> der Node meldete "keine Batteriehardware", BATT 0.00 V, kein /B= in den
+// APRS-Positionen. Siehe icssw-org/MeshCom-Firmware Issue #1116.
+#define ADC_MULTIPLIER 4.13
 
 #define USE_SX1262
 


### PR DESCRIPTION
## Was diese Änderung macht

`variants/heltec_wireless_stick/configuration.h`: `ADC_MULTIPLIER` von **4.9245 auf 4.13**
korrigiert, mit Begründung als Kommentar direkt an der Konstante.

Eine Zeile Code, acht Zeilen Kommentar — bewusst so, damit der Wert nicht beim nächsten
Anlegen einer Variante erneut ungeprüft übernommen wird.

## Warum

Der Wireless Stick V3 trägt bisher denselben Multiplikator wie der Vision Master E213
(4.9245). Für den Spannungsteiler des Stick V3 ist dieser Wert zu hoch.

**Referenzmessung** (OE3LCR, Metrahit ISO, TRMS-Multimeter, Akku 1S LiPo 3,7 V / 850 mAh):

| Messpunkt | Wert |
|---|---|
| Akku am Stick angeschlossen (unter Last) | **4,093 V** |
| Akku abgeklemmt (Leerlauf) | **4,127 V** |
| Firmware-Anzeige `--info` | 4,88 V |
| Firmware-Anzeige MeshCom-App | 4,78 V |

Die 34 mV zwischen Last und Leerlauf sind der Innenwiderstand der Zelle und unauffällig.
Die Firmware liegt dagegen **16,8 bis 19,2 % zu hoch**.

**Rechenweg.** Der Stick-Zweig in `batt_function_old.cpp` rechnet
`floatVoltage = ADC_MULTIPLIER * analogRead()` mit dem Ergebnis in mV:

```
4,9245 x 991 counts            = 4880 mV   (Anzeige)
991 counts / 4095 x 3300 mV    =  798,6 mV (tatsächlich am ADC-Pin)
4093 mV / 798,6 mV             =    5,125  (echtes Teilerverhältnis)
```

Aus 4,9245 folgt ein implizites Verhältnis von 6,111 — daher die Abweichung. Der korrekte
Multiplikator ergibt sich zu `4,9245 x 4093/4880 = 4,13`.

## Warum es jetzt auffällt

Die Fehlkalibrierung besteht seit Langem, war aber folgenlos, weil der zu hohe Wert einfach
angezeigt wurde. Seit `v4.35p.09.01` prüft `battDetectUpdate()` die Rohwerte gegen ein Band
von `0,55x .. 1,15x fBattMax`. Bei `MAXV 4,200` endet das Band bei **4,83 V** — die
gemessenen 4,88 V liegen 50 mV darüber und gelten als implausibel. Nach
`BATT_DETECT_ABSENT_STREAK` Messungen meldet der Node „keine Batteriehardware":

* `--info` zeigt dauerhaft `BATT 0.00 V / 0 %`
* die MeshCom-App zeigt keinen Batteriewert mehr
* `/B=` entfällt in den APRS-Positionen (`loop_functions.cpp`, zwei Stellen)

Die Plausibilitätsprüfung arbeitet dabei völlig korrekt — 4,88 V *kann* keine 1S-Zellenspannung
sein (Ladeschluss 4,2 V). Sie hat den Kalibrierfehler aufgedeckt, nicht verursacht.

## Verifikation am Gerät

Getestet auf OE3LCR-20 (Heltec Wireless Stick V3, `NODE 42 <STICK_V3>`), Firmware-Stand
`898ff7e`:

| | vorher (4.9245) | nachher (4.13) |
|---|---|---|
| `--info` | `BATT 0.00 V / 0 %` | `BATT 4.11 V / 87 %` |
| Verlauf über 30 s | konstant 0,00 V | 4,11 – 4,12 V |
| MeshCom-App | kein Wert | 4,13 V |
| Multimeter | 4,093 V | 4,093 V |

Die verbleibende Differenz von ~30 mV erklärt sich dadurch, dass der Akku während der
Messreihe am USB weiterlädt; die Multimeter-Messung stammt vom Beginn der Reihe.

## Abgrenzung

Der Wert stammt aus zwei Referenzmessungen an **einem** Exemplar, nicht aus dem Schaltplan.
Wer die Bestückung des Teilers kennt, sollte den exakten Sollwert gegenprüfen; eine
Gegenprobe an einem zweiten Stick wäre wegen Bauteiltoleranz wünschenswert.

Diese Änderung behebt **nicht** den zweiten in #1116 beschriebenen Punkt: Die
ADC-Polaritätsprobe entscheidet auf dem Stick V3 weiterhin per Rauschen und setzt in einem
Teil der Starts `BATT_PROBE_NONE`. Weil `battHardwarePresent()` auch daran hängt, kann `/B=`
in diesen Fällen trotz korrekter Anzeige weiterhin fehlen. Das ist bewusst nicht Teil dieses
PRs, da es fremden, frisch gemergten Code berührt — der Lösungsvorschlag steht in #1116.
