### PR TITLE
Fix: ADC-Polaritätsprobe erkennt fest anliegenden Spannungsteiler (Wireless Stick V3)

### DIFF
--- a/src/batt_function_old.cpp
+++ b/src/batt_function_old.cpp
@@ -346,7 +346,17 @@ static void battProbeADCPolarity(uint32_t ctrlPin, uint32_t vbatPin)
 	for (int i = 0; i < 8; i++) { countsLow += analogRead(vbatPin); }
 	countsLow /= 8;
 
-	if (countsHigh >= BATT_PROBE_MIN_COUNTS && countsHigh > countsLow)
+	int probeDelta = countsHigh - countsLow;
+	if (probeDelta < 0) probeDelta = -probeDelta;
+	if (countsHigh >= BATT_PROBE_MIN_COUNTS && countsLow >= BATT_PROBE_MIN_COUNTS && probeDelta < BATT_PROBE_MIN_COUNTS)
+	{
+		// Beide Messungen plausibel und praktisch gleich: der Teiler liegt fest an, der
+		// Steuerpin bewirkt nichts (z.B. Wireless Stick V3). Batteriehardware vorhanden,
+		// Polaritaet ohne Bedeutung -> nicht als "kein Teiler" fehlinterpretieren.
+		battProbeState = BATT_PROBE_ACTIVE_HIGH;
+		digitalWrite(ctrlPin, LOW);
+	}
+	else if (countsHigh >= BATT_PROBE_MIN_COUNTS && countsHigh > countsLow)
 	{
 		battProbeState = BATT_PROBE_ACTIVE_HIGH;
 		digitalWrite(ctrlPin, LOW);    // Ruhezustand: Teiler getrennt (Strom sparen)
@@ -362,6 +372,7 @@ static void battProbeADCPolarity(uint32_t ctrlPin, uint32_t vbatPin)
 	}
 
 	printfdeb("[INIT]...ADC_CTRL_PIN probe: high=%d;low=%d;-> %s\n", countsHigh, countsLow,
+		(battProbeState == BATT_PROBE_ACTIVE_HIGH && probeDelta < BATT_PROBE_MIN_COUNTS && countsLow >= BATT_PROBE_MIN_COUNTS) ? "fester Teiler (active HIGH)" :
 		(battProbeState == BATT_PROBE_ACTIVE_HIGH) ? "active HIGH" :
 		(battProbeState == BATT_PROBE_ACTIVE_LOW)  ? "active LOW"  : "keine Batteriehardware (kein Teiler)");
 }

--- a/src/batt_functions.cpp
+++ b/src/batt_functions.cpp
@@ -154,7 +154,17 @@ static void battProbeADCPolarity(void)
 	for (int i = 0; i < 8; i++) { countsLow += analogRead(BAT_VOLT_PIN); }
 	countsLow /= 8;
 
-	if (countsHigh >= BATT_PROBE_MIN_COUNTS && countsHigh > countsLow)
+	int probeDelta = countsHigh - countsLow;
+	if (probeDelta < 0) probeDelta = -probeDelta;
+	if (countsHigh >= BATT_PROBE_MIN_COUNTS && countsLow >= BATT_PROBE_MIN_COUNTS && probeDelta < BATT_PROBE_MIN_COUNTS)
+	{
+		// Beide Messungen plausibel und praktisch gleich: der Teiler liegt fest an, der
+		// Steuerpin bewirkt nichts (z.B. Wireless Stick V3). Batteriehardware vorhanden,
+		// Polaritaet ohne Bedeutung -> nicht als "kein Teiler" fehlinterpretieren.
+		battProbeState = BATT_PROBE_ACTIVE_HIGH;
+		digitalWrite(ADC_CTRL_PIN, LOW);
+	}
+	else if (countsHigh >= BATT_PROBE_MIN_COUNTS && countsHigh > countsLow)
 	{
 		battProbeState = BATT_PROBE_ACTIVE_HIGH;
 		digitalWrite(ADC_CTRL_PIN, LOW);    // Ruhezustand: Teiler getrennt (Strom sparen)
@@ -170,6 +180,7 @@ static void battProbeADCPolarity(void)
 	}
 
 	printfdeb("[INIT]...ADC_CTRL_PIN probe: high=%d;low=%d;-> %s\n", countsHigh, countsLow,
+		(battProbeState == BATT_PROBE_ACTIVE_HIGH && probeDelta < BATT_PROBE_MIN_COUNTS && countsLow >= BATT_PROBE_MIN_COUNTS) ? "fester Teiler (active HIGH)" :
 		(battProbeState == BATT_PROBE_ACTIVE_HIGH) ? "active HIGH" :
 		(battProbeState == BATT_PROBE_ACTIVE_LOW)  ? "active LOW"  : "keine Batteriehardware (kein Teiler)");
 }


### PR DESCRIPTION
Behebt #1123 (Befund 1 aus #1116).

## Was diese Änderung macht

`battProbeADCPolarity()` bekommt in **beiden** Fassungen (`src/batt_functions.cpp` und
`src/batt_function_old.cpp`, der Block ist identisch) einen zusätzlichen Zweig, der einen
**fest anliegenden Spannungsteiler** erkennt, bevor über die Polarität entschieden wird:

