### PR TITLE
Fix: Watchdog-Absturz beim schnellen Zoomen (refresh_map raus aus tde…

### DIFF
--- a/src/t-deck/lv_obj_functions.cpp
+++ b/src/t-deck/lv_obj_functions.cpp
@@ -1924,7 +1924,10 @@ void tdeck_map_zoom(int dir)
     if (dir > 0) sdmap_zoom_in();
     else         sdmap_zoom_out();
     sdmap_refresh(map_ta, sdmap_lastKnownLat, sdmap_lastKnownLon);
-    refresh_map(meshcom_settings.node_map);
+    // refresh_map() bewusst NICHT hier: zeichnet alle fremden Stationen neu
+    // (teure LVGL-Objekt-Churn) und triggerte bei schnellem/wiederholtem Zoom
+    // in Kombination mit SD-Kacheldecoding den ESP32-Watchdog. Fremde Stationen
+    // aktualisieren sich stattdessen über den periodischen Boundary-Poll.
     add_map_point(meshcom_settings.node_call, sdmap_lastKnownLat, sdmap_lastKnownLon, true);
 }
 


### PR DESCRIPTION
Problem

Gelegentliche Abstürze beim Drücken der Zoom-Buttons auf der Kartenansicht (T-Deck), besonders während Bewegung.

Ursache

refresh_map() wird in tdeck_map_zoom() bei jedem Zoom-Klick aufgerufen und zeichnet dabei alle bekannten fremden Stationen neu (pro Station ein LVGL-Objekt löschen und neu erstellen). Zusammen mit dem SD-Kachel-Decoding, das ebenfalls bei jedem Zoom anfällt, kann das bei mehreren gehörten Stationen den ESP32-Watchdog auslösen.

Bestätigt durch Beobachtung: Nach einem Geräteneustart (leeres Stationen-Array im RAM) trat der Absturz beim Zoomen nicht mehr auf – ein klarer Hinweis, dass die Anzahl der zu zeichnenden Stationen die Ursache ist.

Fix

refresh_map() aus dem Zoom-Pfad entfernt. Fremde Stationen werden weiterhin über den bestehenden periodischen Boundary-Poll aktualisiert, nur nicht mehr bei jedem einzelnen Zoom-Klick. Die eigene Position wird über add_map_point() weiterhin sofort aktualisiert.

Änderung

Eine Zeile in src/t-deck/lv_obj_functions.cpp (tdeck_map_zoom()) entfernt/kommentiert, keine funktionalen Nebenwirkungen auf andere Kartenwechsel-Pfade (set_map() bleibt unverändert).