### PR TITLE
fix: QRS erst ab der dritten eigenen Nachricht bei Ringtiefe >= 5

### DIFF
--- a/src/backpressure.h
+++ b/src/backpressure.h
@@ -19,7 +19,10 @@
 // Episode model (operator decision 2026-08-30, QRS threshold and QRV gating
 // revised 2026-08-31 after a gateway field measurement):
 //   - QRS once when the queue genuinely builds (depth >= 5, fixed across
-//     boards, independent of MAX_RING; the gateway baseline sits at 1-4).
+//     boards, independent of MAX_RING; the gateway baseline sits at 1-4) AND
+//     the sender has put at least 3 messages of their own onto that
+//     already-full ring (QRS_MIN_USER_MSGS, 2026-09-01: depth alone counts
+//     relay/ACK/beacon traffic and warned the sender on their first message).
 //     DK5EN-98 2026-08-31: a 5.5-minute normal-operation capture with no
 //     burst in sight showed baseline depth 1-4 (mode 2) and three false
 //     QRS/QRV pairs under the old rule (depth > 1, i.e. > QUIET_DEPTH),
@@ -187,6 +190,17 @@ public:
     /// 5 on every ring size (10/20/30), not a percentage of MAX_RING.
     static const int QRS_MIN_DEPTH = 5;
 
+    /// How many locally originated user messages must land on a ring that is
+    /// already at/above qrsThreshold() before QRS fires. Operator decision
+    /// 2026-09-01: txRingDepth() counts relay frames, ACKs and beacons too, so
+    /// a gateway idling at depth 4 handed the very first typed message a QRS
+    /// for a queue the sender had not built. onSend() is called exactly once
+    /// per typed message and never for relay/ACK/beacon traffic, so counting
+    /// its calls counts the sender's own contribution. The counter restarts
+    /// whenever the ring is seen below qrsThreshold() again -- a sender whose
+    /// messages drain between keystrokes is not the problem.
+    static const int QRS_MIN_USER_MSGS = 3;
+
     explicit BackPressure(int max_ring) { configure(max_ring); }
 
     /// (Re)bind to a ring size and drop any running episode.
@@ -202,6 +216,7 @@ public:
         latch_        = BP_NOTICE_NONE;
         quiet_armed_  = false;
         quiet_since_  = 0;
+        qrs_user_msgs_ = 0;
     }
 
     int maxRing() const { return max_ring_; }
@@ -269,6 +284,10 @@ public:
         if(depth > QUIET_DEPTH)
             quiet_armed_ = false;
 
+        // Below the QRS line the sender's own run is over (QRS_MIN_USER_MSGS).
+        if(depth < qrsThreshold())
+            qrs_user_msgs_ = 0;
+
         // A real drop is the most specific news there is, so it outranks the
         // plain threshold notice — and it always implies the refusal state.
         if(dropped)
@@ -293,6 +312,14 @@ public:
             // an already-open QRT episode is untouched by this branch (the
             // guard above keeps state_ at BP_QRT) and still only releases at
             // the quiet band below, same as before.
+            //
+            // QRS_MIN_USER_MSGS: the first two typed messages that find the
+            // ring at/above the line stay silent -- the depth may be relay
+            // traffic the sender did not cause. An open QRT episode dipping
+            // through this band is unaffected either way: state_ stays
+            // BP_QRT (guard below) and its latch already sits above QRS.
+            if(++qrs_user_msgs_ < QRS_MIN_USER_MSGS)
+                return BP_NOTICE_NONE;
             if(state_ != BP_QRT)
                 state_ = BP_QRS;
             return latchIfHigher(BP_NOTICE_QRS);