```c
int probeDelta = countsHigh - countsLow;
if (probeDelta < 0) probeDelta = -probeDelta;
if (countsHigh >= BATT_PROBE_MIN_COUNTS && countsLow >= BATT_PROBE_MIN_COUNTS && probeDelta < BATT_PROBE_MIN_COUNTS)
{
    battProbeState = BATT_PROBE_ACTIVE_HIGH;
    digitalWrite(ADC_CTRL_PIN, LOW);
}
else if (...)   // bisherige Zweige unverändert
```

Liegen **beide** Probe-Messwerte über `BATT_PROBE_MIN_COUNTS` und unterscheiden sich um weniger
als diese Schwelle, ist ein Teiler bestückt, dessen Steuerpin nichts bewirkt. Dann gilt
„Batteriehardware vorhanden", die Polarität ist ohne Bedeutung. Die drei bisherigen Zweige
(`ACTIVE_HIGH`, `ACTIVE_LOW`, `NONE`) bleiben unverändert und werden nur noch erreicht, wenn die
Messwerte sich tatsächlich unterscheiden. Die Log-Zeile beim Boot weist den neuen Fall als
`fester Teiler (active HIGH)` aus.

Als Schwelle wird bewusst die vorhandene Konstante `BATT_PROBE_MIN_COUNTS` (50 Zähler ≈ 200 mV)
wiederverwendet: Boards mit echtem Schalter liegen bei ≥ 957 Zählern Abstand, der feste Teiler
bei ≤ 4. Dazwischen ist reichlich Luft, eine neue Konstante wäre nicht gerechtfertigt.

## Warum

Auf dem **Heltec Wireless Stick V3** (`BOARD_STICK_V3`) erbt `ADC_CTRL_PIN 37` aus dem
gemeinsamen `#if` mit `BOARD_HELTEC_V3`/`BOARD_HELTEC_V4` in `batt_function_old.cpp`. Am Stick
bewirkt dieser Pin messbar nichts, beide Probe-Messungen liefern denselben Wert. Die bisherige
Entscheidung kennt nur „einer ist größer" oder „keiner ist plausibel"; bei exaktem Gleichstand
fällt sie in den `else`-Zweig und setzt `BATT_PROBE_NONE`, obwohl beide Werte mit ~962 Zählern
weit über der Plausibilitätsschwelle liegen.

**Auswirkung:** `battHardwarePresent()` liefert `false`, `/B=` entfällt in den
APRS-Positionen (`loop_functions.cpp`, zwei Stellen) – still, bis zum nächsten Neustart, und
seit #1119 bei korrekter Batterieanzeige, also im Feld kaum erkennbar. Über 12 Neustarts trat
das in 8,3 % der Fälle auf, in einer zweiten Serie mit ruhigerer Zellenspannung in 2 von 3
Starts – je stabiler die Messung, desto häufiger der Gleichstand.

Boards mit echtem Schalter sind nicht betroffen (Wireless Paper `high=11 low=2489`, Vision
Master E213 `high=957 low=0`) und ändern ihr Verhalten durch diesen PR nicht.

## Verifikation

**Simulation** über die gemessenen Wertepaare aller drei Boards und synthetische Randfälle
(floatender Eingang `3/5`, Grenzfall `50/50`, Ausreißer `80/4`): Bei echten Schaltern keine
Verhaltensänderung; der Gleichstand landet auf „fester Teiler" statt `NONE`; ein wirklich
floatender Eingang bleibt `NONE`.

**Am Gerät** (OE3LCR-20, Wireless Stick V3, Akku 1S LiPo 3,7 V / 850 mAh), 12 aufeinanderfolgende
Neustarts:

| Boot | high | low | Ergebnis |
|---:|---:|---:|---|
| 1–12 | 971–972 | 971–972 | fester Teiler (active HIGH) |

12/12 konsistent; sieben davon mit exaktem Gleichstand `971/971`, die vorher `NONE` ergeben
hätten. Anzeige `BATT 4.12 V / 87 %`. **`/B=087` ist wieder in der Bake:**

```
NEW-POS  ... OE3LCR-20>*!4748.78N/01614.18E>GW OE3LCR-20#KFZ | Christian/B=087/A=000876/N4/...
TX-LoRa  ... /B=087/...
[NEW-UDP] ... /B=087/...
```

per LoRa gesendet, per UDP zum Server, von OE3LCR-55 zurückgehört.

**Builds** mit dem aktuellen `-Werror`: `heltec_wireless_stick` (nutzt `batt_function_old.cpp`)
und `wireless-paper` (nutzt `batt_functions.cpp`) fehlerfrei.

## Abgrenzung

Ein floatender Eingang mit einem einzelnen hohen Ausreißer (z.B. `80/4`) wird heute schon als
`ACTIVE_HIGH` gewertet. Das ist vorbestehendes Verhalten außerhalb dieses PRs.

Ob `ADC_CTRL_PIN` für `BOARD_STICK_V3` überhaupt definiert sein sollte, lasse ich bewusst
offen: Der Stick-Messzweig ruft `digitalWrite(ADC_CTRL_PIN, …)` an vier Stellen direkt auf,
ein Entfernen des Defines wäre also ein größerer Umbau. Dieser PR behebt das konkrete Symptom
mit minimalem Eingriff.
