### PR TITLE
feat: GPS-Kalmanfilter, T-Deck-Tastaturwiederholung und Logging-Instrumentierung

### DIFF
--- a/src/bme680.cpp
+++ b/src/bme680.cpp
@@ -1,5 +1,6 @@
 #include "configuration.h"
 #include "loop_functions_extern.h"
+#include "gps_functions.h"
 
 #if defined (ENABLE_BMX680)
 
@@ -206,7 +207,7 @@ float getPressASL680(int current_alt)
 	//fBaseAltidude = (float)meshcom_settings.node_alt;
 	//fBasePress = meshcom_settings.node_press;
 	//
-	if(fBaseAltidude680 == 0)
+	if(fBaseAltidude680 == 0 && baroBaseLatchAllowed())
 		fBaseAltidude680 = (float)current_alt;
 
 	return meshcom_settings.node_press / powf(1 - ((0.0065 * fBaseAltidude680) /

--- a/src/bmx280.cpp
+++ b/src/bmx280.cpp
@@ -1,6 +1,7 @@
 #include "configuration.h"
 #include "loop_functions.h"
 #include "loop_functions_extern.h"
+#include "gps_functions.h"
 
 #if defined (ENABLE_BMX280)
 
@@ -323,7 +324,7 @@ float getPressASL(int current_alt)
 	//fBasePress = meshcom_settings.node_press;
 	
 	// 
-	if(fBaseAltidude == 0)
+	if(fBaseAltidude == 0 && baroBaseLatchAllowed())
 		fBaseAltidude = (float)current_alt;
 
 	return fPress / powf(1 - ((0.0065 * fBaseAltidude) /

--- a/src/command_functions.cpp
+++ b/src/command_functions.cpp
@@ -774,7 +774,7 @@ void commandAction(char *umsg_text, bool ble)
 
             printlndeb("--btcode 999999 BT-Code\n--button gpio 99 User-Button PIN\n--analog gpio 99 Analog PIN\n--analog factor 9.9 Analog factor\n--analog check on/off\n");
             delay(100);
-            printfdeb("--pos      show lat/lon/alt/time info\n--weather  show temp/hum/press\n--sendpos  send pos info now\n--setlat   set latitude 44.12345\n--setlon   set logitude 016.12345\n--setalt   set altidude 9999m\n");
+            printfdeb("--pos      show lat/lon/alt/time info\n--weather  show temp/hum/press\n--sendpos  send pos info now\n--setlat   set latitude 44.12345\n--setlon   set logitude 016.12345\n--setalt   set altidude 9999m, with GPS: seeds the altitude filter, GPS keeps refining\n");
             delay(100);
             printlndeb("--symid  set prim/sec Sym-Table\n--symcd  set table column\n--aprscomment  set APRS Comment/none\n--showI2C\n");
             delay(100);
@@ -2293,7 +2293,10 @@ void commandAction(char *umsg_text, bool ble)
     else
     if(commandCheck(msg_text+2, (char*)"setpress") == 0)
     {
-        fBaseAltidude = (float)meshcom_settings.node_alt;
+        // GPS-04/F9: nicht direkt schreiben -- baroBaseRelatch() zieht JEDE
+        // vorhandene Basishoehe nach (BMx280 und BME680), der direkte Griff
+        // auf fBaseAltidude liess die des BME680 stehen.
+        baroBaseRelatch((float)meshcom_settings.node_alt);
         fBasePress = meshcom_settings.node_press;
 
         printfdeb("\nBase Press set to: %.1f at %.1f m\n", fBasePress, fBaseAltidude);
@@ -4125,10 +4128,28 @@ void commandAction(char *umsg_text, bool ble)
         snprintf(_owner_c, sizeof(_owner_c), "%s", msg_text+9);
         sscanf(_owner_c, "%d", &iVar);
 
+        // GPS-03/F7: Ein Tippfehler darf die Hoehe nicht auf 0 klemmen -- das
+        // hat frueher den Schaetzer auf 0 m geseedet UND die barometrische
+        // Referenz auf 0 m nachgezogen. Unbrauchbare Eingabe wird verworfen.
         if(iVar < 0 || iVar > 40000)
-            iVar = 0;
+        {
+            printfdeb("alt out of range (0..40000 m), ignored\n");
+
+            if(ble)
+            {
+                addBLECommandBack((char*)msg_text);
+            }
+
+            return;
+        }
 
         meshcom_settings.node_alt=iVar;
+
+        #ifdef ENABLE_GPS
+        WZ_GPS_AltSeed((float)iVar);
+        #else
+        baroBaseRelatch((float)iVar);
+        #endif
 
         printfdeb("set alt to %i m\n", meshcom_settings.node_alt);
 
@@ -5798,6 +5819,14 @@ void commandAction(char *umsg_text, bool ble)
             
             printfdeb("...DisplayInfo %s ...DisplayCont %s ...DisplyLog %s ...contrast %i\n",
                 (bDisplayInfo?"on":"off"), (bDisplayCont?"on":"off"), (bDisplayLog?"on":"off"), meshcom_settings.node_contrast);
+
+            #if defined(BOARD_T_DECK) || defined(BOARD_T_DECK_PLUS)
+            // TD-10: raw-mode verdict of the keyboard controller. "no" or a
+            // lasting "unknown" after typing means the controller firmware
+            // predates raw mode and keys cannot auto-repeat on this unit.
+            printfdeb("...KBD raw-mode %s ...KEYLOCK %s\n", tdeck_kbd_raw_support_str(),
+                (meshcom_settings.node_keyboardlock?"on":"off"));
+            #endif
 
             printfdeb("...EXTUDP %s ...EXT IP %s ...NOPMOTHER %s\n", (bEXTUDP?"on":"off"), meshcom_settings.node_extern,
                     ((meshcom_settings.node_sset3 & 0x8000)?"on":"off"));

--- a/src/esp32/esp32_main.cpp
+++ b/src/esp32/esp32_main.cpp
@@ -138,6 +138,7 @@ Arduino_GFX *gfx = new Arduino_ST7796(
 #include <mheard_functions.h>
 #include <time_functions.h>
 #include <clock.h>
+#include <setlog_lines.h> // SL-04/SL-05: --setlog on line formatters (Welle 0)
 #include <onewire_functions.h>
 #include <onebutton_functions.h>
 #include <adc_functions.h>
@@ -612,6 +613,26 @@ float getTempForNTC()
 //=======================================================================================
 
 
+// TM-51: name of the last reset cause for the boot banner. A field reboot without
+// this line is indistinguishable from a power cycle (see bug-GPS-uart-overflow §3.3).
+static const char* resetReasonName(esp_reset_reason_t r)
+{
+    switch (r)
+    {
+        case ESP_RST_POWERON:   return "POWERON";
+        case ESP_RST_EXT:       return "EXT";
+        case ESP_RST_SW:        return "SW";
+        case ESP_RST_PANIC:     return "PANIC";
+        case ESP_RST_INT_WDT:   return "INT_WDT";
+        case ESP_RST_TASK_WDT:  return "TASK_WDT";
+        case ESP_RST_WDT:       return "WDT";
+        case ESP_RST_DEEPSLEEP: return "DEEPSLEEP";
+        case ESP_RST_BROWNOUT:  return "BROWNOUT";
+        case ESP_RST_SDIO:      return "SDIO";
+        default:                return "UNKNOWN";
+    }
+}
+
 void esp32setup()
 {
     ///< Initialize T5-EPAPER GUI
@@ -712,6 +733,13 @@ void esp32setup()
     printlndeb("============");
     printlndeb("CLIENT SETUP");
     printlndeb("============");
+
+    // TM-51: reset cause, raw Serial.printf so it survives --debug off (nRF52 prints
+    // [BOOT] RESETREAS=... at the same point).
+    {
+        esp_reset_reason_t rr = esp_reset_reason();
+        Serial.printf("[BOOT] RESET_REASON=%d %s\n", (int)rr, resetReasonName(rr));
+    }
 
     lFreeHeap =  ESP.getFreeHeap();
     lFreePsram = ESP.getFreePsram();
@@ -2098,10 +2126,14 @@ void esp32loop()
         // Deferred display update from OnRxDone (avoid I2C inside radio callback)
         flushDeferredDisplayUpdates();
 
-        // Channel utilization report (every 10s)
+        // Channel utilization report (every 10s). SL-05: the drain of
+        // ch_util_rx_accum/tx_accum below feeds stat_util_rx_5m/tx_5m for the
+        // 5-minute STAT line (--setlog on), so the 10-s tick itself must not
+        // depend on bLORADEBUG any more -- only the diagnostic prints still
+        // do, unchanged from before. The 10-s accumulation math is untouched.
         {
             static unsigned long ch_util_timer = 0;
-            if(bLORADEBUG && (millis() - ch_util_timer) > 10000)
+            if((millis() - ch_util_timer) > 10000)
             {
                 unsigned long window = millis() - ch_util_timer;
                 ch_util_timer = millis();
@@ -2109,13 +2141,18 @@ void esp32loop()
                 unsigned long tx_ms = ch_util_tx_accum.exchange(0);
                 unsigned int util = (unsigned int)((rx_ms + tx_ms) * 100 / window);
                 if(util > 100) util = 100;
-                printfdeb("[MC-DBG] CHANNEL_UTIL rx=%lums tx=%lums util=%u%%\n",
-                    rx_ms, tx_ms, util);
-                // ONRXDONE stats: report max and warn count, then reset
-                printfdeb("[MC-DBG] ONRXDONE_STATS max=%lums warn=%u (>%dms)\n",
-                    onrxdone_max_ms, onrxdone_warn_count, ONRXDONE_WARN_MS);
-                onrxdone_max_ms = 0;
-                onrxdone_warn_count = 0;
+                stat_util_rx_5m.fetch_add((uint32_t)rx_ms);
+                stat_util_tx_5m.fetch_add((uint32_t)tx_ms);
+                if(bLORADEBUG)
+                {
+                    printfdeb("[MC-DBG] CHANNEL_UTIL rx=%lums tx=%lums util=%u%%\n",
+                        rx_ms, tx_ms, util);
+                    // ONRXDONE stats: report max and warn count, then reset
+                    printfdeb("[MC-DBG] ONRXDONE_STATS max=%lums warn=%u (>%dms)\n",
+                        onrxdone_max_ms, onrxdone_warn_count, ONRXDONE_WARN_MS);
+                    onrxdone_max_ms = 0;
+                    onrxdone_warn_count = 0;
+                }
             }
         }
 
@@ -2123,6 +2160,25 @@ void esp32loop()
         if((millis() - stat_prio_timer) > (unsigned long)(PRIO_STAT_INTERVAL_S * 1000UL))
         {
             stat_prio_timer = millis();
+
+            // SL-05: STAT line under --setlog on, independent of bLORADEBUG.
+            // setlogFillStat() reads stat_drop_count[] before the existing
+            // (unconditional) memset further below resets it -- no second
+            // reset here. The interval counters are drained on every tick
+            // (so they never grow unbounded); only the print depends on
+            // bDisplayLog.
+            {
+                struct setlogStatFields f;
+                setlogFillStat(&f, (uint32_t)ESP.getFreeHeap());
+
+                if(bDisplayLog)
+                {
+                    char buf[300];
+                    setlogFormatStat(buf, sizeof(buf), &f);
+                    setlogPrint(buf);
+                }
+            }
+
             if(bLORADEBUG)
             {
                 printfdeb("[MC-STAT] t=%ds qmax=%d/%d\n",
@@ -2176,6 +2232,9 @@ void esp32loop()
             {
                 printfdeb("[MC-WDT] TX_WATCHDOG fired after %lums — forcing RX recovery\n",
                     millis() - _tx_s);
+
+                // SL-05: abort counter for the STAT block's txfail=.
+                stat_txfail.fetch_add(1);
 
                 ch_util_tx_start = 0;
                 transmittedFlag   = false;
@@ -3076,6 +3135,10 @@ void esp32loop()
         gps_refresh_intervall = 1.0;
     }
 
+    #ifdef ENABLE_GPS
+    if (bGPSON && gpsDetected) { INSTR_SECTION("gps_feed"); WZ_GPS_Feed(); }
+    #endif
+
     if ((uint32_t)(millis() - gps_refresh_timer) >= ((unsigned long)gps_refresh_intervall * 1000))
     {
         #ifdef ENABLE_GPS
@@ -3174,7 +3237,7 @@ void esp32loop()
             // aktuell geladene Kachel verlassen hat, und bei Bedarf nachladen -
             // nur solange der Kartenbildschirm auch tatsaechlich sichtbar ist.
             static unsigned long sdmap_boundary_timer = 0;
-            if ((sdmap_boundary_timer + 30000UL) < millis())
+            if ((uint32_t)(millis() - sdmap_boundary_timer) >= 30000UL)   // N-08 idiom, rollover-safe
             {
                 sdmap_boundary_timer = millis();
 
@@ -4120,6 +4183,19 @@ int checkRX(bool bRadio)
 
         // RX channel utilization: CRC-failed packet still occupied the channel
         ch_util_rx_accum.fetch_add(radio.getTimeOnAir(ibytes) / 1000);  // us -> ms
+
+        // SL-04: CRC/RX error, platform-independent counter for the STAT
+        // block (SL-05) and the ERR line under --setlog on. checkRX() runs
+        // in loop() context here (called from esp32loop()), so a local
+        // stack buffer is unproblematic.
+        stat_rx_err.fetch_add(1);
+        if(bDisplayLog)
+        {
+            char buf[300];
+            setlogFormatErr(buf, sizeof(buf), saved_crc_rssi, saved_crc_snr,
+                            (uint16_t)ibytes, (int32_t)saved_crc_ferr, millis());
+            setlogPrint(buf);
+        }
 
         // Diagnose-Output: RSSI/SNR + kompletter Payload-Hex-Dump
         if(bLORADEBUG)

--- a/src/gps_filter.cpp
+++ b/src/gps_filter.cpp
@@ -1,0 +1,104 @@
+/*
+ * Pure altitude / plausibility helpers for the GPS path.
+ * No Arduino dependencies: this file also builds on the host.
+ */
+
+#include "gps_filter.h"
+
+#include <math.h>
+
+void altFilterReset(struct AltFilter *f)
+{
+    f->init = false;
+}
+
+void altFilterSeed(struct AltFilter *f, float alt)
+{
+    f->x       = alt;
+    f->P       = ALT_KF_P0;
+    f->rejects = 0;
+    f->init    = true;
+}
+
+bool altFilterUpdate(struct AltFilter *f, float meas, uint32_t dt_ms)
+{
+    if (!f->init)
+    {
+        altFilterSeed(f, meas);
+        return true;
+    }
+
+    float innov = meas - f->x;
+
+    if (fabsf(innov) > ALT_KF_GATE_M)
+    {
+        f->rejects++;
+        if (f->rejects >= ALT_KF_RESEED_N)
+        {
+            altFilterSeed(f, meas);
+            return true;
+        }
+        return false;
+    }
+
+    /* GPS-03/F2: the process noise is a rate, not a per-call constant. Without
+     * this the 1 s evaluation cadence of the nRF52 build injects three times
+     * the noise per second of the 3 s ESP32 cadence and the estimator's time
+     * constant falls inside the 60-120 s error-correlation time of the
+     * receiver. A long gap (module silent, node asleep) is capped so a single
+     * update cannot blow P up. */
+    if (dt_ms > ALT_KF_DT_MAX_MS)
+        dt_ms = ALT_KF_DT_MAX_MS;
+
+    f->rejects = 0;
+    f->P += ALT_KF_Q * ((float)dt_ms / (float)ALT_KF_DT_REF_MS);
+
+    float K = f->P / (f->P + ALT_KF_R);
+    f->x += K * innov;
+    f->P *= (1.0f - K);
+
+    return true;
+}
+
+bool altFilterConverged(const struct AltFilter *f)
+{
+    return f->init && f->P < ALT_KF_P_CONV;
+}
+
+bool gpsDatePlausible(int year, int month, int day)
+{
+    if (month < 1 || month > 12)
+        return false;
+    if (day < 1 || day > 31)
+        return false;
+    if (year < 2024 || year > 2099)
+        return false;
+
+    return true;
+}
+
+bool gpsTimePlausible(int hour, int minute, int second)
+{
+    if (hour < 0 || hour > 23)
+        return false;
+    if (minute < 0 || minute > 59)
+        return false;
+    /* 60 is a legal leap second; TinyGPS++ never emits 61, but the range is
+     * the one struct tm documents. */
+    if (second < 0 || second > 60)
+        return false;
+
+    return true;
+}
+
+bool gpsSamplePlausible(double lat, double lon, double alt, int year, int month, int day)
+{
+    if (lat == 0.0 || lon == 0.0)
+        return false;
+    if (fabs(lat) > 90.0 || fabs(lon) > 180.0)
+        return false;
+    if (!(alt >= GPS_ALT_MIN_M && alt <= GPS_ALT_MAX_M))   /* also rejects NaN */
+        return false;
+
+    return gpsDatePlausible(year, month, day);
+}

--- a/src/gps_filter.h
+++ b/src/gps_filter.h
@@ -1,0 +1,65 @@
+#ifndef _GPS_FILTER_H_
+#define _GPS_FILTER_H_
+
+/*
+ * Pure altitude / plausibility helpers for the GPS path.
+ * No Arduino dependencies: this file also builds on the host.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/* Scalar Kalman filter on the GPS altitude, constant measurement noise. */
+#define ALT_KF_Q        0.01f   /* process noise per update, tau ~ 410 s at 3 s cadence */
+#define ALT_KF_R        185.0f  /* measurement noise (m^2), (4 m * 1.7 * 2.0)^2          */
+#define ALT_KF_P0       400.0f  /* initial covariance after a seed                        */
+#define ALT_KF_GATE_M   15.0f   /* innovation gate: larger jumps are rejected             */
+#define ALT_KF_RESEED_N 10      /* consecutive rejects that re-seed the filter            */
+#define ALT_KF_P_CONV   2.5f    /* P below this value = converged                          */
+#define ALT_KF_DT_REF_MS  3000u /* cadence ALT_KF_Q is expressed for (one ESP32 cycle)     */
+#define ALT_KF_DT_MAX_MS 60000u /* dt clamp: a longer gap injects no more process noise    */
+
+/* Plausible altitude range of a terrestrial fix (m above MSL). */
+#define GPS_ALT_MIN_M   (-500.0)
+#define GPS_ALT_MAX_M   (10000.0)
+
+struct AltFilter
+{
+    float   x;        /* altitude estimate (m) */
+    float   P;        /* estimate covariance (m^2) */
+    uint8_t rejects;  /* consecutive gate rejections */
+    bool    init;     /* seeded */
+};
+
+/* init = false; nothing else is touched */
+void altFilterReset(struct AltFilter *f);
+/* x = alt, P = ALT_KF_P0, rejects = 0, init = true */
+void altFilterSeed(struct AltFilter *f, float alt);
+/*
+ * One measurement; returns false when the sample was rejected by the gate.
+ *
+ * dt_ms is the wall time since the previous update. The process noise is
+ * injected proportionally (ALT_KF_Q per ALT_KF_DT_REF_MS), so it tracks wall
+ * time instead of call count. R is per sample, so a residual cadence
+ * dependence of sqrt(dt) remains: tau ~ 236 s at a 1 s cadence (nRF52) and
+ * ~ 408 s at 3 s (ESP32), instead of the factor 3 (136 s) without scaling.
+ * dt_ms is clamped to ALT_KF_DT_MAX_MS; pass ALT_KF_DT_REF_MS when the
+ * elapsed time is unknown.
+ */
+bool altFilterUpdate(struct AltFilter *f, float meas, uint32_t dt_ms);
+/* init && P < ALT_KF_P_CONV */
+bool altFilterConverged(const struct AltFilter *f);
+
+/* Calendar values the NMEA parser can plausibly have produced. */
+bool gpsDatePlausible(int year, int month, int day);
+/* Wall-clock values the NMEA parser can plausibly have produced (s <= 60: leap second). */
+bool gpsTimePlausible(int hour, int minute, int second);
+
+/*
+ * Plausibility of a decoded fix. Rejects null island (lat or lon exactly 0.0),
+ * angles out of range, altitudes outside GPS_ALT_MIN_M..GPS_ALT_MAX_M, and
+ * calendar values the parser cannot have produced.
+ */
+bool gpsSamplePlausible(double lat, double lon, double alt, int year, int month, int day);
+
+#endif /* _GPS_FILTER_H_ */

--- a/src/gps_functions.cpp
+++ b/src/gps_functions.cpp
@@ -14,6 +14,10 @@
 
 #include "gps_functions.h"
 
+#include "gps_filter.h"
+
+#include "printfdeb_functions.h"
+
 #include "watchdog_feed.h"
 
 #include <clock.h>
@@ -58,6 +62,13 @@ no more in use
 static HardwareSerial GPSSerial(1);  // UART1
 #endif
 
+// GPS-06: Die wirksamen UART-Pins. Voreinstellung sind die Pins der Variante;
+// ein Board mit GPS_FALLBACK_RX_PIN/GPS_FALLBACK_TX_PIN (T-Deck ohne Plus)
+// wechselt in detectBaudrate() auf die Zweitbelegung, wenn auf der ersten kein
+// NMEA-Satz zu finden ist. Alle spaeteren begin()-Aufrufe nutzen diese Werte.
+static int8_t s_gpsRxPin = GPS_RX_PIN;
+static int8_t s_gpsTxPin = GPS_TX_PIN;
+
 GPSData gpsData;
 
 // Baudrate-Erkennung. Die Reihenfolge ist nach Trefferwahrscheinlichkeit
@@ -86,6 +97,19 @@ bool updateGPSdata;
 #define maxNMEAline MAX_MSG_LEN_PHONE * 2
 int NMEAlineIndex = 0;
 char c;
+
+// GPS-02: Stichproben, die die Plausibilitaetspruefung verworfen hat.
+static uint16_t s_gpsRejectCount = 0;
+
+// GPS-03: Hoehenschaetzer. Der Zustand haelt zwischen den Auswertungen; die
+// Logik selbst liegt Arduino-frei in gps_filter.cpp.
+static struct AltFilter s_alt;
+// Flanke "erstmals konvergiert seit dem letzten Seed" -- sie loest das
+// Nachziehen der barometrischen Referenzhoehe aus.
+static bool s_altConvergedOnce = false;
+// millis() der letzten in den Schaetzer eingespeisten Hoehe. 0 = unbekannt
+// (erste Auswertung nach dem Start/Reset), dann gilt die Nennkadenz.
+static uint32_t s_altLastMs = 0;
 
 unsigned long detectedBaud = 0;
 String ver = "";
@@ -197,14 +221,11 @@ static bool nmeaCheckFeed(struct NMEAframeCheck *nc, char ch)
     return false;
 }
 
-unsigned long detectBaudrate()
+// Ein Durchlauf ueber alle Baudraten auf den aktuell wirksamen Pins.
+// Liefert den Index der ersten Baudrate mit gueltigem NMEA-Satz, sonst -1.
+static int gpsScanBauds()
 {
-    #if defined(GPS_BAUDRATE_SETFIX)
-        return GPS_BAUDRATE_SETFIX;
-    #endif
-
     int ipos = -1;      // Index der Baudrate mit gueltigem NMEA-Satz
-    uint32_t tScan = millis();
 
     // Vollstaendig zuruecksetzen: der Scan bricht jetzt vorzeitig ab, sonst
     // stuenden in den restlichen Eintraegen die Zaehlerstaende des letzten
@@ -218,7 +239,7 @@ unsigned long detectBaudrate()
         Serial1.begin(GPS_BAUDS[iGpsBaud]);
         Serial1.flush();
         #else
-        GPSSerial.begin(GPS_BAUDS[iGpsBaud], SERIAL_8N1, GPS_RX_PIN, GPS_TX_PIN);
+        GPSSerial.begin(GPS_BAUDS[iGpsBaud], SERIAL_8N1, s_gpsRxPin, s_gpsTxPin);
         GPSSerial.flush();
         #endif
 
@@ -291,6 +312,58 @@ unsigned long detectBaudrate()
         if(bFrameOK)
             ipos = iGpsBaud;
     }
+
+    return ipos;
+}
+
+unsigned long detectBaudrate()
+{
+    #if defined(GPS_BAUDRATE_SETFIX)
+        return GPS_BAUDRATE_SETFIX;
+    #endif
+
+    uint32_t tScan = millis();
+
+    // Jede Erkennung beginnt auf den Pins der Variante -- auch "--gps reset"
+    // nach einem Umverdrahten.
+    s_gpsRxPin = GPS_RX_PIN;
+    s_gpsTxPin = GPS_TX_PIN;
+
+    int ipos = gpsScanBauds();
+
+    #if defined(GPS_FALLBACK_RX_PIN) && defined(GPS_FALLBACK_TX_PIN)
+    // GPS-06: Bis 4.35d hat der T-Deck ohne Plus per SoftwareSerial auf
+    // GPIO43 empfangen und auf GPIO44 gesendet; seit 4.35p (a672d18b) ist es
+    // umgekehrt, wie beim T-Deck Plus und in der LilyGo-Belegung. Ein selbst
+    // verdrahtetes Modul nach alter Belegung ist seither stumm. Ein zweiter
+    // Durchlauf auf der alten Belegung kostet einmalig bis zu 12 s und nur,
+    // wenn der erste nichts gefunden hat.
+    if(ipos < 0)
+    {
+        Serial.printf("[GPS ]...nichts auf RX=%d TX=%d, zweiter Versuch auf RX=%d TX=%d (Belegung bis 4.35d)\n",
+                      (int)GPS_RX_PIN, (int)GPS_TX_PIN, (int)GPS_FALLBACK_RX_PIN, (int)GPS_FALLBACK_TX_PIN);
+
+        s_gpsRxPin = GPS_FALLBACK_RX_PIN;
+        s_gpsTxPin = GPS_FALLBACK_TX_PIN;
+        pinMode(s_gpsRxPin, INPUT);
+        pinMode(s_gpsTxPin, OUTPUT);
+
+        ipos = gpsScanBauds();
+
+        if(ipos >= 0)
+        {
+            Serial.printf("[GPS ]...Modul auf RX=%d TX=%d gefunden -- bitte Draehte tauschen, Standard ist RX=%d TX=%d\n",
+                          (int)s_gpsRxPin, (int)s_gpsTxPin, (int)GPS_RX_PIN, (int)GPS_TX_PIN);
+        }
+        else
+        {
+            s_gpsRxPin = GPS_RX_PIN;
+            s_gpsTxPin = GPS_TX_PIN;
+            pinMode(s_gpsRxPin, INPUT);
+            pinMode(s_gpsTxPin, OUTPUT);
+        }
+    }
+    #endif
 
     gpsDetected = false;
 
@@ -812,7 +885,12 @@ void WZ_GPS_Init()
   WZ_GPS_Reset();
 
   gpsInitDone = true;
-  
+
+  // GPS-03: Neue Sitzung, neuer Schaetzer.
+  altFilterReset(&s_alt);
+  s_altConvergedOnce = false;
+  s_altLastMs = 0;
+
   Serial.printf("[GPS ]...Init GPIO RX=%d TX=%d\n", GPS_RX_PIN, GPS_TX_PIN);
   
   #if defined(USE_HELTEC_T114) or defined(BOARD_T_ECHO)
@@ -841,7 +919,7 @@ void WZ_GPS_Init()
     #if defined(USE_HELTEC_T114) or defined(BOARD_T_ECHO)
     Serial1.begin(detectedBaud);
     #else
-    GPSSerial.begin(detectedBaud,SERIAL_8N1,GPS_RX_PIN,GPS_TX_PIN);
+    GPSSerial.begin(detectedBaud,SERIAL_8N1,s_gpsRxPin,s_gpsTxPin);
     #endif
 
     gpsDetected = true;
@@ -863,24 +941,20 @@ void WZ_GPS_Init()
 
 
 /**
- * @brief Non-blocking GPS-Update. In jedem loop()-Durchlauf aufrufen.
+ * @brief GPS-01: UART leeren und in den Parser fuettern. In JEDEM
+ *        loop()-Durchlauf aufrufen.
  *
- * Liest alle verfuegbaren Bytes von der GPS-UART und fuettert 
- * in den TinyGPS++ Parser. Aktualisiert gpsData wenn neue Daten da sind.
+ * Der Ringpuffer der Arduino-UART fasst 256 Byte. Bei 38400 Baud liefert ein
+ * Modul das in rund 65 ms; die Auswertung in WZ_GPS_Loop() laeuft aber nur
+ * alle gps_refresh_intervall Sekunden. Wer erst dort liest, verliert den
+ * groessten Teil jeder Sekunde an Ueberlauf -- und ein Ueberlauf mitten im
+ * Satz erzeugt zusammengesetzte Zeilen, die die NMEA-Pruefsumme zufaellig
+ * passieren koennen. Deshalb ist das Leeren vom Auswerten getrennt.
  */
-int WZ_GPS_Loop() {
-
-    int igps = POSINFO_INTERVAL;
-
-    if(iGPSDEBUG > 2)
-    {
-      Serial.printf("[GPS ]...igps: %i\n", igps);
-    }
-
-    if (!gpsDetected) return igps;
-
-    NMEAlineIndex = 0;
-    memset(msg_text, 0x00, maxNMEAline);
+void WZ_GPS_Feed()
+{
+    if (!gpsDetected)
+        return;
 
     // Alle verfuegbaren Bytes lesen (non-blocking)
     #if defined(USE_HELTEC_T114) or defined(BOARD_T_ECHO)
@@ -897,28 +971,65 @@ int WZ_GPS_Loop() {
 
         if (gps.encode(char(ic))) { updateGPSdata = true; }
 
+        // NMEA-Echo. msg_text ist der globale Kommandopuffer -- diese Schleife
+        // laeuft in jedem loop()-Durchlauf, ein memset() darauf waere nicht
+        // vertretbar. Ab Debugstufe 3 wird zeilenweise gesammelt und bei '\n'
+        // genau einmal ausgegeben; darunter bleiben msg_text und
+        // NMEAlineIndex vollstaendig unberuehrt.
         if(iGPSDEBUG > 2)
         {
-          // TODO: nicht einzeln ausgeben, sondern sammeln in LineBuffer
-          // und erst ausgeben, wenn ein Satz vollständig ist \r\n
-          if (NMEAlineIndex < (int)maxNMEAline-2) {
-              msg_text[NMEAlineIndex] = char(ic);
-              NMEAlineIndex++;
-          }
+            if(ic != '\r' && ic != '\n' && NMEAlineIndex < (int)(maxNMEAline) - 2)
+            {
+                msg_text[NMEAlineIndex] = char(ic);
+                NMEAlineIndex++;
+            }
+
+            if(ic == '\n' || NMEAlineIndex >= (int)(maxNMEAline) - 2)
+            {
+                if(NMEAlineIndex > 0)
+                {
+                    msg_text[NMEAlineIndex] = 0x00;
+                    Serial.printf("[GPS ]...NMEA: %s\n", msg_text);
+                }
+
+                NMEAlineIndex = 0;
+            }
         }
     }
+}
+
+/**
+ * @brief Auswertung des zuletzt Gelesenen. Laeuft auf dem eigenen Takt
+ *        (gps_refresh_intervall).
+ *
+ * Das Leeren der UART liegt in WZ_GPS_Feed(); hier wird nur noch bewertet,
+ * was der Parser inzwischen zusammengesetzt hat, sobald updateGPSdata gesetzt
+ * ist.
+ */
+int WZ_GPS_Loop() {
+
+    int igps = POSINFO_INTERVAL;
+
+    if(iGPSDEBUG > 2)
+    {
+      Serial.printf("[GPS ]...igps: %i\n", igps);
+    }
+
+    if (!gpsDetected) return igps;
 
     if (updateGPSdata)
     {
-        if(iGPSDEBUG > 2)
-        {
-            Serial.printf("[GPS ]...NMEABuffer size:%i\n%s\n", NMEAlineIndex, msg_text);
-        }
-
         // GPS-Daten in unsere Struktur uebertragen
         gpsData.valid      = gps.location.isValid();
         gpsData.latitude   = gps.location.lat();
         gpsData.longitude  = gps.location.lng();
+
+        // GPS-03/F6: isUpdated() muss VOR meters() gelesen werden -- der
+        // Zugriff auf den Wert loescht das Flag. updateGPSdata setzt jeder
+        // beliebige Satz; ohne diese Abfrage speist ein GGA mit Fixqualitaet 0
+        // oder leerem Hoehenfeld den alten Wert erneut in den Filter und
+        // schrumpft P auf einer Stichprobe ohne Informationsgehalt.
+        bool altNew        = gps.altitude.isUpdated();
         gpsData.altitude   = gps.altitude.meters();
         gpsData.satellites = gps.satellites.value();
         gpsData.hdop       = gps.hdop.hdop();
@@ -956,25 +1067,53 @@ int WZ_GPS_Loop() {
 
         bool has_gnss_location=false;
 
-        if ((fposinfo_hdop < 6.0) && (posinfo_satcount > 5))
+        // GPS-02: HDOP und Satellitenzahl sagen nichts darueber aus, ob der
+        // Satz UNVERSEHRT ist. Ein aus zwei Haelften zusammengesetzter Satz
+        // kann die Pruefsumme zufaellig passieren und liefert dann Null-Insel
+        // oder einen unmoeglichen Kalender. Solche Stichproben nehmen ab hier
+        // den bestehenden Zweig ohne Fix.
+        bool bPlausible = gpsSamplePlausible(gpsData.latitude, gpsData.longitude, gpsData.altitude,
+                                             (int)gpsData.year, (int)gpsData.month, (int)gpsData.day);
+
+        if ((fposinfo_hdop < 6.0) && (posinfo_satcount > 5) && bPlausible)
         {
             has_gnss_location = true;
             posinfo_fix = true;
         }
         else
         {
+            if((fposinfo_hdop < 6.0) && (posinfo_satcount > 5) && !bPlausible)
+            {
+                if(s_gpsRejectCount < 0xFFFF)
+                    s_gpsRejectCount++;
+
+                if(iGPSDEBUG > 0)
+                    printfdeb("[GPS ]...reject: lat:%.6lf lon:%.6lf date:%04d.%02d.%02d n:%u\n",
+                              gpsData.latitude, gpsData.longitude,
+                              (int)gpsData.year, (int)gpsData.month, (int)gpsData.day,
+                              (unsigned int)s_gpsRejectCount);
+            }
+
             posinfo_fix = false;
         }
-        
+
         if (WZ_GPS_HasFix() && has_gnss_location)
         {
             // time -> variables
-            if(gpsData.year > 2023)
+            //
+            // GPS-02/F1: Bei einem gespleissten RMC kann der Datumsteil heil
+            // durchkommen, waehrend der Zeitteil zerstoert ist ("1834" wird zu
+            // 00:18:34, "999999.99" zu h=99). mktime() nimmt beides
+            // widerspruchslos an -- nur eine eigene Bereichspruefung faengt es
+            // ab, bevor die Systemzeit verstellt wird.
+            if(gpsData.year > 2023 && gps.time.isValid()
+               && gpsDatePlausible((int)gpsData.year, (int)gpsData.month, (int)gpsData.day)
+               && gpsTimePlausible((int)gpsData.hour, (int)gpsData.minute, (int)gpsData.second))
             {
                 MyClock.setCurrentTime(meshcom_settings.node_utcoff, gpsData.year, gpsData.month, gpsData.day, gpsData.hour, gpsData.minute, gpsData.second);
                 snprintf(cTimeSource, sizeof(cTimeSource), (char*)"GPS");
             }
-                
+
             meshcom_settings.node_date_year = MyClock.Year();
             meshcom_settings.node_date_month = MyClock.Month();
             meshcom_settings.node_date_day = MyClock.Day();
@@ -1019,7 +1158,48 @@ int WZ_GPS_Loop() {
             else
                 meshcom_settings.node_lat_c='N';
 
-            meshcom_settings.node_alt = (int)gpsData.altitude;
+            // GPS-03: Die Rohhoehe eines Consumer-Empfaengers streut um
+            // mehrere Meter. Im Ruhezustand glaettet ein skalarer
+            // Kalman-Filter das; in TRACK bewegt sich der Knoten und eine
+            // Zeitkonstante von Minuten waere dort ein Fehler.
+            if(bDisplayTrack)
+            {
+                altFilterReset(&s_alt);
+                s_altConvergedOnce = false;
+                s_altLastMs = 0;
+
+                meshcom_settings.node_alt = (int)gpsData.altitude;
+            }
+            else
+            {
+                // GPS-03/F2: Das Prozessrauschen ist eine Rate. Die Auswertung
+                // laeuft auf nRF52 im Sekundentakt, auf ESP32 im
+                // Dreisekundentakt; ohne dt waere die Zeitkonstante dort ein
+                // Drittel. F6: nur eine WIRKLICH neue Hoehe darf einspeisen.
+                if(altNew)
+                {
+                    uint32_t nowMs = millis();
+                    uint32_t dtMs  = (s_altLastMs == 0) ? ALT_KF_DT_REF_MS : (nowMs - s_altLastMs);
+                    s_altLastMs    = nowMs;
+
+                    if(altFilterUpdate(&s_alt, (float)gpsData.altitude, dtMs))
+                        meshcom_settings.node_alt = (int)lroundf(s_alt.x);
+                }
+
+                // Flanke: erst ab hier ist die Hoehe gut genug, um die
+                // barometrische Referenz darauf festzunageln.
+                if(!s_altConvergedOnce && altFilterConverged(&s_alt))
+                {
+                    s_altConvergedOnce = true;
+
+                    baroBaseRelatch(s_alt.x);
+
+                    if(iGPSDEBUG > 0)
+                        printfdeb("[GPS ]...alt converged: %d m (P=%.1f)\n",
+                                  (int)lroundf(s_alt.x), (double)s_alt.P);
+                }
+            }
+
             if(meshcom_settings.node_alt < 0)
                 meshcom_settings.node_alt = 0;
 
@@ -1030,7 +1210,12 @@ int WZ_GPS_Loop() {
         else
         {
             // time -> variables
-            if(gpsData.year > 2024)
+            // GPS-02/F1: gleiche Bereichspruefung wie im Fix-Zweig -- dieser
+            // Pfad nimmt gerade die Stichproben auf, die das
+            // Plausibilitaets-Gate verworfen hat.
+            if(gpsData.year > 2024 && gps.time.isValid()
+               && gpsDatePlausible((int)gpsData.year, (int)gpsData.month, (int)gpsData.day)
+               && gpsTimePlausible((int)gpsData.hour, (int)gpsData.minute, (int)gpsData.second))
             {
                 MyClock.setCurrentTime(meshcom_settings.node_utcoff, gpsData.year, gpsData.month, gpsData.day, gpsData.hour, gpsData.minute, gpsData.second);
                 snprintf(cTimeSource, sizeof(cTimeSource), (char*)"GPS");
@@ -1056,9 +1241,33 @@ int WZ_GPS_Loop() {
 }
 
 /**
- * @brief 
- * 
- * @return true | false 
+ * @brief GPS-03: Hoehenschaetzer auf einen bekannten Wert setzen (--setalt).
+ *
+ * Der Wert ist ein Startpunkt, keine Festlegung: das GPS verfeinert danach
+ * weiter. Die barometrische Referenz wird sofort nachgezogen, weil der
+ * Bediener hier mehr weiss als der Empfaenger.
+ */
+void WZ_GPS_AltSeed(float alt)
+{
+    altFilterSeed(&s_alt, alt);
+    s_altConvergedOnce = false;
+    s_altLastMs        = 0;
+
+    baroBaseRelatch(alt);
+}
+
+/**
+ * @brief GPS-03: true, sobald die Kovarianz unter ALT_KF_P_CONV liegt.
+ */
+bool WZ_GPS_AltConverged()
+{
+    return altFilterConverged(&s_alt);
+}
+
+/**
+ * @brief
+ *
+ * @return true | false
  */
 bool WZ_GPS_HasFix() {
     return gpsInitDone && gpsData.valid && gpsData.age_ms < 5000;
@@ -1142,3 +1351,52 @@ void WZ_L76Kreset() {
 
 
 #endif // ENABLE_GPS
+
+// ---------------------------------------------------------------------------
+// GPS-04: barometrische Referenzhoehe
+//
+// Die Drucksensoren rechnen ihren Messwert mit einer Basishoehe auf
+// Meeresniveau um und nageln diese Basis beim ersten Aufruf fest. Mit GPS ist
+// der erste Wert der erste Rohfix -- also genau der schlechteste, den die
+// Sitzung zu bieten hat. Die beiden Helfer verschieben das: gelatcht wird
+// erst, wenn der Hoehenschaetzer konvergiert ist, und --setalt zieht die
+// Referenz sofort nach.
+//
+// Beide Funktionen sind auf JEDEM Board uebersetzt -- ein Board kann einen
+// Drucksensor ohne GPS haben. Ohne ENABLE_GPS erlaubt der Latch wie bisher
+// den ersten Wert.
+// ---------------------------------------------------------------------------
+
+void baroBaseRelatch(float alt)
+{
+    #if defined(ENABLE_BMX280)
+    fBaseAltidude = alt;
+    #endif
+
+    #if defined(ENABLE_BMX680)
+    fBaseAltidude680 = alt;
+    #endif
+
+    #if !defined(ENABLE_BMX280) && !defined(ENABLE_BMX680)
+    (void)alt;   // kein Drucksensor an Bord
+    #endif
+}
+
+bool baroBaseLatchAllowed()
+{
+    #if defined(ENABLE_GPS)
+    // In TRACK laeuft kein Schaetzer (bewegter Knoten); dort gilt wie bisher
+    // der erste Wert, sonst wuerde die Referenz nie gesetzt.
+    //
+    // GPS-04/F4: Zurueckgehalten wird nur, solange ein Fix vorliegt und der
+    // Schaetzer noch nicht konvergiert ist. Ohne WZ_GPS_HasFix() haelt ein
+    // abgeschatteter WX-Knoten, der nie fixt, fBaseAltidude fuer immer auf 0
+    // und meldet QFE als QNH -- vor dem Patch hat dort der gespeicherte
+    // node_alt gelatcht. Der erste getPressASL()-Aufruf faellt ausserdem auf
+    // t~60 s, also vor TTFF. Die Konvergenzflanke latcht spaeter nach.
+    if(bGPSON && gpsDetected && !bDisplayTrack && WZ_GPS_HasFix())
+        return WZ_GPS_AltConverged();
+    #endif
+
+    return true;
+}

--- a/src/gps_functions.h
+++ b/src/gps_functions.h
@@ -39,6 +39,21 @@ unsigned long detectBaudrate();
 bool WZ_GPS_HasFix();
 String WZ_GPS_GetMaidenhead();  // Maidenhead-Locator (fuer Amateurfunk)
 
+// GPS-01: drain the GPS UART into the parser. Call every loop pass; the
+// evaluation stays in WZ_GPS_Loop() on its own timer.
+void WZ_GPS_Feed();
+
+// GPS-03: altitude filter access. --setalt seeds the estimate (x = alt, P = P0).
+void WZ_GPS_AltSeed(float alt);
+bool WZ_GPS_AltConverged();
+
 #endif // ENABLE_GPS
+
+// GPS-04: barometer reference altitude, independent of ENABLE_GPS.
+// baroBaseRelatch() writes every existing base-altitude latch (BMx280, BME680);
+// baroBaseLatchAllowed() is true when no GPS is active or the altitude filter
+// has converged -- the sensors latch their first value only then.
+void baroBaseRelatch(float alt);
+bool baroBaseLatchAllowed();
 
 #endif

--- a/src/loop_functions.cpp
+++ b/src/loop_functions.cpp
@@ -27,6 +27,7 @@
 
 #include "via_functions.h"
 #include "charset_filter.h"
+#include "setlog_lines.h"
 
 bool gpsDetected = false;
 bool gpsInitDone = false;
@@ -451,6 +452,21 @@ ch_util_rx_start_t ch_util_rx_start{0};   // timestamp when RX started
 ch_util_ulong_t ch_util_tx_start{0};   // timestamp when TX started
 ch_util_ulong_t ch_util_rx_accum{0};   // accumulated RX airtime (ms) in current window
 ch_util_ulong_t ch_util_tx_accum{0};   // accumulated TX airtime (ms) in current window
+
+// SL-05 -- Zaehler fuer die 5-Minuten-STAT-Zeile unter `--setlog on`.
+// std::atomic wie ch_util_*_accum daneben: geschrieben werden sie im LORA-Task
+// (OnRxDone/OnRxError, SL-01/SL-04) und in loop() (doTX, SL-03), gelesen und
+// per exchange(0) zurueckgesetzt in setlogFillStat().
+std::atomic<uint32_t> stat_newid{0};       // neue msg_id im Dedup-Ring
+std::atomic<uint32_t> stat_dup{0};         // erkannte Kopien
+std::atomic<uint32_t> stat_rx_err{0};      // RX-/CRC-Fehler
+std::atomic<uint32_t> stat_txn{0};         // eigene Sendungen
+std::atomic<uint32_t> stat_txfail{0};      // vom TX-Watchdog abgebrochen
+std::atomic<uint32_t> stat_util_rx_5m{0};  // RX-Luftzeit im 5-min-Fenster (ms)
+std::atomic<uint32_t> stat_util_tx_5m{0};  // TX-Luftzeit im 5-min-Fenster (ms)
+// Hochwasser von txRingDepth(); in addTxRingEntry() mitgefuehrt
+// (txring_functions.cpp), im STAT-Druck zurueckgesetzt.
+std::atomic<uint8_t> stat_ring_max{0};
 
 int isPhoneReady = 0;      // flag we receive from phone when itis ready to receive data
 
@@ -3119,6 +3135,57 @@ String getTimeString()
     return (String)currTime;
 }
 
+// SL -- `HH:MM:SS [LOG] <body>` ohne die String-Allokation von
+// getTimeString(): die RX-Pfade drucken zwei bis vier solcher Zeilen je Frame.
+void setlogPrint(const char *body)
+{
+    char ts[10];
+    snprintf(ts, sizeof(ts), "%02i:%02i:%02i", meshcom_settings.node_date_hour,
+             meshcom_settings.node_date_minute, meshcom_settings.node_date_second);
+
+    printfdeb("%s [LOG] %s\n", ts, body);
+}
+
+// SL-05 -- Felder der STAT-Zeile fuellen. Die Intervallzaehler werden hier
+// geleert (exchange(0)); stat_drop_count[] wird nur gelesen, das Nullen bleibt
+// plattformseitig (ESP32 memset, nRF52 unter taskENTER_CRITICAL()).
+void setlogFillStat(struct setlogStatFields *f, uint32_t heap)
+{
+    if(f == NULL)
+        return;
+
+    uint32_t rx5 = stat_util_rx_5m.exchange(0);
+    uint32_t tx5 = stat_util_tx_5m.exchange(0);
+    uint32_t util = 100UL * (rx5 + tx5) / (uint32_t)(PRIO_STAT_INTERVAL_S * 1000UL);
+    if(util > 100)
+        util = 100;
+
+    f->util_pct       = (uint8_t)util;
+    f->rx_ms          = rx5;
+    f->tx_ms          = tx5;
+    f->newid          = stat_newid.exchange(0);
+    f->dup            = stat_dup.exchange(0);
+    f->err            = stat_rx_err.exchange(0);
+    f->txn            = stat_txn.exchange(0);
+    f->txfail         = stat_txfail.exchange(0);
+    f->ringmax        = stat_ring_max.exchange(0);
+    f->ring_size      = MAX_RING;
+    f->drop[0]        = stat_drop_count[1];
+    f->drop[1]        = stat_drop_count[2];
+    f->drop[2]        = stat_drop_count[3];
+    f->drop[3]        = stat_drop_count[4];
+    f->drop[4]        = stat_drop_count[5];
+    f->mh             = (uint16_t)getMheardCount();
+    f->heap           = heap;
+    f->trk_interval_s = trickle_interval_ms / 1000UL;
+    f->trk_consistent = trickle_consistent_count;
+    f->fw_major       = shortVERSION();
+    f->fw_sub         = shortSUBVERSION();
+    f->flash          = FLASH_VERSION;
+    f->up_s           = millis() / 1000UL;
+    f->t_ms           = millis();
+}
+
 void charBuffer_aprs(struct aprsMessage &aprsmsg)
 {
     char internal_message[UDP_TX_BUF_SIZE];
@@ -3141,19 +3208,21 @@ void charBuffer_aprs(struct aprsMessage &aprsmsg)
     memcpy(ringbufferRAWLoraRX[RAWLoRaWrite], internal_message, UDP_TX_BUF_SIZE-1);
 }
 
-void printBuffer_aprs(char *msgSource, struct aprsMessage &aprsmsg)
+// SL-01: `tail` haengt VOR dem `\n` an die bestehende Zeile an -- leer bei
+// jedem Aufrufer ausser der RX-Zeile, die Zeile bleibt damit byteidentisch.
+void printBuffer_aprs(char *msgSource, struct aprsMessage &aprsmsg, const char *tail)
 {
-    printfdeb("%s %s %03i %c x%08X H%02X S%i T%i M%02X %s>%s%c%s HW:%02i MOD:%01X/%01i FCS:%04X FW:%02i:%c LH:%02X\n", getTimeString().c_str(), msgSource, aprsmsg.msg_len, aprsmsg.payload_type, aprsmsg.msg_id, aprsmsg.max_hop,
+    printfdeb("%s %s %03i %c x%08X H%02X S%i T%i M%02X %s>%s%c%s HW:%02i MOD:%01X/%01i FCS:%04X FW:%02i:%c LH:%02X%s\n", getTimeString().c_str(), msgSource, aprsmsg.msg_len, aprsmsg.payload_type, aprsmsg.msg_id, aprsmsg.max_hop,
         aprsmsg.msg_server, aprsmsg.msg_track, aprsmsg.msg_mesh, aprsmsg.msg_source_path.c_str(), aprsmsg.msg_destination_path.c_str(), aprsmsg.payload_type, aprsmsg.msg_payload.c_str(),
-        aprsmsg.msg_source_hw, (aprsmsg.msg_source_mod>>4), (aprsmsg.msg_source_mod & 0xf), aprsmsg.msg_fcs, aprsmsg.msg_source_fw_version, aprsmsg.msg_source_fw_sub_version, aprsmsg.msg_last_hw);
+        aprsmsg.msg_source_hw, (aprsmsg.msg_source_mod>>4), (aprsmsg.msg_source_mod & 0xf), aprsmsg.msg_fcs, aprsmsg.msg_source_fw_version, aprsmsg.msg_source_fw_sub_version, aprsmsg.msg_last_hw, tail);
 }
 
-void printBuffer_ack(char *msgSource, uint8_t payload[UDP_TX_BUF_SIZE+10], int16_t size)
+void printBuffer_ack(char *msgSource, uint8_t payload[UDP_TX_BUF_SIZE+10], int16_t size, const char *tail)
 {
     if(size == 7)
-        printfdeb("%s %s 007 %c x%02X%02X%02X%02X H%02X %02X\n", getTimeString().c_str(), msgSource, payload[0], payload[4], payload[3], payload[2], payload[1], payload[5], payload[6]);
+        printfdeb("%s %s 007 %c x%02X%02X%02X%02X H%02X %02X%s\n", getTimeString().c_str(), msgSource, payload[0], payload[4], payload[3], payload[2], payload[1], payload[5], payload[6], tail);
     else
-        printfdeb("%s %s 012 %c x%02X%02X%02X%02X H%02X x%02X%02X%02X%02X %02X %02X\n", getTimeString().c_str(), msgSource, payload[0], payload[4], payload[3], payload[2], payload[1], payload[5], payload[9], payload[8], payload[7], payload[6], payload[10], payload[11]);
+        printfdeb("%s %s 012 %c x%02X%02X%02X%02X H%02X x%02X%02X%02X%02X %02X %02X%s\n", getTimeString().c_str(), msgSource, payload[0], payload[4], payload[3], payload[2], payload[1], payload[5], payload[9], payload[8], payload[7], payload[6], payload[10], payload[11], tail);
 }
 
 
@@ -4301,26 +4370,28 @@ String PositionToAPRS(bool bConvPos, bool bSsendTele, bool bFuss, double plat, c
     //strcat(strconcat, cname);
 
     char strconcat[100]={0};
-    strcpy(strconcat, cbatt);
-    strncat(strconcat, calt, sizeof(strconcat)-1);
-    strncat(strconcat, cncnt, sizeof(strconcat)-1);
-    strncat(strconcat, cpress, sizeof(strconcat)-1);
-    strncat(strconcat, chum, sizeof(strconcat)-1);
-    strncat(strconcat, ctemp, sizeof(strconcat)-1);
-    strncat(strconcat, ctemp2, sizeof(strconcat)-1);
-    strncat(strconcat, cqfe, sizeof(strconcat)-1);
-    strncat(strconcat, cqnh, sizeof(strconcat)-1);
-    strncat(strconcat, cgasres, sizeof(strconcat)-1);
-    strncat(strconcat, cco2, sizeof(strconcat)-1);
-    strncat(strconcat, cgrc, sizeof(strconcat)-1);
-    strncat(strconcat, csfpegel, sizeof(strconcat)-1);
-    strncat(strconcat, csfpegel2, sizeof(strconcat)-1);
-    strncat(strconcat, csftemp, sizeof(strconcat)-1);
-    strncat(strconcat, csfbatt, sizeof(strconcat)-1);
-    strncat(strconcat, cversion, sizeof(strconcat)-1);    
-    strncat(strconcat, cinaU, sizeof(strconcat)-1);   
-    strncat(strconcat, cinaI, sizeof(strconcat)-1);
-    strncat(strconcat, ctele, sizeof(strconcat)-1);
+    // C02: strncat(dst, src, sizeof(dst)-1) bounds the source, not the remaining room;
+    // the worst-case tag set (~111 B) overran strconcat[100]. Bound by the room left.
+    snprintf(strconcat, sizeof(strconcat), "%s", cbatt);
+    strncat(strconcat, calt, sizeof(strconcat) - strlen(strconcat) - 1);
+    strncat(strconcat, cncnt, sizeof(strconcat) - strlen(strconcat) - 1);
+    strncat(strconcat, cpress, sizeof(strconcat) - strlen(strconcat) - 1);
+    strncat(strconcat, chum, sizeof(strconcat) - strlen(strconcat) - 1);
+    strncat(strconcat, ctemp, sizeof(strconcat) - strlen(strconcat) - 1);
+    strncat(strconcat, ctemp2, sizeof(strconcat) - strlen(strconcat) - 1);
+    strncat(strconcat, cqfe, sizeof(strconcat) - strlen(strconcat) - 1);
+    strncat(strconcat, cqnh, sizeof(strconcat) - strlen(strconcat) - 1);
+    strncat(strconcat, cgasres, sizeof(strconcat) - strlen(strconcat) - 1);
+    strncat(strconcat, cco2, sizeof(strconcat) - strlen(strconcat) - 1);
+    strncat(strconcat, cgrc, sizeof(strconcat) - strlen(strconcat) - 1);
+    strncat(strconcat, csfpegel, sizeof(strconcat) - strlen(strconcat) - 1);
+    strncat(strconcat, csfpegel2, sizeof(strconcat) - strlen(strconcat) - 1);
+    strncat(strconcat, csftemp, sizeof(strconcat) - strlen(strconcat) - 1);
+    strncat(strconcat, csfbatt, sizeof(strconcat) - strlen(strconcat) - 1);
+    strncat(strconcat, cversion, sizeof(strconcat) - strlen(strconcat) - 1);    
+    strncat(strconcat, cinaU, sizeof(strconcat) - strlen(strconcat) - 1);   
+    strncat(strconcat, cinaI, sizeof(strconcat) - strlen(strconcat) - 1);
+    strncat(strconcat, ctele, sizeof(strconcat) - strlen(strconcat) - 1);
 
     // wenn die concatenation zu lang ist, dann catxt und cname löschen
     if((strlen(strconcat) + strlen(catxt) + strlen(cname)) > 100)

--- a/src/loop_functions.h
+++ b/src/loop_functions.h
@@ -41,9 +41,11 @@ String getTimeString();
 
 void printBuffer(uint8_t *buffer, int len);
 void printAsciiBuffer(uint8_t *buffer, int len);
-void printBuffer_aprs(char *msg_source, struct aprsMessage &aprsMessage);
+// SL-01: `tail` wird VOR dem `\n` angehaengt (Pegel-/Dedup-Anhang der
+// RX-Zeile, siehe setlogFormatRxTail()); leer heisst Zeile wie bisher.
+void printBuffer_aprs(char *msg_source, struct aprsMessage &aprsMessage, const char *tail = "");
 void charBuffer_aprs(struct aprsMessage &aprsMessage);
-void printBuffer_ack(char *msgSource, uint8_t payload[UDP_TX_BUF_SIZE+10], int16_t size);
+void printBuffer_ack(char *msgSource, uint8_t payload[UDP_TX_BUF_SIZE+10], int16_t size, const char *tail = "");
 
 void addBLEOutBuffer(uint8_t *buffer, uint16_t len);
 void addBLEComToOutBuffer(uint8_t *buffer, uint16_t len);
@@ -85,6 +87,7 @@ unsigned int setSMartBeaconing(double flat, double flon);
 String convertCallToShort(char callsign[10]);
 
 uint8_t shortVERSION();
+char shortSUBVERSION();
 
 double cround4(double dvar);
 double cround4abs(double dvar);

--- a/src/loop_functions_extern.h
+++ b/src/loop_functions_extern.h
@@ -140,6 +140,7 @@ extern bool bEXTUDP;
 extern bool bNETCONSOLE;
 
 extern float fBaseAltidude;
+extern float fBaseAltidude680;
 extern float fBasePress;
 
 extern unsigned long onewireTimeWait;
@@ -322,6 +323,28 @@ extern ch_util_rx_start_t ch_util_rx_start;
 extern ch_util_ulong_t ch_util_tx_start;
 extern ch_util_ulong_t ch_util_rx_accum;
 extern ch_util_ulong_t ch_util_tx_accum;
+
+// SL-05 -- Zaehler der 5-Minuten-STAT-Zeile unter `--setlog on`.
+// Definitionsstelle ist loop_functions.cpp neben ch_util_*_accum; alle sind
+// std::atomic, weil LORA-Task (SL-01/SL-04) und loop() (SL-03/SL-05) sie
+// gleichzeitig anfassen. Zuruecksetzen im STAT-Druck per exchange(0).
+extern std::atomic<uint32_t> stat_newid;       // neue msg_id im Dedup-Ring
+extern std::atomic<uint32_t> stat_dup;         // erkannte Kopien
+extern std::atomic<uint32_t> stat_rx_err;      // RX-/CRC-Fehler
+extern std::atomic<uint32_t> stat_txn;         // eigene Sendungen
+extern std::atomic<uint32_t> stat_txfail;      // vom TX-Watchdog abgebrochen
+extern std::atomic<uint32_t> stat_util_rx_5m;  // RX-Luftzeit im Fenster (ms)
+extern std::atomic<uint32_t> stat_util_tx_5m;  // TX-Luftzeit im Fenster (ms)
+extern std::atomic<uint8_t>  stat_ring_max;    // Hochwasser von txRingDepth()
+
+// SL: prints `HH:MM:SS [LOG] <body>` via printfdeb without a String allocation
+// (definition in loop_functions.cpp next to getTimeString()).
+void setlogPrint(const char *body);
+// SL-05: fills the STAT fields from the interval counters (drains them), the
+// mheard/trickle/version globals and uptime; heap is platform-specific and passed in.
+// stat_drop_count[] is read, not cleared -- the platform tick clears it.
+struct setlogStatFields;
+void setlogFillStat(struct setlogStatFields *f, uint32_t heap);
 
 
 // Trickle-HEY state

--- a/src/lora_functions.cpp
+++ b/src/lora_functions.cpp
@@ -6,6 +6,7 @@
 #include "ack_functions.h"
 #include "capture_functions.h"
 #include "dedup_functions.h"
+#include "setlog_lines.h"
 
 #ifdef SX127X
     #include <RadioLib.h>
@@ -266,14 +267,48 @@ static int findAndStopRingSlot(uint32_t msgId)
     return -1;
 }
 
+// SL-01 -- Dedup-Verdikt zaehlen, genau einmal je Frame und dort, wo die
+// Entscheidung faellt. Die Zaehler muessen zu RX_DEDUP_NEW/RX_DEDUP_DUP passen.
+static inline bool setlogCountDedup(bool is_new)
+{
+    if(is_new)
+        stat_newid.fetch_add(1);
+    else
+        stat_dup.fetch_add(1);
+
+    return is_new;
+}
+
+// SL-01 -- eigenes Rufzeichen als vollstaendiges Pfadglied im Source-Path?
+// Wie die Loop-Erkennung im Relay-Block, aber ohne String-Allokation.
+static bool setlogPathHasCall(const char *path, const char *call)
+{
+    if(path == NULL || call == NULL || call[0] == 0x00)
+        return false;
+
+    size_t lc = strlen(call);
+    const char *p = path;
+
+    while((p = strstr(p, call)) != NULL)
+    {
+        bool left_ok  = (p == path) || (p[-1] == ',');
+        bool right_ok = (p[lc] == 0x00) || (p[lc] == ',');
+
+        if(left_ok && right_ok)
+            return true;
+
+        p += lc;
+    }
+
+    return false;
+}
+
 /**
  * Handle incoming ACK packet (msg_type 0x41).
  * Returns true if packet was processed as ACK, false otherwise.
  */
 static bool handleACK(uint8_t *payload, uint16_t size, int rssi, int snr)
 {
-    (void)rssi;
-    (void)snr;
     if(payload[0] != MSG_TYPE_ACK)
         return false;
 
@@ -294,12 +329,19 @@ static bool handleACK(uint8_t *payload, uint16_t size, int rssi, int snr)
 
     uint8_t print_buff[30];
 
+    memcpy(print_buff, payload, 12);
+
+    // SL-01: Dedup-Verdikt vor dem Druck, damit die [LOG]-Zeile `DUP:` fuehren
+    // kann. is_new_packet() ist eine reine Suche ohne Seiteneffekt.
+    bool bIsNew = setlogCountDedup(is_new_packet(print_buff+1));
+
     if(bDisplayLog)
     {
-        printBuffer_ack((char*)"[LOG]", payload, size);
+        // ACK-Frames tragen keinen Pfad, deshalb OWN: immer '-'.
+        char tail[56];
+        setlogFormatRxTail(tail, sizeof(tail), (int16_t)rssi, (int8_t)snr, !bIsNew, false, (uint32_t)millis());
+        printBuffer_ack((char*)"[LOG]", payload, (int16_t)size, tail);
     }
-
-    memcpy(print_buff, payload, 12);
 
     bool bServerFlag = false;
     if((print_buff[5] & 0x80) == 0x80)
@@ -307,7 +349,6 @@ static bool handleACK(uint8_t *payload, uint16_t size, int rssi, int snr)
 
     unsigned msg_id = print_buff[6] | (print_buff[7] << 8) | (print_buff[8] << 16) | (print_buff[9] << 24);
     int itxcheck = checkOwnTx(msg_id);
-    bool bIsNew = is_new_packet(print_buff+1);
 
     if(bIsNew || itxcheck >= 0)
     {
@@ -377,8 +418,8 @@ void OnRxDone(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr)
     //
     // Frueher hing das hinter `-D MC_TEST_HOOKS` und druckte hier direkt, was
     // in keinem Produktionsbuild lief: der Dump saesse im Radio-Callback
-    // (nRF52: Timer-Service-Task, 1 KB Stack) und printfdeb() braucht davon
-    // allein ~900 Byte, dazu ~48 ms Serial-Zeit mitten im RX-Pfad.
+    // (LORA-Task) und printfdeb() braucht allein ~900 Byte Stack, dazu
+    // ~48 ms Serial-Zeit mitten im RX-Pfad.
     // captureFrame() kopiert nur; ausgegeben wird aus dem Loop
     // (captureDrain() in main.cpp), siehe capture_functions.h.
     if(bLORADEBUG)
@@ -476,6 +517,10 @@ void OnRxDone(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr)
 
     uint8_t print_buff[30];
 
+    // SL-02: Puffer fuer RLY/GWU (nie beide im selben Durchlauf). Laengste
+    // Zeile: "RLY x12345678 : H03 q=gwfilter prio=5 slot=19".
+    char setlog_buf[96];
+
     //printfdeb("Start OnRxDone:<%c#%-20.20s> %i\n", payload[0], payload+6, size);
 
     bNewLine=false;
@@ -570,15 +615,26 @@ void OnRxDone(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr)
 
         int icheck = checkOwnTx(aprsmsg.msg_id);
 
+        // SL-01: genau EIN is_new_packet() je Frame (die Suche druckt unter
+        // --loradebug); unten von setlogCountDedup() wiederverwendet.
+        bool rx_is_new = is_new_packet(RcvBuffer+1);
+        bool rx_dup = !rx_is_new;
+        bool rx_own_echo = false;
+
         if(bDisplayLog)
         {
+            rx_own_echo = setlogPathHasCall(aprsmsg.msg_source_path.c_str(), meshcom_settings.node_call);
+
+            char tail[56];
+            setlogFormatRxTail(tail, sizeof(tail), (int16_t)rssi, (int8_t)snr, rx_dup, rx_own_echo, (uint32_t)millis());
+
             if(LogCallsign[0] != 0x00)
             {
                 if(is_equ((char*)LogCallsign, aprsmsg.msg_source_call.c_str()))
-                    printBuffer_aprs((char*)"[LOG]", aprsmsg);
+                    printBuffer_aprs((char*)"[LOG]", aprsmsg, tail);
             }
             else
-                printBuffer_aprs((char*)"[LOG]", aprsmsg);
+                printBuffer_aprs((char*)"[LOG]", aprsmsg, tail);
         }
 
         if(msg_type_b_lora == 0x00)
@@ -593,6 +649,15 @@ void OnRxDone(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr)
             // relay -- drop it here, before mheard, display, phone/BLE out,
             // the gateway upload and the relay decision below.
             logRxDropUnconfigured(aprsmsg.msg_source_call.c_str());
+
+            // SL-02: Ausstieg vor dem Relay-Block, gleiche Aussage "nicht
+            // weitergesendet, Grund unconf". Nur fuer neue Frames.
+            if(bDisplayLog && !rx_dup)
+            {
+                setlogFormatRly(setlog_buf, sizeof(setlog_buf), aprsmsg.msg_id,
+                                aprsmsg.payload_type, aprsmsg.max_hop & 0x0F, "unconf", 0, -1);
+                setlogPrint(setlog_buf);
+            }
         }
         else
         {
@@ -794,7 +859,7 @@ void OnRxDone(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr)
                 }
             }
             else
-            if(is_new_packet(RcvBuffer+1))
+            if(setlogCountDedup(rx_is_new))    // SL-01: Verdikt von oben, Logik unveraendert
             {
                 // :|0x11223344|0x05|OE1KBC|>*:Hallo Mike, ich versuche eine APRS Meldung\0x00
                 if(bDisplayCont)
@@ -870,6 +935,14 @@ void OnRxDone(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr)
                         snprintf(destination_call, sizeof(destination_call), "%s", aprsmsg.msg_destination_call.c_str());
 
                         bool bMeshDestination = true;
+
+                        // SL-02: Grund an den Ausstiegen setzen, eine RLY-Zeile
+                        // am Blockende. rly_hop ist der Hop WIE EMPFANGEN
+                        // (Relay dekrementiert aprsmsg.max_hop weiter unten).
+                        const char *rly_reason = NULL;
+                        int rly_prio = 0;
+                        int rly_slot = -1;
+                        uint8_t rly_hop = aprsmsg.max_hop & 0x0F;
 
                         if(msg_type_b_lora == MSG_TYPE_TEXT)    // text message store&forward
                         {
@@ -1228,18 +1301,33 @@ void OnRxDone(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr)
                             if(strcmp(destination_call, "100001") == 0)
                                 bMeshDestination = false;
 
+                            if(!bMeshDestination)
+                                rly_reason = "gwfilter";    // SL-02
+
                             if(aprsmsg.payload_type == ':' && aprsmsg.msg_last_path_cnt >= meshcom_settings.max_hop_text+1)    // TEXT
+                            {
+                                if(bMeshDestination)
+                                    rly_reason = "gwcap";   // SL-02
                                 bMeshDestination = false;
+                            }
                             if(aprsmsg.payload_type == '!' && aprsmsg.msg_last_path_cnt >= meshcom_settings.max_hop_pos+1)    // POS
+                            {
+                                if(bMeshDestination)
+                                    rly_reason = "gwcap";   // SL-02
                                 bMeshDestination = false;
-                            
+                            }
+
                             //KBC not usefull if(aprsmsg.payload_type == '@' && meshcom_settings.node_hasIPaddress)    // HEY no Mesh on GATEWAYs with Server-Connected
                             //KBC not usefill bMeshDestination = false;
                         }
 
                         // ping no mesh
                         if(aprsmsg.payload_type == ':' && strcmp(destination_call, "100001") == 0 && aprsmsg.msg_payload.startsWith("{ping}"))    // TEXT
+                        {
+                            if(bMeshDestination)
+                                rly_reason = "ping";        // SL-02
                             bMeshDestination = false;
+                        }
 
                         // GATEWAY action before MESH
                         // and not MESHed from another Gateways
@@ -1260,13 +1348,55 @@ void OnRxDone(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr)
                                     size = UDP_TX_BUF_SIZE - 2;
                             }
 
+                            // SL-06: Upload zum Server, unmittelbar vor
+                            // addNodeData() und vor dem Hop-Dekrement des Relays.
+                            if(bDisplayLog)
+                            {
+                                setlogFormatGwu(setlog_buf, sizeof(setlog_buf), aprsmsg.msg_id,
+                                                aprsmsg.payload_type, aprsmsg.max_hop & 0x0F, (uint32_t)millis());
+                                setlogPrint(setlog_buf);
+                            }
+
                             addNodeData(RcvBuffer, size, rssi, snr);
                         }
 
                         // resend only Packet to all and !owncall
                         // bSetLoRaAPRS = APRS via 433.775 usw.
 
-                        if(strcmp(destination_call, meshcom_settings.node_call) != 0 && !bSetLoRaAPRS && checkMesh(aprsmsg) && bMeshDestination)
+                        // SL-02: dieselbe Bedingung wie bisher, nur zerlegt, damit
+                        // genau ein Grund benannt wird -- Kurzschlussreihenfolge
+                        // und damit jeder checkMesh()-Aufruf bleiben erhalten.
+                        bool rly_go = false;
+
+                        if(strcmp(destination_call, meshcom_settings.node_call) == 0)
+                        {
+                            if(rly_reason == NULL)
+                                rly_reason = "self";
+                        }
+                        else
+                        if(bSetLoRaAPRS)
+                        {
+                            if(rly_reason == NULL)
+                                rly_reason = "aprs";
+                        }
+                        else
+                        if(!checkMesh(aprsmsg))
+                        {
+                            if(rly_reason == NULL)
+                                rly_reason = "nomesh";
+                        }
+                        else
+                        if(!bMeshDestination)
+                        {
+                            // Die uebrigen Ruecksetzer des Flags liegen im Zweig
+                            // "Ziel ist das eigene Rufzeichen", hier nie erreicht.
+                            if(rly_reason == NULL)
+                                rly_reason = "gwfilter";
+                        }
+                        else
+                            rly_go = true;
+
+                        if(rly_go)
                         {
                             // MESH only max. hops (default 3...TEXT 1...POS)
                             if(aprsmsg.max_hop > 0)
@@ -1288,6 +1418,7 @@ void OnRxDone(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr)
                                     {
                                         if(bLORADEBUG)
                                             printfdeb("[MC-DBG] RELAY_LOOP_BLOCKED own_call_in_path\n");
+                                        rly_reason = "loop";    // SL-02
                                         goto skip_relay;
                                     }
                                 }
@@ -1343,7 +1474,17 @@ void OnRxDone(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr)
 
                                 // no retransmission for ANY relay message; Slot vorher komplett
                                 // nullen (Alt-Verhalten: memset des ganzen Rings vor dem Schreiben)
-                                addTxRingEntry(RcvBuffer, size, RING_STATUS_DONE, "rx_relay", 0, true);
+                                rly_slot = addTxRingEntry(RcvBuffer, size, RING_STATUS_DONE, "rx_relay", 0, true);
+
+                                // SL-02: Rueckgabe ist der belegte Slot bzw. -1,
+                                // wenn der Ring den Eintrag verworfen hat.
+                                if(rly_slot >= 0)
+                                {
+                                    rly_reason = "tx";
+                                    rly_prio = ringPriority[rly_slot];
+                                }
+                                else
+                                    rly_reason = "full";
 
                                 /*
                                 if(bDisplayInfo)
@@ -1353,12 +1494,24 @@ void OnRxDone(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr)
                                 }
                                 */
                             }
+                            else
+                                rly_reason = "hop0";    // SL-02
+
                             skip_relay: ;
                         }
                         else
                         {
                             if(bDisplayInfo && !bNewLine)
                                 printfdeb("\n");
+                        }
+
+                        // SL-02: genau eine RLY-Zeile je neuem Frame, hinter
+                        // allen Ausstiegen des Relay-Blocks (auch skip_relay).
+                        if(bDisplayLog && rly_reason != NULL)
+                        {
+                            setlogFormatRly(setlog_buf, sizeof(setlog_buf), aprsmsg.msg_id,
+                                            aprsmsg.payload_type, rly_hop, rly_reason, rly_prio, rly_slot);
+                            setlogPrint(setlog_buf);
                         }
                     }
                 }
@@ -1480,6 +1633,32 @@ void OnRxError(void)
         #endif
     }
 
+    // SL-04: verlorener Frame. Zaehler unabhaengig von jedem Debug-Flag, die
+    // Zeile nur unter --setlog. Die [MC-DBG]-Ausgabe oben bleibt unveraendert.
+    stat_rx_err.fetch_add(1);
+
+    if(bDisplayLog)
+    {
+        int16_t err_rssi = 0;
+        int8_t  err_snr  = 0;
+
+        #if defined BOARD_RAK4630
+        {
+            // Wie oben: von SX126xGetPacketStatus() in RadioBgIrqProcess
+            // gefuellt. Bei Header-Fehlern koennen die Werte alt sein.
+            extern PacketStatus_t RadioPktStatus;
+            err_rssi = (int16_t)RadioPktStatus.Params.LoRa.RssiPkt;
+            err_snr  = (int8_t)RadioPktStatus.Params.LoRa.SnrPkt;
+        }
+        #endif
+
+        // Laenge und Frequenzfehler liefert dieser Pfad nicht (die ESP32-Seite
+        // in esp32_main.cpp tut es).
+        char err_buf[64];
+        setlogFormatErr(err_buf, sizeof(err_buf), err_rssi, err_snr, 0, 0, (uint32_t)millis());
+        setlogPrint(err_buf);
+    }
+
     {
         unsigned long _rx_s = ch_util_rx_start.exchange(0);
         if(_rx_s > 0)
@@ -1498,6 +1677,16 @@ void OnRxError(void)
 // wurden nach txring_functions.cpp verschoben (QA-Welle 2026-08-22, N-14) --
 // reine Verschiebung, Logik unveraendert. Siehe txring_functions.h/.cpp und
 // test/test_txring/test_txring.cpp.
+
+// SL-03 -- eine Zeile je gestarteter Sendung (Erfolgsausgaenge von doTX()).
+// stat_txn zaehlt auch bei --setlog off.
+static void setlogPrintTx(const char *line)
+{
+    stat_txn.fetch_add(1);
+
+    if(bDisplayLog && line[0] != 0x00)
+        setlogPrint(line);
+}
 
 /**@brief our Lora TX sequence — priority-based slot selection
  */
@@ -1555,6 +1744,25 @@ bool doTX()
                           "len=%d msg_id=%08X retry=%d queued=%d/%d lat=%lums\n",
                           txSlot, prio, ringBuffer[txSlot][2], ringBuffer[txSlot][1],
                           sendlng, tx_mid, retryCount[txSlot], queued, MAX_RING, (unsigned long)latency);
+        }
+
+        // SL-03: hier nur formatieren, gedruckt wird erst nach erfolgreichem
+        // Sendestart (setlogPrintTx()), damit ein Rollback keine Zeile hinterlaesst.
+        char setlog_tx_buf[128];
+        setlog_tx_buf[0] = 0x00;
+
+        if(bDisplayLog)
+        {
+            uint32_t sl_tx_mid = ((uint32_t)ringBuffer[txSlot][6] << 24) |
+                                 ((uint32_t)ringBuffer[txSlot][5] << 16) |
+                                 ((uint32_t)ringBuffer[txSlot][4] << 8)  |
+                                  (uint32_t)ringBuffer[txSlot][3];
+
+            setlogFormatTx(setlog_tx_buf, sizeof(setlog_tx_buf), sl_tx_mid,
+                           (char)ringBuffer[txSlot][2],
+                           (uint8_t)(ringBuffer[txSlot][7] & 0x0F),
+                           prio, (char)ringSource[txSlot], latency, txRingDepth(),
+                           cad_attempt, (uint16_t)sendlng, (uint32_t)millis());
         }
 
         if(ringBuffer[txSlot][1] == RING_STATUS_READY) // mark open to send
@@ -1699,6 +1907,8 @@ bool doTX()
 
                 bSetLoRaAPRS = true;
 
+                setlogPrintTx(setlog_tx_buf);   // SL-03
+
                 // For text messages needing retransmit: restore length so
                 // updateRetransmissionStatus() can find and retransmit them.
                 if(ringBuffer[save_read][1] != (char)RING_STATUS_DONE && ringBuffer[save_read][2] == MSG_TYPE_TEXT)
@@ -1760,6 +1970,8 @@ bool doTX()
                         #endif
                         bLED_RED = true;
                     #endif
+
+                    setlogPrintTx(setlog_tx_buf);   // SL-03
 
                     if(bDisplayInfo)
                     {
@@ -1885,8 +2097,13 @@ bool updateRetransmissionStatus()
                 // memcpy(dst==src) hier folgenlos (Quelle == Ziel-Byte fuer Byte).
                 // Original erst NACH dem Kopieren freigeben, damit die Payload beim
                 // Kopiervorgang garantiert noch gueltig ist.
-                addTxRingEntry(&ringBuffer[ircheck][2], (uint16_t)size, retransmitStatus,
+                int retxSlot = addTxRingEntry(&ringBuffer[ircheck][2], (uint16_t)size, retransmitStatus,
                                 "retransmit", retryCount[ircheck] + 1);
+
+                // SL-03: "retransmit" bildet auf 'o' ab -- die Kennung des
+                // Quellslots wird deshalb mitgenommen (wie bei der Prio-Verdraengung).
+                if(retxSlot >= 0)
+                    ringSource[retxSlot] = ringSource[ircheck];
 
                 // Mark original as done and free slot (after copy, so len is correct in new slot)
                 ringBuffer[ircheck][1] = RING_STATUS_DONE;

--- a/src/nrf52/nrf52_main.cpp
+++ b/src/nrf52/nrf52_main.cpp
@@ -121,6 +121,7 @@ void sendHeartbeat();
 #include <lora_setchip.h>
 #include <loop_functions.h>
 #include <loop_functions_extern.h>
+#include "setlog_lines.h"
 #include "dedup_functions.h"
 #include <command_functions.h>
 #include <aprs_functions.h>
@@ -1348,24 +1349,61 @@ void nrf52loop()
         if(_pendPos)  sendDisplayPosition(_msg, _rssi, _snr);
     }
 
-    // Channel utilization report (every 10s)
+    // Channel utilization report (every 10s). SL-05: the drain of the
+    // ch_util accumulators feeds stat_util_rx_5m/tx_5m for the STAT line
+    // (--setlog on), so the 10-s tick runs independent of bLORADEBUG; only
+    // the diagnostic prints stay behind the flag, unchanged.
     {
         static unsigned long ch_util_timer = 0;
-        if(bLORADEBUG && (millis() - ch_util_timer) > 10000)
+        if((millis() - ch_util_timer) > 10000)
         {
             unsigned long window = millis() - ch_util_timer;
             ch_util_timer = millis();
             unsigned long rx_ms = ch_util_rx_accum.exchange(0);
             unsigned long tx_ms = ch_util_tx_accum.exchange(0);
+            stat_util_rx_5m += (uint32_t)rx_ms;
+            stat_util_tx_5m += (uint32_t)tx_ms;
             unsigned int util = (unsigned int)((rx_ms + tx_ms) * 100 / window);
             if(util > 100) util = 100;
-            Serial.printf("[MC-DBG] CHANNEL_UTIL rx=%lums tx=%lums util=%u%%\n",
-                rx_ms, tx_ms, util);
-            // ONRXDONE stats: report max and warn count, then reset
-            Serial.printf("[MC-DBG] ONRXDONE_STATS max=%lums warn=%u (>%dms)\n",
-                onrxdone_max_ms, onrxdone_warn_count, ONRXDONE_WARN_MS);
-            onrxdone_max_ms = 0;
-            onrxdone_warn_count = 0;
+            if(bLORADEBUG)
+            {
+                Serial.printf("[MC-DBG] CHANNEL_UTIL rx=%lums tx=%lums util=%u%%\n",
+                    rx_ms, tx_ms, util);
+                // ONRXDONE stats: report max and warn count, then reset
+                Serial.printf("[MC-DBG] ONRXDONE_STATS max=%lums warn=%u (>%dms)\n",
+                    onrxdone_max_ms, onrxdone_warn_count, ONRXDONE_WARN_MS);
+                onrxdone_max_ms = 0;
+                onrxdone_warn_count = 0;
+            }
+        }
+    }
+
+    // SL-05 STAT tick (--setlog on / bDisplayLog): runs independent of
+    // bLORADEBUG so the interval counters never grow unbounded even when the
+    // block above never fires. Reset always, print only when enabled.
+    {
+        static uint32_t setlog_stat_timer = 0;
+        if((uint32_t)(millis() - setlog_stat_timer) >= PRIO_STAT_INTERVAL_S * 1000UL)
+        {
+            setlog_stat_timer = millis();
+
+            struct setlogStatFields f;
+            setlogFillStat(&f, nrf52_getFreeHeap());
+
+            // stat_drop_count[] increments happen under this same lock in
+            // txring_functions.cpp -- clear under it too, right after the
+            // (uncleared) read inside setlogFillStat().
+            taskENTER_CRITICAL();
+            for(int i = 0; i < 5; i++)
+                stat_drop_count[i + 1] = 0;
+            taskEXIT_CRITICAL();
+
+            if(bDisplayLog)
+            {
+                char buf[300];
+                setlogFormatStat(buf, sizeof(buf), &f);
+                setlogPrint(buf);
+            }
         }
     }
 
@@ -1687,6 +1725,8 @@ void nrf52loop()
         #if defined(ENABLE_GPS)
         if(bGPSON)
         {
+            if (gpsDetected) { INSTR_SECTION("gps_feed"); WZ_GPS_Feed(); }
+
             // gps refresh every sec
             if ((uint32_t)(millis() - gps_refresh_timer) >= 1000)
             {

--- a/src/nrf52/nrf_eth.cpp
+++ b/src/nrf52/nrf_eth.cpp
@@ -24,6 +24,7 @@
 #include "via_functions.h"
 #include "regex_functions.h"
 #include "conf_frame.h"
+#include "setlog_lines.h"
 
 EthernetUDP Udp;
 
@@ -655,7 +656,16 @@ int NrfETH::getUDP()
 
                   addTxRingEntry(convBuffer, size, RING_STATUS_DONE, "udp_rx", 0); // fire-and-forget, no retransmission for UDP relay
 
+                  if(bDisplayLog)
+                  {
+                      char buf[96];
+                      setlogFormatGwi(buf, sizeof(buf), aprsmsg.msg_id, aprsmsg.payload_type,
+                                       aprsmsg.max_hop & 0x0F, aprsmsg.msg_source_call.c_str(), (uint32_t)millis());
+                      setlogPrint(buf);
+                  }
+
                   addLoraRxBuffer(aprsmsg.msg_id, true);
+                  stat_newid.fetch_add(1); // S2: server-injected ids occupy dedup-ring slots too
 
                   // add rcvMsg to BLE out Buff
                   // size message is int -> uint16_t buffer size

--- a/src/setlog_lines.cpp
+++ b/src/setlog_lines.cpp
@@ -1,0 +1,128 @@
+// SL-00 -- Implementierung der `--setlog on`-Formatierer. Siehe setlog_lines.h
+// fuer die bindenden Regeln (kein Arduino, kein statischer Puffer, kein
+// Semikolon als Trenner, kein Praefix, kein Zeilenumbruch).
+
+#include "setlog_lines.h"
+
+#include <stdio.h>
+
+// snprintf() liefert die Laenge, die OHNE Kuerzung noetig gewesen waere, und
+// bei Encoding-Fehlern einen negativen Wert. Beides ist als Rueckgabewert
+// unbrauchbar: der Aufrufer haengt das Ergebnis an eine Ausgabe an und muss
+// wissen, wieviel wirklich im Puffer steht.
+static int setlogClamp(int written, size_t n)
+{
+    if(n == 0)
+        return 0;
+
+    if(written < 0)
+        return 0;
+
+    if((size_t)written >= n)
+        return (int)(n - 1);
+
+    return written;
+}
+
+int setlogFormatRxTail(char *buf, size_t n, int16_t rssi, int8_t snr,
+                       bool dup, bool own_echo, uint32_t t_ms)
+{
+    if(buf == NULL || n == 0)
+        return 0;
+
+    return setlogClamp(snprintf(buf, n, " RSSI:%d SNR:%d DUP:%c OWN:%c t=%lu",
+                                (int)rssi, (int)snr,
+                                dup ? 'd' : 'n',
+                                own_echo ? 'e' : '-',
+                                (unsigned long)t_ms), n);
+}
+
+int setlogFormatRly(char *buf, size_t n, uint32_t msg_id, char typ,
+                    uint8_t hop, const char *reason, int prio, int slot)
+{
+    if(buf == NULL || n == 0)
+        return 0;
+
+    return setlogClamp(snprintf(buf, n, "RLY x%08lX %c H%02X q=%s prio=%d slot=%d",
+                                (unsigned long)msg_id, typ, (unsigned)hop,
+                                (reason == NULL) ? "?" : reason,
+                                prio, slot), n);
+}
+
+int setlogFormatTx(char *buf, size_t n, uint32_t msg_id, char typ, uint8_t hop,
+                   int prio, char src, uint32_t wait_ms, int q_depth,
+                   int cad, uint16_t len, uint32_t t_ms)
+{
+    if(buf == NULL || n == 0)
+        return 0;
+
+    return setlogClamp(snprintf(buf, n,
+                                "TX x%08lX %c H%02X prio=%d src=%c wait=%lu q=%d cad=%d len=%u t=%lu",
+                                (unsigned long)msg_id, typ, (unsigned)hop,
+                                prio, src, (unsigned long)wait_ms, q_depth,
+                                cad, (unsigned)len, (unsigned long)t_ms), n);
+}
+
+int setlogFormatErr(char *buf, size_t n, int16_t rssi, int8_t snr,
+                    uint16_t len, int32_t ferr_hz, uint32_t t_ms)
+{
+    if(buf == NULL || n == 0)
+        return 0;
+
+    return setlogClamp(snprintf(buf, n, "ERR rssi=%d snr=%d len=%u ferr=%ld t=%lu",
+                                (int)rssi, (int)snr, (unsigned)len,
+                                (long)ferr_hz, (unsigned long)t_ms), n);
+}
+
+int setlogFormatStat(char *buf, size_t n, const struct setlogStatFields *f)
+{
+    if(buf == NULL || n == 0 || f == NULL)
+        return 0;
+
+    // Der Formatstring bleibt deutlich unter den 300 Byte, bei denen
+    // printfdeb_functions.cpp (char nformat[300]) den FORMATSTRING kappt --
+    // nicht nur die Ausgabe. Die native Testsuite haelt diese Schranke fest.
+    return setlogClamp(snprintf(buf, n,
+                                "STAT util=%u rx=%lu tx=%lu newid=%lu dup=%lu err=%lu txn=%lu txfail=%lu "
+                                "ringmax=%u/%u drop=%u/%u/%u/%u/%u mh=%u heap=%lu trk=%lu/%u "
+                                "fw=%u%c/%lu up=%lu t=%lu",
+                                (unsigned)f->util_pct,
+                                (unsigned long)f->rx_ms, (unsigned long)f->tx_ms,
+                                (unsigned long)f->newid, (unsigned long)f->dup,
+                                (unsigned long)f->err, (unsigned long)f->txn,
+                                (unsigned long)f->txfail,
+                                (unsigned)f->ringmax, (unsigned)f->ring_size,
+                                (unsigned)f->drop[0], (unsigned)f->drop[1],
+                                (unsigned)f->drop[2], (unsigned)f->drop[3],
+                                (unsigned)f->drop[4],
+                                (unsigned)f->mh, (unsigned long)f->heap,
+                                (unsigned long)f->trk_interval_s,
+                                (unsigned)f->trk_consistent,
+                                (unsigned)f->fw_major, f->fw_sub,
+                                (unsigned long)f->flash,
+                                (unsigned long)f->up_s,
+                                (unsigned long)f->t_ms), n);
+}
+
+int setlogFormatGwi(char *buf, size_t n, uint32_t msg_id, char typ,
+                    uint8_t hop, const char *from_call, uint32_t t_ms)
+{
+    if(buf == NULL || n == 0)
+        return 0;
+
+    return setlogClamp(snprintf(buf, n, "GWI x%08lX %c H%02X from=%s t=%lu",
+                                (unsigned long)msg_id, typ, (unsigned)hop,
+                                (from_call == NULL) ? "?" : from_call,
+                                (unsigned long)t_ms), n);
+}
+
+int setlogFormatGwu(char *buf, size_t n, uint32_t msg_id, char typ,
+                    uint8_t hop, uint32_t t_ms)
+{
+    if(buf == NULL || n == 0)
+        return 0;
+
+    return setlogClamp(snprintf(buf, n, "GWU x%08lX %c H%02X t=%lu",
+                                (unsigned long)msg_id, typ, (unsigned)hop,
+                                (unsigned long)t_ms), n);
+}

--- a/src/setlog_lines.h
+++ b/src/setlog_lines.h
@@ -1,0 +1,159 @@
+#ifndef _SETLOG_LINES_H_
+#define _SETLOG_LINES_H_
+
+// SL-00 -- reine Formatierer fuer die zusaetzlichen `--setlog on`-Zeilen
+// (Implementierungsplan SL-01..SL-07, 2026-09-02).
+//
+// Regeln, die diese Datei bindend halten muss:
+//
+//  * Keine Arduino-Abhaengigkeit. Die Uebersetzungseinheit baut unter
+//    `env:native` mit `-D NATIVE_BUILD=1` und nur <stdio.h>/<stdint.h>/
+//    <stdbool.h>/<string.h>. Damit sind die Zeilen ohne Hardware pruefbar.
+//  * Keine statischen Puffer. Jeder Formatierer schreibt in den vom Aufrufer
+//    gestellten `char buf[]` und schreibt nie mehr als `n` Byte (inkl. NUL).
+//  * Kein Semikolon als Feldtrenner. printfdeb() schreibt `;` ausserhalb des
+//    CSV-Modus um (src/printfdeb_format.h). Trenner ist immer das Leerzeichen,
+//    Felder sind `key=value` bzw. `KEY:value` wie in der bestehenden
+//    [LOG]-Zeile.
+//  * Die Formatierer liefern den Zeilenrumpf OHNE `HH:MM:SS [LOG] `-Praefix
+//    und OHNE `\n`. Beides setzt der Aufrufer, so wie printBuffer_aprs() es
+//    heute schon tut.
+//
+// Rueckgabewert ist immer die Zahl der tatsaechlich geschriebenen Zeichen
+// (ohne NUL) -- also bereits auf `n-1` geklemmt, nicht der Wunschwert von
+// snprintf(). Bei `n == 0` wird `buf` nicht angefasst und 0 geliefert.
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+//////////////////////////////////////////////////////////////////////////////
+// SL-01 -- Anhang an die bestehende RX-Zeile.
+//
+// Ergebnis (fuehrendes Leerzeichen ist Teil des Anhangs):
+//
+//     " RSSI:<int> SNR:<int> DUP:<n|d> OWN:<-|e> t=<ms>"
+//
+// dup      = true  -> `DUP:d` (msg_id lag schon im Dedup-Ring), sonst `DUP:n`
+// own_echo = true  -> `OWN:e` (eigenes Rufzeichen steht im Pfad), sonst `OWN:-`
+// t_ms     = millis() beim Empfang
+//
+// Laenge im schlimmsten Fall (RSSI -32768, SNR -128, t = 2^32-1): 46 Zeichen;
+// mit realen Pegeln rund 38. Der Aufrufer braucht also 47 Byte Puffer --
+// OnRxDone() in lora_functions.cpp stellt 56.
+int setlogFormatRxTail(char *buf, size_t n, int16_t rssi, int8_t snr,
+                       bool dup, bool own_echo, uint32_t t_ms);
+
+//////////////////////////////////////////////////////////////////////////////
+// SL-02 -- Relay-Entscheidung mit Grund, eine Zeile je NEUEM Frame.
+//
+//     "RLY x<id> <typ> H<hop> q=<code> prio=<n> slot=<n>"
+//
+// reason ist entweder "tx" (eingereiht, dann sind prio/slot gueltig) oder
+// genau einer der Ablehnungsgruende aus SL-02 (unconf, self, aprs, nomesh,
+// gwfilter, gwcap, ping, hop0, loop, full). Wurde nichts eingereiht, geben
+// die Aufrufer prio = 0 und slot = -1 mit.
+int setlogFormatRly(char *buf, size_t n, uint32_t msg_id, char typ,
+                    uint8_t hop, const char *reason, int prio, int slot);
+
+//////////////////////////////////////////////////////////////////////////////
+// SL-03 -- jede eigene Sendung, beim erfolgreichen Start (nicht bei TX_DONE).
+//
+//     "TX x<id> <typ> H<hop> prio=<n> src=<o|r|g> wait=<ms> q=<depth>
+//      cad=<n> len=<bytes> t=<ms>"   (eine Zeile, hier nur umbrochen)
+//
+// src stammt aus ringSource[] (SL-06): 'o' eigene Nachricht, 'r' Relay,
+// 'g' vom Server eingespeist.
+int setlogFormatTx(char *buf, size_t n, uint32_t msg_id, char typ, uint8_t hop,
+                   int prio, char src, uint32_t wait_ms, int q_depth,
+                   int cad, uint16_t len, uint32_t t_ms);
+
+//////////////////////////////////////////////////////////////////////////////
+// SL-04 -- verlorener Frame (CRC/RX-Error), plattformunabhaengig.
+//
+//     "ERR rssi=<int> snr=<int> len=<n> ferr=<hz> t=<ms>"
+//
+// Wo eine Plattform einen Wert nicht liefert (nRF52 kennt keine Laenge),
+// geben die Aufrufer 0 mit.
+int setlogFormatErr(char *buf, size_t n, int16_t rssi, int8_t snr,
+                    uint16_t len, int32_t ferr_hz, uint32_t t_ms);
+
+//////////////////////////////////////////////////////////////////////////////
+// SL-05 -- Statuszeile alle fuenf Minuten (PRIO_STAT_INTERVAL_S).
+//
+// Viele Werte, deshalb ein Struct statt einer Parameterlawine. Alle
+// Intervallzaehler setzt der Aufrufer nach dem Druck auf null (exchange(0)).
+struct setlogStatFields
+{
+    uint8_t  util_pct;        // Kanalauslastung ueber das 5-min-Fenster in %
+    uint32_t rx_ms;           // aufsummierte RX-Luftzeit im Fenster
+    uint32_t tx_ms;           // aufsummierte TX-Luftzeit im Fenster
+    uint32_t newid;           // neue msg_id im Dedup-Ring (SL-01)
+    uint32_t dup;             // erkannte Kopien (SL-01)
+    uint32_t err;             // RX-/CRC-Fehler (SL-04)
+    uint32_t txn;             // eigene Sendungen (SL-03)
+    uint32_t txfail;          // vom TX-Watchdog abgebrochene Sendungen
+    uint8_t  ringmax;         // Hochwasser von txRingDepth() im Fenster
+    uint8_t  ring_size;       // MAX_RING des Boards
+    uint16_t drop[5];         // stat_drop_count[1..5], Prio 1..5
+    uint16_t mh;              // getMheardCount()
+    uint32_t heap;            // freier Heap in Byte
+    uint32_t trk_interval_s;  // Trickle-Intervall in Sekunden
+    uint16_t trk_consistent;  // konsistente HEYs seit letztem Reset
+    uint8_t  fw_major;        // shortVERSION()
+    char     fw_sub;          // shortSUBVERSION()
+    uint32_t flash;           // FLASH_VERSION
+    uint32_t up_s;            // Uptime in Sekunden
+    uint32_t t_ms;            // millis()
+};
+
+//     "STAT util=<pct> rx=<ms> tx=<ms> newid=<n> dup=<n> err=<n> txn=<n>
+//      txfail=<n> ringmax=<n>/<MAX_RING> drop=<p1>/<p2>/<p3>/<p4>/<p5>
+//      mh=<n> heap=<bytes> trk=<interval_s>/<consistent>
+//      fw=<major><sub>/<flash> up=<s> t=<ms>"   (eine Zeile)
+int setlogFormatStat(char *buf, size_t n, const struct setlogStatFields *f);
+
+//////////////////////////////////////////////////////////////////////////////
+// SL-06 -- Gateway-Einspeisung und -Upload.
+//
+//     "GWI x<id> <typ> H<hop> from=<call> t=<ms>"
+//     "GWU x<id> <typ> H<hop> t=<ms>"
+int setlogFormatGwi(char *buf, size_t n, uint32_t msg_id, char typ,
+                    uint8_t hop, const char *from_call, uint32_t t_ms);
+
+int setlogFormatGwu(char *buf, size_t n, uint32_t msg_id, char typ,
+                    uint8_t hop, uint32_t t_ms);
+
+//////////////////////////////////////////////////////////////////////////////
+// SL-06/SL-03 -- Herkunftskennung fuer ringSource[].
+//
+// Bewusst `inline` im Header und nicht in setlog_lines.cpp: txring_functions.cpp
+// braucht die Abbildung, wird aber in `env:native_aprs` gebaut, wo
+// setlog_lines.cpp NICHT im build_src_filter steht (dort laeuft test_txring).
+// Als Header-Inline entsteht keine Link-Abhaengigkeit.
+//
+// Abbildung der `source`-Labels, die addTxRingEntry() heute nur in der
+// `RING_WRITE ... src=`-Zeile druckt:
+//
+//   "rx_relay", "rx_ack_fwd", "rx_dm_ack_gw", "rx_dm_ack_new"  -> 'r'
+//        alles, was aus einem Empfang heraus weitergereicht wird
+//   "udp_rx"                                                    -> 'g'
+//        vom Server eingespeist (WiFi-UDP und RAK-Ethernet nutzen dasselbe
+//        Label)
+//   alles andere ("user_msg", "beacon", "user_pos", "phone_msg", ...) -> 'o'
+static inline uint8_t setlogRingSourceCode(const char *source)
+{
+    if(source == NULL)
+        return (uint8_t)'o';
+
+    if(strncmp(source, "rx_", 3) == 0)
+        return (uint8_t)'r';
+
+    if(strcmp(source, "udp_rx") == 0)
+        return (uint8_t)'g';
+
+    return (uint8_t)'o';
+}
+
+#endif // _SETLOG_LINES_H_

--- a/src/t-deck/kbd_repeat.h
+++ b/src/t-deck/kbd_repeat.h
@@ -1,0 +1,209 @@
+/**
+ * @file        kbd_repeat.h
+ * @brief       Pure state machine for T-Deck keyboard auto-repeat (raw I2C mode)
+ * @license     MIT
+ * @copyright   Copyright (c) 2025 ICSSW.org
+ *
+ * Header-only, no Arduino dependency: takes `now` (millis()) from the caller
+ * and never touches I2C itself, so it builds and runs on the native test
+ * target.
+ */
+#ifndef KBD_REPEAT_H
+#define KBD_REPEAT_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+
+#define KBD_RAW_FRAME_LEN     5
+#define KBD_RAW_TIMEOUT_MS    5000
+#define KBD_RAW_PROBE_MAX     3
+#define KBD_RAW_MAX_BITS      3      /* key + up to two modifiers */
+
+enum kbd_raw_support { KBD_RAW_UNKNOWN = 0, KBD_RAW_YES, KBD_RAW_NO };
+
+/* Why a hold poll ended -- so the caller's reason ladder does not have to
+ * repeat the timeout arithmetic. */
+enum kbd_hold { KBD_HOLD_ACTIVE = 0, KBD_HOLD_RELEASED, KBD_HOLD_TIMEOUT };
+
+/* uint32_t members first, then the pointer, then the bytes: 20 B on the
+ * 32-bit target, 24 B on a 64-bit host (checked by the native test). */
+struct KbdRepeat {
+    uint32_t since_ms;
+    uint32_t key;          /* the remapped act_key being repeated */
+    void    *focus;        /* lv_obj_t* focused at arm time (K5); NULL on the
+                            * native target, which has no LVGL */
+    uint8_t  mask[KBD_RAW_FRAME_LEN];
+    uint8_t  support;      /* enum kbd_raw_support */
+    uint8_t  probes;
+    bool     active;
+};
+
+/* Physical matrix of the LilyGo T-Deck keyboard C3, transcribed from
+ * examples/Keyboard_ESP32C3/Keyboard_ESP32C3.ino (setup(), keyboard[col][row]
+ * and keyboard_symbol[col][row]).  Frame byte i is column i, bit r is row r.
+ * `0` marks a cell that emits no character (SYM, ALT, shifts, Mic, Enter,
+ * Backspace -- the last two are special-cased in kbdExpectedCell()). */
+static const char KBD_BASE[5][7] = {
+    { 'q', 'w',  0 , 'a',  0 , ' ',  0  },   /* col 0: q w SYM a ALT SPACE MIC   */
+    { 'e', 's', 'd', 'p', 'x', 'z',  0  },   /* col 1: e s d p x z LSHIFT        */
+    { 'r', 'g', 't',  0 , 'v', 'c', 'f' },   /* col 2: r g t RSHIFT v c f        */
+    { 'u', 'h', 'y',  0 , 'b', 'n', 'j' },   /* col 3: u h y ENTER b n j         */
+    { 'o', 'l', 'i',  0 , '$', 'm', 'k' },   /* col 4: o l i BACKSPACE $ m k     */
+};
+
+static const char KBD_SYM[5][7] = {
+    { '#', '1',  0 , '*',  0 ,  0 , '0'  },  /* col 0 */
+    { '2', '4', '5', '@', '8', '7',  0   },  /* col 1 */
+    { '3', '/', '(',  0 , '?', '9', '6'  },  /* col 2 */
+    { '_', ':', ')',  0 , '!', ',', ';'  },  /* col 3 */
+    { '+', '"', '-',  0 ,  0 , '.', '\'' },  /* col 4 */
+};
+
+/* Maps a character byte as delivered by the keyboard MCU back to the matrix
+ * cell that produced it, so an arm can verify that the key it is about to
+ * repeat is the one actually held down.  Returns false for anything with no
+ * physical cell (Enter, Alt combos, 0x00, non-ASCII). */
+static inline bool kbdExpectedCell(uint8_t ch, uint8_t *col, uint8_t *row)
+{
+    if (ch == 0)
+        return false;
+
+    if (ch == 0x08)                  /* Backspace: no character in the table */
+    {
+        *col = 4; *row = 3;
+        return true;
+    }
+    if (ch == ' ')
+    {
+        *col = 0; *row = 5;
+        return true;
+    }
+
+    if (ch >= 'A' && ch <= 'Z')      /* shifted alpha sits on the base cell */
+        ch = (uint8_t)(ch + ('a' - 'A'));
+
+    for (uint8_t c = 0; c < 5; c++)
+    {
+        for (uint8_t r = 0; r < 7; r++)
+        {
+            if (KBD_BASE[c][r] != 0 && (uint8_t)KBD_BASE[c][r] == ch)
+            {
+                *col = c; *row = r;
+                return true;
+            }
+        }
+    }
+    for (uint8_t c = 0; c < 5; c++)
+    {
+        for (uint8_t r = 0; r < 7; r++)
+        {
+            if (KBD_SYM[c][r] != 0 && (uint8_t)KBD_SYM[c][r] == ch)
+            {
+                *col = c; *row = r;
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+/* Frame plausibility: 1..KBD_RAW_MAX_BITS bits set across all five bytes and
+ * no byte above 0x7F -- only rows 0..6 exist, so bit 7 is never set by a
+ * keyboard that understands raw mode.  0xFF bytes are what an old firmware's
+ * idle-high SDA leaves behind, and are the caller's stand-in for a failed
+ * I2C read. */
+static inline bool kbdRawFrameValid(const uint8_t *f)
+{
+    int bits = 0;
+    for (int i = 0; i < KBD_RAW_FRAME_LEN; i++)
+    {
+        if (f[i] > 0x7F)
+            return false;
+        for (uint8_t b = f[i]; b != 0; b >>= 1)
+            bits += (b & 1);
+    }
+    return bits >= 1 && bits <= KBD_RAW_MAX_BITS;
+}
+
+/* First frame after a key: arm the window only when the frame is plausible
+ * AND shows the very cell (col,row) that produced this key -- otherwise a
+ * fast a->b transition would bind key 'a' to key 'b's bits and repeat 'a'
+ * under 'b's finger.  Returns false when the frame disqualifies the arm.
+ *
+ * An all-zero frame does NOT count as a probe failure: the char can arrive
+ * up to one LVGL poll plus one C3 matrix scan (roughly 65 ms) after the
+ * physical press, so a quick tap is often already released by the time the
+ * first raw frame is read, and a key-mode slave answers a 5-byte request
+ * with five zeros as well.  Every other rejection (a byte above 0x7F, too
+ * many bits, or the expected bit missing from a non-zero frame) is a real
+ * probe failure; KBD_RAW_PROBE_MAX of them mark the keyboard unsupported
+ * for this boot.  Once support is YES the verdict is final: later failures
+ * only decline the arm (K3). */
+static inline bool kbdRepeatArm(struct KbdRepeat *s, const uint8_t *f, uint32_t key,
+                                uint8_t col, uint8_t row, uint32_t now)
+{
+    bool all_zero = true;
+    for (int i = 0; i < KBD_RAW_FRAME_LEN; i++)
+    {
+        if (f[i] != 0)
+        {
+            all_zero = false;
+            break;
+        }
+    }
+    if (all_zero)
+        return false;               /* released before the read -- not a probe */
+
+    if (col < KBD_RAW_FRAME_LEN && row < 7
+        && kbdRawFrameValid(f)
+        && (f[col] & (uint8_t)(1u << row)) != 0)
+    {
+        memcpy(s->mask, f, KBD_RAW_FRAME_LEN);
+        s->since_ms = now;
+        s->key      = key;
+        s->focus    = NULL;         /* caller fills this in after a successful arm */
+        s->active   = true;
+        s->support  = KBD_RAW_YES;
+        s->probes   = 0;
+        return true;
+    }
+
+    if (s->support != KBD_RAW_YES)
+    {
+        s->probes++;
+        if (s->probes >= KBD_RAW_PROBE_MAX)
+            s->support = KBD_RAW_NO;
+    }
+    return false;
+}
+
+/* Subsequent frames: KBD_HOLD_ACTIVE while every bit armed in `mask` is still
+ * set in `f` (extra bits, e.g. a modifier added mid-hold, are accepted) and
+ * the window has not timed out.  `now - since_ms` in uint32_t arithmetic is
+ * the standard millis()-rollover-safe comparison. */
+static inline enum kbd_hold kbdRepeatHold(struct KbdRepeat *s, const uint8_t *f, uint32_t now)
+{
+    if (!s->active)
+        return KBD_HOLD_RELEASED;
+    if ((uint32_t)(now - s->since_ms) >= KBD_RAW_TIMEOUT_MS)
+        return KBD_HOLD_TIMEOUT;
+    for (int i = 0; i < KBD_RAW_FRAME_LEN; i++)
+    {
+        if ((f[i] & s->mask[i]) != s->mask[i])
+            return KBD_HOLD_RELEASED;
+    }
+    return KBD_HOLD_ACTIVE;
+}
+
+/* Ends the hold. `support`/`probes` are a per-boot verdict on the keyboard
+ * firmware, not per-hold state -- left untouched here. */
+static inline void kbdRepeatClear(struct KbdRepeat *s)
+{
+    s->active = false;
+    memset(s->mask, 0, KBD_RAW_FRAME_LEN);
+    s->key   = 0;
+    s->focus = NULL;
+}
+
+#endif /* KBD_REPEAT_H */

--- a/src/t-deck/tdeck_debug.h
+++ b/src/t-deck/tdeck_debug.h
@@ -129,6 +129,12 @@ void tdeck_dbg_spitrace_note_sd(void);
  * the GT911 hardware. */
 bool tdeck_touch_inject(const char *subcmd, int x, int y, int dur_ms);
 
+/* TD-10: per-boot verdict on the keyboard controller's raw-mode support,
+ * "yes" / "no" / "unknown" (no eligible key pressed yet, or every probe so
+ * far answered all-zero -- the pre-2025-06 LilyGo controller firmware).
+ * Implemented in tdeck_main.cpp, printed by --info. */
+const char *tdeck_kbd_raw_support_str(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/t-deck/tdeck_main.cpp
+++ b/src/t-deck/tdeck_main.cpp
@@ -36,6 +36,7 @@ using namespace ace_button;
 #include "lv_obj_functions.h"
 #include "lv_obj_functions_extern.h"
 #include "tdeck_debug.h"
+#include "kbd_repeat.h"
 #include <soc/spi_struct.h>
 #include <loop_functions_extern.h>
 #include <batt_functions.h>
@@ -62,6 +63,10 @@ void scanDevices(TwoWire*);
 bool setupCoder();
 void setupLvgl();
 bool setupSD();
+
+// TD-10: keyboard raw-mode command, defined next to keypad_get_key() below;
+// forward-declared here so setup() can force key mode right after checkKb().
+static void kbdRawMode(bool on);
 
 // LVGL functions
 static void disp_flush(lv_disp_drv_t *disp, const lv_area_t *area, lv_color_t *color_p);
@@ -215,6 +220,12 @@ void initTDeck()
 
     //! Keyboard
     kbDected = checkKb();
+
+    // TD-10 (K2): an ESP32 reset (WDT, OTA) mid-hold leaves a powered C3 in
+    // raw mode, where 1-byte key reads return column bitmasks as characters.
+    // Nothing else ever sends 0x04, so establish key mode once at boot.
+    if (kbDected)
+        kbdRawMode(false);
 
     //! Screen initialisation
     setupLvgl();
@@ -775,15 +786,106 @@ static uint32_t keypad_get_key(void)
     return key_ch;
 }
 
+// TD-10: raw-mode I2C helpers for key auto-repeat -- same beginTransmission/
+// write/endTransmission pattern as setKeyboardBacklight() (tdeck_helpers.cpp).
+// 0x03 switches the C3 to bitmask-per-poll output, 0x04 back to one-char-
+// per-key; an old keyboard firmware ignores both silently.
+static void kbdRawMode(bool on)
+{
+    Wire.beginTransmission(0x55);
+    Wire.write(on ? 0x03 : 0x04);
+    Wire.endTransmission();
+}
+
+// Reads the 5-byte raw matrix frame; false unless exactly 5 bytes arrived
+// (a stale/short response is discarded rather than partially applied).
+static bool kbdRawRead(uint8_t *frame)
+{
+    uint8_t n = (uint8_t)Wire.requestFrom(0x55, KBD_RAW_FRAME_LEN);
+    if (n != KBD_RAW_FRAME_LEN)
+    {
+        while (Wire.available() > 0)
+            Wire.read();
+        return false;
+    }
+    for (uint8_t i = 0; i < KBD_RAW_FRAME_LEN; i++)
+        frame[i] = (uint8_t)Wire.read();
+    return true;
+}
 
 /**
  * Will be called by the library to read the mouse
  */
+// TD-10: auto-repeat window state; support/probes persist across holds
+// (per-boot verdict on this keyboard's firmware), the rest per-hold. File
+// scope so --info can report the verdict (tdeck_kbd_raw_support_str()).
+static struct KbdRepeat s_rep = {};
+
+const char *tdeck_kbd_raw_support_str(void)
+{
+    switch (s_rep.support)
+    {
+        case KBD_RAW_YES: return "yes";
+        case KBD_RAW_NO:  return "no";
+        default:          return "unknown";
+    }
+}
+
 static void keypad_read(lv_indev_drv_t *indev_drv, lv_indev_data_t *data)
 {
     static uint32_t last_key = 0;
+
+    if (s_rep.active)
+    {
+        // A hold is in progress: keep reporting PR with the armed key for as
+        // long as the raw frame still shows it down, the window has not
+        // timed out, and the keyboard has not been locked meanwhile.
+        uint8_t f[KBD_RAW_FRAME_LEN] = {0, 0, 0, 0, 0};
+        uint32_t now = millis();
+        bool i2c_ok  = kbdRawRead(f);
+        enum kbd_hold hold = i2c_ok ? kbdRepeatHold(&s_rep, f, now) : KBD_HOLD_RELEASED;
+        bool locked  = meshcom_settings.node_keyboardlock;
+        // K5: LVGL re-resolves the focused object on every repeat tick, and a
+        // touch anywhere moves keypad focus (indev_click_focus). End the hold
+        // rather than keep typing into whatever was touched.
+        bool refocused = ((void *)lv_group_get_focused(lv_group_get_default()) != s_rep.focus);
+
+        if (i2c_ok && hold == KBD_HOLD_ACTIVE && !locked && !refocused)
+        {
+            data->state = LV_INDEV_STATE_PR;
+            data->key = s_rep.key;
+            return;
+        }
+
+        const char *reason;
+        if (!i2c_ok)
+            reason = "i2c";
+        else if (locked)
+            reason = "lock";
+        else if (refocused)
+            reason = "focus";
+        else if (hold == KBD_HOLD_TIMEOUT)
+            reason = "timeout";
+        else
+            reason = "release";
+
+        kbdRawMode(false);
+        Serial.printf("[KBD];repeat;key;%02x;held_ms;%lu;reason;%s\n",
+                      (unsigned)s_rep.key, (unsigned long)(now - s_rep.since_ms), reason);
+        last_key = s_rep.key;
+        kbdRepeatClear(&s_rep);
+        data->state = LV_INDEV_STATE_REL;
+        data->key = last_key;
+        return;
+    }
+
     uint32_t act_key ;
     act_key = keypad_get_key();
+    // TD-10 (K1): the physical matrix cell must be derived from the byte the
+    // keyboard actually sent -- in iKeyBoardType 2/3/4 act_key below is a
+    // remap ('a' -> 'A', 'w' -> '1', 'q' -> '#') whose character sits on a
+    // different cell than the key under the finger.
+    const uint32_t raw_key = act_key;
     if (act_key != 0)
     {
         bool bSPEC=false;
@@ -988,6 +1090,51 @@ static void keypad_read(lv_indev_drv_t *indev_drv, lv_indev_data_t *data)
                 #else
                 meshcom_settings.node_mute = !meshcom_settings.node_mute;
                 #endif
+            }
+        }
+
+        // TD-10: open a raw-mode repeat window for this key -- once armed,
+        // keypad_read() reports PR on every poll until it releases/times
+        // out/locks. Enter, Alt+C, SYM combos (all bSPEC), a locked keyboard
+        // and the SYM+M mute toggle (0x2e outside the message/status tabs,
+        // which does not set bSPEC) never open a window; once a keyboard
+        // has failed KBD_RAW_PROBE_MAX probes it is skipped for the rest
+        // of this boot.
+        uint32_t tab_act_now = lv_tabview_get_tab_act(tv);
+        uint8_t exp_col = 0;
+        uint8_t exp_row = 0;
+        bool has_cell = kbdExpectedCell((uint8_t)raw_key, &exp_col, &exp_row);
+        bool eligible = !bSPEC && !meshcom_settings.node_keyboardlock
+                     && act_key != 0x00 && act_key != 0x0D && act_key != 0x0C
+                     && !(act_key == 0x2e && tab_act_now != 1 && tab_act_now != 7)
+                     && has_cell
+                     && s_rep.support != KBD_RAW_NO;
+
+        if (eligible)
+        {
+            uint8_t f[KBD_RAW_FRAME_LEN] = {0, 0, 0, 0, 0};
+            kbdRawMode(true);
+            uint8_t supportBeforeProbe = s_rep.support;
+            // A 0-byte read is an I2C failure, not a partial frame: hand the
+            // arm a 0xFF-filled frame so it counts as a probe failure.
+            if (!kbdRawRead(f))
+                memset(f, 0xFF, KBD_RAW_FRAME_LEN);
+
+            bool armed = kbdRepeatArm(&s_rep, f, act_key, exp_col, exp_row, millis());
+            if (armed)
+                s_rep.focus = (void *)lv_group_get_focused(lv_group_get_default());
+            else
+                kbdRawMode(false);             // degrade: one char per press, as today
+
+            // Only while the verdict is still open, and hard-capped per boot;
+            // support legend: 0 = unknown (KBD_RAW_UNKNOWN), 1 = yes
+            // (KBD_RAW_YES), 2 = no (KBD_RAW_NO).
+            static uint8_t s_probe_lines = 0;
+            if (supportBeforeProbe == KBD_RAW_UNKNOWN && s_probe_lines < (KBD_RAW_PROBE_MAX + 2))
+            {
+                s_probe_lines++;
+                Serial.printf("[KBD];rawprobe;%02x %02x %02x %02x %02x;key;%02x;support;%d\n",
+                              f[0], f[1], f[2], f[3], f[4], (unsigned)act_key, (int)s_rep.support);
             }
         }
 

--- a/src/txring_functions.cpp
+++ b/src/txring_functions.cpp
@@ -14,6 +14,10 @@
 #include <loop_functions_extern.h>
 #include <aprs_functions.h>
 
+// setlogRingSourceCode() -- Header-Inline, keine Link-Abhaengigkeit auf
+// setlog_lines.cpp (env:native_aprs baut diese TU, aber nicht setlog_lines.cpp).
+#include <setlog_lines.h>
+
 #if defined(NATIVE_BUILD)
 // Native Testbuild: loop_functions.cpp (die kanonische Definitionsstelle
 // dieser Globals, siehe loop_functions_extern.h) wird hier NICHT mitgebaut
@@ -32,7 +36,16 @@ uint8_t ringPriority[MAX_RING];
 uint32_t ringEnqueueTime[MAX_RING];
 uint16_t stat_drop_count[6];
 uint8_t stat_queue_hwm;
+// SL-05: im Hardware-Build steht stat_ring_max in loop_functions.cpp neben
+// ch_util_*_accum; nativ gilt dieselbe Begruendung wie fuer die Arrays oben.
+std::atomic<uint8_t> stat_ring_max;
 #endif
+
+// SL-03/SL-06 (siehe txring_functions.h): Herkunft je Ring-Slot. Anders als
+// ringPriority[]/ringEnqueueTime[] hier definiert und nicht in
+// loop_functions.cpp -- geschrieben wird das Array ausschliesslich in dieser
+// Datei, und so braucht der native Testbuild keinen zweiten Definitionszweig.
+uint8_t ringSource[MAX_RING] = {0};
 
 //////////////////////////////////////////////////////////////////////////
 // LoRa TX functions
@@ -476,6 +489,9 @@ int addTxRingEntry(const uint8_t* frame, uint16_t len, uint8_t ring_status,
     // Assign priority and enqueue timestamp
     ringPriority[w] = getMessagePriority(w);
     ringEnqueueTime[w] = millis();
+    // SL-03/SL-06: Herkunft aus dem `source`-Label festhalten, solange es im
+    // Scope ist -- die TX-Zeile in doTX() sieht spaeter nur noch den Slot.
+    ringSource[w] = setlogRingSourceCode(source);
     prio = ringPriority[w];
 
     // Track queue depth for high-water mark
@@ -540,6 +556,7 @@ int addTxRingEntry(const uint8_t* frame, uint16_t len, uint8_t ring_status,
                 memcpy(ringBuffer[worst_slot], ringBuffer[r], sizeof(ringBuffer[0]));
                 ringPriority[worst_slot]    = ringPriority[r];
                 ringEnqueueTime[worst_slot] = ringEnqueueTime[r];
+                ringSource[worst_slot]      = ringSource[r];   // SL-03/SL-06
                 retryCount[worst_slot]      = retryCount[r];
                 ringBuffer[r][0] = 0;
             }
@@ -579,7 +596,25 @@ int addTxRingEntry(const uint8_t* frame, uint16_t len, uint8_t ring_status,
     taskEXIT_CRITICAL();
 #endif
 
-    // ---- Ab hier ausserhalb des Locks: nur noch Debug-Ausgabe ----
+    // ---- Ab hier ausserhalb des Locks ----
+
+    // SL-05: Hochwasser des Ringfuellstands im 5-Minuten-Fenster. Bewusst
+    // ausserhalb des Locks und ueber txRingDepth() (selbst lock-frei, siehe
+    // dessen Doku): iWrite ist hier bereits weitergeschaltet, die Tiefe
+    // enthaelt also den neuen Eintrag. Auch bei resultSlot < 0 gemessen -- ein
+    // verworfener Eintrag heisst voller Ring, und genau der Wert ist gesucht.
+    // Kein Ersatz fuer stat_queue_hwm -- das zaehlt seit dem Boot und wird nie
+    // zurueckgesetzt, stat_ring_max wird nach jedem STAT-Druck genullt.
+    // CAS-Schleife statt load/store, damit ein gleichzeitiger Schreiber aus
+    // dem anderen Task kein Maximum verliert.
+    {
+        uint8_t depth_now = (uint8_t)txRingDepth();
+        uint8_t seen = stat_ring_max.load();
+        while(depth_now > seen && !stat_ring_max.compare_exchange_weak(seen, depth_now))
+            ; // seen wird von compare_exchange_weak aktualisiert
+    }
+
+    // ---- nur noch Debug-Ausgabe ----
     if(bLORADEBUG)
     {
         printfdeb("[MC-DBG] RING_WRITE slot=%d type=%02X status=%02X "

--- a/src/txring_functions.h
+++ b/src/txring_functions.h
@@ -16,6 +16,14 @@
 #include <Arduino.h>
 #include <configuration.h>
 
+// SL-03/SL-06: Herkunft je Ring-Slot, 'o' eigene Nachricht, 'r' Relay eines
+// Empfangs, 'g' vom Server eingespeist. Gesetzt in addTxRingEntry() aus dem
+// `source`-Label, das dort bisher nur in der `RING_WRITE ... src=`-Zeile
+// auftauchte; bei der Prio-Verdraengung mitkopiert wie ringEnqueueTime[].
+// Die TX-Zeile aus SL-03 druckt den Wert als `src=`.
+// MAX_RING Byte (20 auf allen aktuellen Boards).
+extern uint8_t ringSource[MAX_RING];
+
 uint8_t getMessagePriority(int slot);
 int getNextTxSlot(void);
 void advanceIReadPastEmpty(void);

--- a/src/udp_functions.cpp
+++ b/src/udp_functions.cpp
@@ -23,6 +23,7 @@
 #include "via_functions.h"
 #include "regex_functions.h"
 #include "conf_frame.h"
+#include "setlog_lines.h"
 
 #if defined(ESP32)
 #include "esp_task_wdt.h"
@@ -332,6 +333,7 @@ void getMeshComUDPpacket(unsigned char inc_udp_buffer[UDP_TX_BUF_SIZE], int pack
 
             // add rcvMsg to forward to LoRa TX
             addLoraRxBuffer(aprsmsg.msg_id, true);
+            stat_newid.fetch_add(1); // S2: server-injected ids occupy dedup-ring slots too
 
             if(bGATEWAY_NOPOS)
               bUDPtoLoraSend=false;
@@ -478,11 +480,22 @@ void getMeshComUDPpacket(unsigned char inc_udp_buffer[UDP_TX_BUF_SIZE], int pack
 
                 addTxRingEntry(convBuffer, (uint16_t)size, 0xFF, "udp_rx", 0); // 0xFF no retransmission for UDP relay messages
 
+                if(bDisplayLog)
+                {
+                    char buf[96];
+                    setlogFormatGwi(buf, sizeof(buf), aprsmsg.msg_id, aprsmsg.payload_type,
+                                     aprsmsg.max_hop & 0x0F, aprsmsg.msg_source_call.c_str(), (uint32_t)millis());
+                    setlogPrint(buf);
+                }
+
                 // TM-31: position frames were already entered into the dedup ring
                 // in the 0x21 branch above -- adding them again here would spend
                 // two ring slots per frame and halve the dedup window.
                 if(msg_type_b != 0x21)
+                {
                     addLoraRxBuffer(aprsmsg.msg_id, true);
+                    stat_newid.fetch_add(1); // S2: server-injected ids occupy dedup-ring slots too
+                }
 
                 // add rcvMsg to BLE out Buff
                 // size message is int -> uint16_t buffer size

--- a/variants/t_deck/configuration.h
+++ b/variants/t_deck/configuration.h
@@ -79,6 +79,11 @@
 #define BAUD_CHARS 250
 #define GPS_RX_PIN        44
 #define GPS_TX_PIN        43
+// GPS-06: Zweitbelegung fuer selbst verdrahtete Module nach der Belegung bis
+// 4.35d (SoftwareSerial RX=43/TX=44). Greift nur, wenn auf RX=44/TX=43 kein
+// NMEA-Satz gefunden wird; siehe detectBaudrate() in gps_functions.cpp.
+#define GPS_FALLBACK_RX_PIN 43
+#define GPS_FALLBACK_TX_PIN 44
 
 #define LORA_RST  17
 #define LORA_DIO0 13 // aka BUSY Pin


### PR DESCRIPTION
Ein Commit, drei Themen plus zwei Begleitfixes. Basis ist `upstream/dev` @ `c6e1894`,
nur `src/` und `variants/t_deck/configuration.h` — kein Test-, Tool- oder Doku-Delta,
`platformio.ini` unveraendert (die neuen `.cpp` fallen unter das bestehende `+<*>`).

## Was wurde geaendert

### 1. GPS-Stabilisierung: NMEA-Drain, Plausibilitaetsgatter, Hoehenfilter, QNH-Relatch

**`src/gps_filter.h` / `src/gps_filter.cpp` (neu).** Arduino-freie Uebersetzungseinheit,
kein `Serial`, kein `millis()`, kein `meshcom_settings`:

- `struct AltFilter` + `altFilterReset/Seed/Update/Converged()` — skalares Kalmanfilter
  auf der Hoehe. Prozessrauschen ist mit `dt` skaliert, Ausreisser jenseits
  `ALT_KF_GATE_M` werden verworfen, nach `ALT_KF_RESEED_N` Verwuerfen in Folge wird neu
  aufgesetzt (sonst haengt der Filter fest, wenn sich der Knoten wirklich bewegt hat).
- `gpsSamplePlausible()` — verwirft Nullinsel (`lat`/`lon` exakt 0.0), Winkel ausserhalb
  ±90/±180, Hoehen ausserhalb −500..10000 m und Kalenderdaten, die der Parser nicht
  erzeugt haben kann. `gpsDatePlausible()` / `gpsTimePlausible()` als eigene Pruefung
  fuer den Zeitstempel-Pfad.

**`src/gps_functions.cpp/.h`.**

- Neue `WZ_GPS_Feed()`: nur die UART-Leseschleife (`while (GPSSerial.available())`) plus
  NMEA-Echo (`iGPSDEBUG > 2`, jetzt zeilenweise statt bytesweise). Sie wird auf beiden
  Plattformen in **jedem** `loop()`-Durchlauf gerufen. `WZ_GPS_Loop()` behaelt nur noch
  die Auswertung ab `updateGPSdata` und laeuft weiter auf `gps_refresh_intervall`.
- Fix-Gate `hdop < 6.0 && sat > 5` zusaetzlich um `gpsSamplePlausible()` erweitert; ein
  verworfenes Sample zaehlt einen Zaehler hoch und loggt unter `iGPSDEBUG > 0` eine
  `[GPS ]...reject:`-Zeile.
- Beide `MyClock.setCurrentTime()`-Aufrufe pruefen jetzt zusaetzlich
  `gps.time.isValid() && gpsDatePlausible() && gpsTimePlausible()`.
- `gps.altitude.isUpdated()` wird **vor** `.meters()` gelesen (der Zugriff loescht das
  Flag), der Filter also nur bei wirklich neuer Hoehe gefuettert.
- `node_alt` kommt aus `altFilterUpdate()` statt direkt aus dem GPS. In TRACK
  (`bDisplayTrack`) wird der Filter zurueckgesetzt und `node_alt` bleibt die rohe
  GPS-Hoehe wie bisher — ein Filter mit Zeitkonstante im Minutenbereich waere auf einem
  bewegten Knoten falsch.
- Neu: `WZ_GPS_AltSeed()`, `WZ_GPS_AltConverged()` sowie die plattformunabhaengigen
  `baroBaseRelatch()` / `baroBaseLatchAllowed()` (bewusst ohne `WZ_GPS_`-Praefix, sie
  uebersetzen auch auf Boards ohne GPS).

**`src/bmx280.cpp` / `src/bme680.cpp`.** Die Latch-Bedingung in `getPressASL()` /
`getPressASL680()` lautet jetzt `if (fBaseAltidude == 0 && baroBaseLatchAllowed())`.

**`src/command_functions.cpp`.** `--setalt` verwirft Werte ausserhalb 0..40000 m mit
Meldung, statt sie auf 0 zu klemmen und so in die Konfiguration zu schreiben; ein
gueltiger Wert setzt zusaetzlich `WZ_GPS_AltSeed()` (mit GPS) bzw. `baroBaseRelatch()`
(ohne GPS) — der Wert ist Startpunkt fuer den Filter, keine Festlegung. `--setpress`
schreibt die Basishoehe ueber `baroBaseRelatch()`, damit sie auch beim BME680 wirkt
(vorher blieb sie dort unveraendert). Hilfetext ergaenzt.

**`src/esp32/esp32_main.cpp` / `src/nrf52/nrf52_main.cpp`.** `WZ_GPS_Feed()` in jedem
Durchlauf, innerhalb des bestehenden `ENABLE_GPS`/`bGPSON`/`gpsDetected`-Guards. Der
bestehende `WZ_GPS_Loop()`-Aufruf bleibt unveraendert an seiner Stelle.

### 2. T-Deck ohne Plus: Fallback auf die alte GPS-Pinbelegung

`variants/t_deck/configuration.h` bekommt `GPS_FALLBACK_RX_PIN` / `GPS_FALLBACK_TX_PIN`;
`detectBaudrate()` scannt zuerst auf den Pins der Variante und nur bei Fehlschlag — und
nur, wenn die Variante die Fallback-Defines hat (allein `variants/t_deck`) — ein zweites
Mal auf der alten Belegung. Die wirksamen Pins stehen in `s_gpsRxPin`/`s_gpsTxPin`; ein
Treffer auf der Zweitbelegung wird mit der Bitte um Umverdrahten geloggt.

### 3. T-Deck-Tastatur: Auto-Repeat fuer Backspace, Leertaste und Alphatasten

**`src/t-deck/kbd_repeat.h` (neu).** Header-only Zustandsautomat ohne Arduino-Bezug,
20 Byte statisch auf dem 32-Bit-Ziel: `kbdRawFrameValid()`, `kbdExpectedCell()` (bildet
ein zugestelltes Zeichen auf die physische Matrixzelle `(col,row)` zurueck, anhand einer
aus dem LilyGo-Quelltext transkribierten Matrixtabelle), `kbdRepeatArm/Hold/Clear()`.

**`src/t-deck/tdeck_main.cpp`.** `setup()` ruft ein `kbdRawMode(false)` direkt nach
`checkKb()`, damit die C3 nach jedem Boot im Zeichen-Modus startet. `keypad_read()`
bekommt am Anfang einen Zweig, der einen laufenden Halte-Zustand pollt (5-Byte-I2C-Read,
Fokus- und Sperr-Check, Timeout) und ihn bei Bedarf beendet, und direkt vor
`last_key = act_key` eine Eligibility-Pruefung, die bei einer erlaubten Taste das
Halte-Fenster oeffnet. Zwei neue statische Helfer `kbdRawMode()`/`kbdRawRead()` (gleiches
Muster wie `setKeyboardBacklight()`). `--info` zeigt auf T-Deck-Builds zusaetzlich
`KBD raw-mode yes|no|unknown` und `KEYLOCK on|off` (`tdeck_kbd_raw_support_str()`,
deklariert in `tdeck_debug.h`).

### 4. Instrumentierung unter `--setlog on`

**`src/setlog_lines.h` / `src/setlog_lines.cpp` (neu).** Reine Formatierer, keine
Arduino-Abhaengigkeit, keine statischen Puffer — jeder schreibt in den vom Aufrufer
gestellten `char buf[]` und nie mehr als `n` Byte. Leerzeichen als Trenner, `key=value`
wie in der bestehenden `[LOG]`-Zeile (kein `;` — `printfdeb()` schreibt das ausserhalb
des CSV-Modus um).

Aufrufstellen, alle an `bDisplayLog` gehaengt, nichts unter `bLORADEBUG`, nichts
unbedingt:

| Zeile     | Aufrufstelle                                       | Inhalt                                                       |
| --------- | -------------------------------------------------- | ------------------------------------------------------------ |
| RX-Anhang | `lora_functions.cpp` (`OnRxDone()`)                | `RSSI: SNR: DUP: OWN: t=` an die bestehende `[LOG]`-Zeile     |
| `RLY`     | `lora_functions.cpp`                                | Relay-Entscheidung je neuem Frame, mit Ablehnungsgrund        |
| `TX`      | `lora_functions.cpp` (`doTX()`)                     | Wartezeit im Ring, CAD, Ringfuellstand, Herkunft (`src=`)     |
| `ERR`     | `lora_functions.cpp`, `esp32/esp32_main.cpp`        | CRC-/RX-Fehler, jetzt auch auf nRF52 und ohne `--loradebug`   |
| `STAT`    | `esp32/esp32_main.cpp`, `nrf52/nrf52_main.cpp`      | alle 5 min: Kanalauslastung, newid/dup, Drops, Heap, txfail   |
| `GWI`     | `udp_functions.cpp`, `nrf52/nrf_eth.cpp`            | Server-Injektion mit `msg_id`                                 |
| `GWU`     | `lora_functions.cpp`                                | Gateway-Update mit `msg_id`                                   |

Traegerdaten dafuer: `txring_functions.cpp/.h` bekommt `ringSource[MAX_RING]` (1 Byte je
Ring-Slot, Herkunft aus dem bereits vorhandenen `source`-Label, bei der Prio-Verdraengung
mitkopiert wie `ringEnqueueTime[]`) und `stat_ring_max` (Hochwasser des Ringfuellstands
im 5-Minuten-Fenster, per CAS-Schleife, damit ein gleichzeitiger Schreiber aus dem
anderen Task kein Maximum verliert). `loop_functions.cpp` / `loop_functions_extern.h`
tragen die uebrigen Zaehler.

Die bestehenden Felder der `[LOG]`-Zeile bleiben in Reihenfolge und Format
byteidentisch, neue Felder haengen hinten an. Neue Zaehler sind `std::atomic<uint32_t>`
wie `ch_util_rx_accum`, weil Timer-Task und `loop()` sie gleichzeitig anfassen
(`loop_functions_extern.h`, `loop_functions.cpp`).

Eine Verhaltensaenderung steckt drin und ist beabsichtigt: der 10-s-Tick der
Kanalauslastung in `esp32loop()` haengt nicht mehr an `bLORADEBUG`, weil sein Drain von
`ch_util_rx_accum`/`tx_accum` jetzt die 5-Minuten-`STAT`-Zeile speist. Die Diagnoseausgaben
darin haengen unveraendert an `bLORADEBUG`, die Akkumulationsmathematik ist unberuehrt.

### 5. Zwei Begleitfixes in ohnehin beruehrten Dateien

- **`loop_functions.cpp`, `PositionToAPRS()`:** `strncat(dst, src, sizeof(dst)-1)` begrenzt
  die Quelle, nicht den verbleibenden Platz. Der Wetter-Vollausbau (~111 Byte Tags) lief
  ueber `char strconcat[100]`. Jetzt `sizeof(strconcat) - strlen(strconcat) - 1`.
- **`esp32/esp32_main.cpp`:** `[BOOT] RESET_REASON=<n> <name>` als rohes `Serial.printf`
  im Boot-Banner (ein Feld-Reboot ohne diese Zeile ist von einem Power-Cycle nicht zu
  unterscheiden; nRF52 druckt an derselben Stelle bereits `[BOOT] RESETREAS=`), und der
  SD-Karten-Kachel-Timer nutzt das rollover-sichere `(uint32_t)(millis() - t) >= X`
  statt `(t + X) < millis()`.

## Warum

**GPS.** Feldlog OE5HWN vom 2026-09-01/02: der NMEA-Empfaenger lief in den UART-Overflow,
weil die Leseschleife nur im `gps_refresh_intervall`-Takt (bis 60 s) drankam — der
Treiberpuffer laeuft dabei ueber, halbe Saetze fuehren zu Sprungfixes. Das ist die
Ursache fuer Positionen, die zwischen zwei Meldungen um Kilometer springen, und fuer
Hoehen, die um zig Meter zittern, obwohl der Knoten fest montiert ist. Die Hoehe geht
zusaetzlich als Basishoehe in die QNH-Rechnung ein: latcht sie auf einen Ausreisser
(oder auf 0, bevor ueberhaupt ein Fix da ist), ist der gemeldete Luftdruck auf
Meeresniveau dauerhaft falsch — deshalb `baroBaseLatchAllowed()` erst nach Konvergenz.

**T-Deck ohne Plus.** Bis 4.35e empfing dieses Board per
`SoftwareSerial GPS(GPS_RX_PIN=43, GPS_TX_PIN=44)` auf GPIO43. `a672d18b` (v4.35p) hat
die Defines auf `RX 44 / TX 43` gedreht, und der Hardware-UART-Code wendet sie in
richtiger Reihenfolge an — das ist die LilyGo-Belegung und die des Plus, aber das
Gegenteil von 4.35d auf diesem Board. Jedes selbst verdrahtete Modul nach alter Belegung
ist seither stumm (OE5HWN 2026-09-02: unter 4.35d Fix mit 7 Satelliten, unter 4.35p
"keine gueltige NMEA-Sequenz auf 8 Baudraten"). Kosten fuer ein T-Deck ohne Modul:
einmalig bis zu 12 s beim Start.

**Tastatur.** Operator-Wunsch: Halten der Ruecktaste soll mehrere Zeichen loeschen,
erweitert auf Leertaste und alle Alphatasten inkl. ihrer Shift-/SYM-/Zahlen-Remaps. Die
Wiederholungs-Mechanik existiert bereits vollstaendig in LVGL
(`lv_indev.c`, Keypad-Treiber wiederholt jede Nicht-Spezialtaste, solange der Treiber
`PRESSED` mit demselben `data->key` meldet) — es fehlte nur die Information "Taste wird
noch gehalten". Die T-Deck-Tastatur ist ein eigener ESP32-C3 (I2C `0x55`), der im
Zeichen-Modus je Druck genau ein Byte liefert, kein Release-Event. Die
Stock-Keyboard-Firmware kennt seit `1eb6fb0e` (2025-06-11) einen Raw-Modus (`0x03` an /
`0x04` aus): jeder Request liefert dann fuenf Byte Live-Matrixzustand, ein Byte je
Spalte, ein Bit je Zeile. Damit laesst sich "noch gehalten" je LVGL-Poll pruefen; die
Wiederholung selbst macht LVGL unveraendert.

**Instrumentierung.** Auf den OE3-Bergknoten (OE3XIR-12, OE3XOC-12, OE3XWJ-12, OE3MAG-12)
ist im Dauerbetrieb nur `--setlog on` vertretbar — `--loradebug on` erzeugt
10-Sekunden-Zeilen, `[MC-SM]`-Uebergaenge und Heap-Churn. Bisher liefert `--setlog` genau
eine Zeile je Empfang: ohne Pegel, ohne Dedup-Verdikt, ohne Relay-Entscheidung, ohne
eigene Sendungen. Damit sind Rauschboden, Dedup-Fenster, Warteschlangenlatenz,
Kollisionsrate und Gateway-Vervielfachung aus einem Mitschnitt nicht rekonstruierbar.
Genau diese Groessen braucht es, um ueber intelligenteres Routing (adaptiver Relay-Slot)
auf Messwerten statt auf Vermutungen zu entscheiden. Der PR ist reine Instrumentierung —
die daraus abgeleiteten Verhaltensaenderungen sind eigene, spaetere PRs.

## Verhalten bei alter Tastatur-Firmware (unveraendert)

`Wire.requestFrom(0x55, 5)` liefert auf dem ESP32-Arduino-Core immer 5 Byte oder 0, nie
eine kurze Antwort. Eine Zeichen-Modus-Tastatur hat ihr anstehendes Byte fuer die
vorangehende 1-Byte-Abfrage bereits geschrieben und ihr I2C-TX-FIFO wird bei jedem STOP
zurueckgesetzt — die 5-Byte-Anfrage kommt also als `00 00 00 00 00` zurueck. Ein
All-Zero-Frame gilt als **unentscheidbar**, nicht als Fehlversuch: der Support-Status
bleibt fuer den ganzen Boot `UNKNOWN`, wird nie `NO`, und das Halte-Fenster wird nie
geoeffnet. Ein einmal erreichtes `YES` wird durch spaetere Fehlversuche nie
zurueckgenommen. Einziger messbarer Effekt auf alter Firmware: eine zusaetzliche
I2C-Transaktion (~1 ms) je berechtigtem Tastendruck. Feldbefund 2026-09-02 (OE5HWN,
T-Deck Plus): jede Probe antwortete `00 00 00 00 00`, das Geraet tippt wie bisher ein
Zeichen je Druck — genau dieser Pfad. Das Auto-Repeat greift also nur auf Geraeten mit
neuerer Tastatur-Controller-Firmware.

## Getestet

- **Alle 7 Standard-Targets gebaut**, auf genau diesem Branch (Basis `upstream/dev`,
  nicht im Fork-Baum), nach `rm -rf .pio/build`, sequenziell:
  `heltec_wifi_lora_32_V3`, `E22-DevKitC`, `ttgo_tbeam`, `ttgo_tbeam_supreme`, `t_deck`,
  `t_deck_plus`, `wiscore_rak4631` — alle SUCCESS.
- **Warnungsfrei** unter dem seit #1118 aktiven `-Wall -Wextra` fuer `src/`: alle
  geaenderten Uebersetzungseinheiten neu uebersetzt (ESP32-Pfad ueber `t_deck_plus`,
  nRF52-Pfad ueber `wiscore_rak4631`), keine `warning:`/`error:`-Zeile.
- **Hardware, GPS:** T-Deck Plus (DK5EN-14), erster Lauf auf dem gefixten Build —
  128 Fixes, 0 verworfene Samples, Hoehenfilter nach 256 s konvergiert.
- **Hardware, Tastatur:** T-Deck Plus mit alter Controller-Firmware — Verhalten
  unveraendert, `--info` meldet `KBD raw-mode no`, keine Wiederholung. Der Repeat-Pfad
  auf neuer Controller-Firmware ist **noch nicht auf Hardware** bestaetigt; die
  Zustandslogik ist im Fork durch 39 native Testfaelle abgedeckt
  (Frame-Plausibilitaet, Zellen-Ruecktransformation inkl. Shift-/SYM-Tabelle,
  Arm/Halten/Timeout inkl. `millis()`-Rollover, alle Degradationsfaelle).
- **Instrumentierung:** die Zeilenformatierer sind im Fork nativ getestet
  (`setlog_lines`, `gps_filter`, `kbd_repeat`); das Test-Env liegt nicht in diesem PR,
  weil `env:native` und `test/support` upstream nicht existieren. Ein 5-Minuten-Dauerlauf
  auf dem Bergknoten steht aus, dafuer muss dieser Stand erst dort laufen.

## Hinweise fuer den Reviewer

- Der Diff enthaelt **keine** `platformio.ini`-Aenderung: `gps_filter.cpp` und
  `setlog_lines.cpp` liegen in `src/` und fallen unter das bestehende `+<*>` in
  `build_src_filter`. Nur die Fork-eigenen `env:native`-Filter haetten Eintraege
  gebraucht; die sind bewusst draussen.
- `FLASH_VERSION` ist **nicht** angefasst — der Fork-Stempel gehoert nicht in diesen PR.
- Die einzige nicht rein additive Stelle ist der oben genannte 10-s-Tick in `esp32loop()`.
  Alles andere ist `if(bDisplayLog) { ... }` um neuen Code herum.
- `src/t-deck/` wird auf keinem anderen Board uebersetzt; Punkt 3 kostet dort exakt
  0 Byte Flash und RAM.
- Punkt 5 (Begleitfixes) liegt in Dateien, die dieser PR ohnehin anfasst. Wenn du die
  lieber getrennt haettest, schneide ich sie in einen eigenen PR heraus.