@@ -325,6 +352,12 @@ public:
     {
         if(depth < 0)
             depth = 0;
+
+        // Same rule as onSend(): a ring seen below the QRS line ends the
+        // sender's own run (QRS_MIN_USER_MSGS). The drain poll is where that
+        // sighting usually happens, between two typed messages.
+        if(depth < qrsThreshold())
+            qrs_user_msgs_ = 0;
 
         if(depth > QUIET_DEPTH)
         {
@@ -400,6 +433,7 @@ private:
     BpNotice latch_;
     bool     quiet_armed_;
     uint32_t quiet_since_;
+    int      qrs_user_msgs_;
 };
 
 #endif // __cplusplus


### PR DESCRIPTION
## Was wurde geaendert

### `src/backpressure.h` -- QRS-Feinjustierung (eine Datei, 35 Zeilen inkl. Kommentare)

- Neue Konstante `BackPressure::QRS_MIN_USER_MSGS = 3` neben `QRS_MIN_DEPTH`.
- Neues Member `qrs_user_msgs_`, in `reset()` auf 0 gesetzt.
- `onSend()`: bei `depth < qrsThreshold()` wird der Zaehler auf 0 gesetzt; im QRS-Zweig
  (`depth >= qrsThreshold()`) wird er hochgezaehlt und QRS erst gemeldet, wenn er
  `QRS_MIN_USER_MSGS` erreicht. Vorher: `return BP_NOTICE_NONE`, ohne `state_`/Latch anzufassen.
- `poll()`: derselbe Reset bei `depth < qrsThreshold()`, damit ein Ring, der zwischen zwei
  getippten Nachrichten abfliesst, die Zaehlung ebenfalls beendet.
- QRT, QTA, Latch, Hysterese und QRV-Hold sind unveraendert. `loop_functions.cpp` ist nicht
  betroffen.

## Warum

`txRingDepth()` zaehlt alles im TX-Ring: Relay-Frames, ACKs, Beacons, fremden Chat. Auf einem
Gateway liegt die Grundlast im Normalbetrieb bei Tiefe 1 bis 4. Sitzt der Ring wegen
Mesh-Verkehr bei 4, macht die erste eigene Nachricht die 5 voll, und der Absender bekommt
`QRS - slow down, TX buffer is filling` fuer einen Stau, den er nicht verursacht hat.
Feldbefund vom 2026-09-01: "QRS ist auch mit Schwelle 5 viel zu empfindlich und kommt schon bei
der ersten Nachricht."

`onSend()` wird genau einmal pro lokal getippter Nachricht aufgerufen und nie fuer
Relay/ACK/Beacon. Die Zustandsmaschine kann dort also ohne Ringzugriff die eigenen Nachrichten
des Absenders zaehlen.

**QRS kommt jetzt, wenn drei eigene Nachrichten in Folge den Ring bei Tiefe >= 5 vorfinden.**
Faellt der Ring zwischendurch unter 5, weil die Funke abarbeitet, beginnt die Zaehlung von vorn.
Konkret:

- Ring bei 4 durch Mesh-Verkehr, Absender tippt eine Nachricht: Tiefe 5, still.
- Zweite Nachricht kurz danach: Tiefe 6, still.
- Dritte Nachricht: QRS, wie bisher einmal pro Episode.
- Wer so langsam tippt, dass zwischen zwei Nachrichten der Ring unter 5 faellt, bekommt kein QRS.
- QRT (Abweisen ab 80 % von `MAX_RING`) und QTA (Verwerfen) werden weiterhin sofort gemeldet,
  auch bei der ersten Nachricht. Das sind echte Ereignisse, keine Warnung.

## Getestet

- Gebaut auf diesem Branch (upstream/dev `e9b293f7` + Patch): `heltec_wifi_lora_32_V3` und
  `wiscore_rak4631`, beide SUCCESS.
- Im Fork zusaetzlich alle 32 Release-Envs gebaut und die Host-Tests der Zustandsmaschine
  (34 Faelle, davon 4 neue fuer diese Regel) gruen; Tests sind nicht Teil dieses PRs.
- Hardware: Heltec V3 als Live-Gateway (DK5EN-98) laeuft den Build seit 2026-09-01 per OTA.
  Ein gezielter Burst gegen die Drei-Nachrichten-Regel wurde auf Hardware noch nicht gefahren.

## Hinweise fuer den Reviewer

- Reiner Header-Eingriff, keine API-Aenderung, keine neuen Aufrufer.
- Der Zaehler ist absichtlich kein Zeitfenster: "drei in Folge bei vollem Ring" braucht keine
  Zeitkonstante und reicht fuer den Feldbefund. Sollte sich die Regel als zu lasch zeigen, waere
  ein Zeitfenster (z. B. 3 Nachrichten in 60 s) mit `now_ms` in `onSend()` in drei Zeilen
  nachruestbar.
