### PR TITLE
feat/fix: Deepsleep, ACK-Herkunft, Web-Queue, Hoehenfusion, Feldfixes

### DIFF
--- a/src/ack_attribution.h
+++ b/src/ack_attribution.h
@@ -1,0 +1,138 @@
+#pragma once
+
+// ACK-Attribution: wer hat quittiert?
+//
+// Reine Funktionen ohne Globals, ohne String, ohne Heap, damit sie aus dem
+// OnRxDone-Kontext (nRF52: LORA-Task) aufrufbar und nativ testbar sind
+// (test/test_ack_validate, test/test_ack_phone_frame).
+//
+// Hintergrund und Entscheidungen: docs/ack-wer-hat-quittiert.md,
+// Umsetzung: docs/ack-implementierungsplan.md.
+//
+// Draht (0x41, gelesen):
+//   [0..10]  wie bisher, siehe ack_functions.h
+//   [11]     n = Laenge des Anhangs, akzeptiert 0 und 3, alles andere = kein Anhang
+//   [12..14] 22-Bit-Node-Hash des Gateways, little endian, nur wenn n == 3
+//
+// BLE (0x41, erzeugt, Uebergabe an addBLEOutBuffer(), die 4 Byte Zeit anhaengt):
+//   [0]      0x41
+//   [1..4]   msg_id, little endian
+//   [5]      Status 0x00 Node ACK (heard) / 0x01 Gateway bzw. Server / 0x02 Peer ACK
+//   [6]      n = Laenge des Anhangs, 0 = altes Format (byteidentisch mit frueher)
+//   [7..]    Rufzeichen, n Byte, [A-Z0-9-], n <= ACK_ATTR_CALL_MAX, kein NUL
+
+#include <stdint.h>
+#include <string.h>
+
+#define ACK_WIRE_BASE_LEN      12
+#define ACK_WIRE_APPENDIX_LEN  3
+#define ACK_WIRE_MAX_LEN       (ACK_WIRE_BASE_LEN + ACK_WIRE_APPENDIX_LEN)
+
+#define ACK_PHONE_BASE_LEN     7
+#define ACK_ATTR_CALL_MAX      10
+#define ACK_PHONE_MAX_LEN      (ACK_PHONE_BASE_LEN + ACK_ATTR_CALL_MAX)
+
+/**
+ * @brief Laenge des Draht-Anhangs eines ACK-Frames.
+ *
+ * Verwirft nie einen Frame: bei jedem Verstoss (n != 3, Puffer zu kurz,
+ * NULL) ist die Antwort 0 und der Frame gilt als 12-Byte-ACK.
+ *
+ * @return 3, wenn Byte 11 == 3 und size >= 15, sonst 0.
+ */
+static inline uint8_t ackWireAppendixLen(const uint8_t *payload, uint16_t size)
+{
+    if(payload == NULL)
+        return 0;
+
+    if(size < ACK_WIRE_MAX_LEN)
+        return 0;
+
+    if(payload[11] != ACK_WIRE_APPENDIX_LEN)
+        return 0;
+
+    return ACK_WIRE_APPENDIX_LEN;
+}
+
+/**
+ * @brief 22-Bit-Node-Hash aus Byte 12..14. Nur gueltig, wenn
+ *        ackWireAppendixLen() == 3 geliefert hat.
+ */
+static inline uint32_t ackWireHash(const uint8_t *payload)
+{
+    return ((uint32_t)payload[12] | ((uint32_t)payload[13] << 8) | ((uint32_t)payload[14] << 16)) & 0x3FFFFF;
+}
+
+/**
+ * @brief Stammt die msg_id von diesem Node? Eigene msg_ids sind
+ *        ((GW_ID & 0x3FFFFF) << 10) | counter, siehe loop_functions.cpp.
+ *
+ * own_msg_id[] enthaelt auf einem Gateway auch fremde msg_ids, die nur vom
+ * Server zum LoRa-Funk weitergeleitet wurden (insertOwnTx in udp_functions.cpp
+ * / nrf_eth.cpp); der reine LoRa-Relay-Pfad ruft insertOwnTx nie auf. Ohne
+ * diese Pruefung wuerde --ackinfo fuer jede
+ * fremde, weitergeleitete Meldung bei jedem Repeat ein Heard zur App legen
+ * (Bench 2026-09-05: DK8VW-99, DL9PN-1, DM3KS-12 auf DK5EN-98).
+ */
+static inline bool ackMsgIdFromNode(uint32_t msgId, uint32_t gwId)
+{
+    return (msgId >> 10) == (gwId & 0x3FFFFF);
+}
+
+/** @brief Zeichensatz des Rufzeichen-Anhangs: [A-Z0-9-]. */
+static inline bool ackAttrCallChar(char c)
+{
+    return (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-';
+}
+
+/**
+ * @brief Laenge eines gueltigen Rufzeichen-Anhangs, 0 bei jedem Verstoss.
+ *
+ * NULL, leer, laenger als ACK_ATTR_CALL_MAX oder ein Zeichen ausserhalb
+ * [A-Z0-9-] (auch Kleinbuchstaben) liefern 0: lieber kein Rufzeichen als
+ * ein halbes.
+ */
+static inline uint8_t ackAttrCallLen(const char *call)
+{
+    if(call == NULL)
+        return 0;
+
+    uint8_t n = 0;
+    for(; call[n] != '\0'; n++)
+    {
+        if(n >= ACK_ATTR_CALL_MAX)
+            return 0;
+
+        if(!ackAttrCallChar(call[n]))
+            return 0;
+    }
+
+    return n;
+}
+
+/**
+ * @brief Baut den BLE-Statusframe (Layout siehe oben).
+ *
+ * @param out     Zielpuffer, mindestens ACK_PHONE_MAX_LEN Byte.
+ * @param msgId   msg_id der quittierten Nachricht.
+ * @param status  0x00 / 0x01 / 0x02.
+ * @param call    Rufzeichen des Quittierenden, NULL oder "" fuer "unbekannt".
+ * @return Laenge fuer addBLEOutBuffer(): 7 + n.
+ */
+static inline uint16_t buildAckPhoneFrame(uint8_t *out, uint32_t msgId, uint8_t status, const char *call)
+{
+    uint8_t n = ackAttrCallLen(call);
+
+    out[0] = 0x41;
+    out[1] = (uint8_t)(msgId & 0xFF);
+    out[2] = (uint8_t)((msgId >> 8) & 0xFF);
+    out[3] = (uint8_t)((msgId >> 16) & 0xFF);
+    out[4] = (uint8_t)((msgId >> 24) & 0xFF);
+    out[5] = status;
+    out[6] = n;
+
+    if(n > 0)
+        memcpy(out + ACK_PHONE_BASE_LEN, call, n);
+
+    return (uint16_t)(ACK_PHONE_BASE_LEN + n);
+}

--- a/src/adc_functions.cpp
+++ b/src/adc_functions.cpp
@@ -65,7 +65,8 @@ uint16_t SampleCount = 0;
 void loop_ADCFunctions()
 {    
     #if defined (ANALOG_PIN)
-        if(bAnalogCheck)
+        // Pin 99 is the unset default: the ESP32 core logs "Pin 99 is not ADC pin!" on every read.
+        if(bAnalogCheck && meshcom_settings.node_analog_pin > 0 && meshcom_settings.node_analog_pin < 99)
         {
             // bAnalogFilter noch irgendwie sinnvoll?
             ADCslope = meshcom_settings.node_analog_slope;

--- a/src/alt_fusion.cpp
+++ b/src/alt_fusion.cpp
@@ -1,0 +1,31 @@
+/*
+ * GPS/barometer complementary altitude filter (GPS-05b).
+ * No Arduino dependencies: this file also builds on the host.
+ */
+
+#include "alt_fusion.h"
+
+#include <math.h>
+
+void altFusionReset(struct AltFusion *f)
+{
+    f->init = false;
+}
+
+float altFusionUpdate(struct AltFusion *f, float gpsAlt, float baroAlt, uint32_t dtMs)
+{
+    if (!f->init)
+    {
+        f->gpsLp  = gpsAlt;
+        f->baroLp = baroAlt;
+        f->init   = true;
+        return gpsAlt;
+    }
+
+    float a = 1.0f - expf(-(float)dtMs / (float)ALT_FUSION_TAU_MS);
+
+    f->gpsLp  += a * (gpsAlt - f->gpsLp);
+    f->baroLp += a * (baroAlt - f->baroLp);
+
+    return f->gpsLp + (baroAlt - f->baroLp);
+}

--- a/src/alt_fusion.h
+++ b/src/alt_fusion.h
@@ -1,0 +1,66 @@
+#ifndef _ALT_FUSION_H_
+#define _ALT_FUSION_H_
+
+/*
+ * GPS/barometer complementary altitude filter (GPS-05b).
+ * No Arduino dependencies: this file also builds on the host.
+ *
+ * out = LPF_tau(gps) + (baro - LPF_tau(baro))
+ *
+ * A single-pole, irregular-sample complementary filter. The GPS side is
+ * low-passed to reject its noise; the barometer side is high-passed (its
+ * own low-pass subtracted back out) to reject its drift while keeping its
+ * short-term precision. Because only the barometer's HIGH-pass component
+ * (baro - LPF(baro)) is added to the output, any constant offset in the
+ * barometric channel cancels exactly: getPressALTf() anchors on whatever
+ * pressure/altitude pair happened to latch at filter convergence
+ * (docs/bug-baro-altitude-20260906.md S5.2), and that arbitrary anchor never
+ * reaches the fused output, only the pressure's short-term wiggle does.
+ *
+ * gpsAlt is meant to be the already-gated GPS estimate from gps_filter.h
+ * (struct AltFilter's x), not the raw NMEA altitude: the Kalman gate has
+ * already removed single-sample outliers, so the low-pass here only has to
+ * smooth the remaining multi-minute wander (measured on the DK5EN-93
+ * corpus: Kalman input sd 2.76 m fused, raw input 3.17 m).
+ *
+ * ALT_FUSION_TAU_MS = 30 min: the knee of the tau sweep in
+ * docs/bug-baro-altitude-20260906.md S7 -- below it GPS wander leaks
+ * through, above it the filter starts tracking the barometer's own weather
+ * drift over the same timescale and 30-minute stability gets worse again.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#define ALT_FUSION_TAU_MS 1800000u /* 30 min: knee of the tau sweep, bug doc S7 */
+
+struct AltFusion
+{
+    float gpsLp;  /* low-passed GPS altitude estimate (m) */
+    float baroLp; /* low-passed barometric altitude (m) */
+    bool  init;   /* seeded */
+};
+
+/* init = false; nothing else is touched */
+void altFusionReset(struct AltFusion *f);
+
+/*
+ * One update. dtMs is the wall time since the previous update (0 on the
+ * first call after altFusionReset() is fine: the first call always seeds).
+ *
+ * On the first call (f->init == false), both low-passes seed exactly on
+ * their inputs and the function returns gpsAlt unchanged -- enabling the
+ * fusion, or reseeding it (e.g. on TRACK-mode entry, together with the GPS
+ * Kalman filter), never steps the output.
+ *
+ * Otherwise a = 1 - exp(-dtMs / ALT_FUSION_TAU_MS) is the per-update blend
+ * factor; both low-passes are updated toward their current sample by that
+ * factor, and the return value is gpsLp + (baroAlt - baroLp). dtMs == 0
+ * yields a == 0 (both low-passes and the output are unchanged). No dt is
+ * clamped: an unusually long gap converges both low-passes onto the
+ * current samples, which is the correct behaviour for a low-pass filter
+ * fed at an irregular cadence.
+ */
+float altFusionUpdate(struct AltFusion *f, float gpsAlt, float baroAlt, uint32_t dtMs);
+
+#endif /* _ALT_FUSION_H_ */

--- a/src/aprs_functions.cpp
+++ b/src/aprs_functions.cpp
@@ -550,6 +550,7 @@ void initAPRSPOS(struct aprsPosition &aprspos)
 
     aprspos.version = 0;
     aprspos.telemetry = 0;
+    aprspos.din[0] = 0x00;
 }
 
 uint16_t decodeAPRSPOS(String PayloadBuffer, struct aprsPosition &aprspos)
@@ -1013,6 +1014,60 @@ uint16_t decodeAPRSPOS(String PayloadBuffer, struct aprsPosition &aprspos)
                 {
                     decode_text[ipt]=PayloadBuffer.charAt(id);
                     ipt++;
+                }
+            }
+
+            break;
+        }
+    }
+
+    memset(decode_text, 0x00, sizeof(decode_text));
+    ipt=0;
+
+    // check Digital /D=
+    for(itxt=istarttext; itxt<PayloadBuffer.length(); itxt++)
+    {
+        if(PayloadBuffer.charAt(itxt) == '/' && PayloadBuffer.charAt(itxt+1) == 'D' && PayloadBuffer.charAt(itxt+2) == '=')
+        {
+            bool din_overflow = false;
+
+            for(unsigned int id=itxt+3;id<PayloadBuffer.length();id++)
+            {
+                // ENDE
+                if(PayloadBuffer.charAt(id) == '/' || PayloadBuffer.charAt(id) == ' ' || id == PayloadBuffer.length())
+                {
+                    break;
+                }
+
+                if(ipt < 8)
+                {
+                    decode_text[ipt]=PayloadBuffer.charAt(id);
+                    ipt++;
+                }
+                else
+                {
+                    // 9th+ data byte -- token too long, reject below
+                    din_overflow = true;
+                }
+            }
+
+            if(!din_overflow && ipt == 8)
+            {
+                bool din_valid = true;
+
+                for(int idb=0; idb<8; idb++)
+                {
+                    if(decode_text[idb] != '0' && decode_text[idb] != '1')
+                    {
+                        din_valid = false;
+                        break;
+                    }
+                }
+
+                if(din_valid)
+                {
+                    memcpy(aprspos.din, decode_text, 8);
+                    aprspos.din[8] = 0x00;
                 }
             }
 

--- a/src/aprs_structures.h
+++ b/src/aprs_structures.h
@@ -62,6 +62,7 @@ struct aprsPosition
     // more
     int version;
     int telemetry;
+    char din[9]; // /D= MCP23017 port A bits, GPA0 first; "" when absent or malformed
 };
 
 struct mheardLine

--- a/src/backpressure.h
+++ b/src/backpressure.h
@@ -47,6 +47,7 @@
 #ifdef __cplusplus
 
 #include <stdint.h>
+#include <string.h>
 
 /// Coarse state of the sender-facing back-pressure machine.
 enum BpState
@@ -158,6 +159,46 @@ inline const char *bpNoticeText(BpNotice n)
     }
 }
 
+/// BP-11: true if text is nothing but this node's own back-pressure wording --
+/// a notice or nack that a client (phone app, web GUI, EXTUDP peer) fed back
+/// into sendMessage() as if the operator had typed it. Such a text must never
+/// reach the TX ring: the observed field case (IZ5CND-1/-10, 2026-09-04) was
+/// "QRT NOT SENT - QRT NOT SENT - QRT NOT SENT - QRS - slow down, ..." on the
+/// air, one prefix added per re-injection while the ring sat in the QRT band.
+/// Rule (operator decision 2026-09-04, strict block): after leading spaces the
+/// text either starts with one of the two bpNackPrefix() literals or equals one
+/// of the four bpNoticeText() literals. Exact and case-sensitive on purpose --
+/// only the literals this firmware itself emits are caught, a text that merely
+/// quotes the wording mid-sentence is legitimate operator traffic. The literals
+/// are taken from the accessors, never duplicated here, so a reworded notice
+/// cannot silently unhook the guard (test_bp_echo_guard pins that).
+/// No allocation, no String: runs on the nRF52 4 KB loop stack (N-22).
+inline bool bpIsOwnWording(const char *text)
+{
+    if(text == nullptr)
+        return false;
+
+    while(*text == ' ')
+        text++;
+
+    static const BpNack kNackPrefixes[] = { BP_NACK_QRT, BP_NACK_QTA };
+    for(size_t i = 0; i < sizeof(kNackPrefixes) / sizeof(kNackPrefixes[0]); i++)
+    {
+        const char *prefix = bpNackPrefix(kNackPrefixes[i]);
+        size_t prefix_len = strlen(prefix);
+        if(prefix_len > 0 && strncmp(text, prefix, prefix_len) == 0)
+            return true;
+    }
+
+    for(int n = BP_NOTICE_QRS; n <= BP_NOTICE_QRV; n++)
+    {
+        if(strcmp(text, bpNoticeText((BpNotice)n)) == 0)
+            return true;
+    }
+
+    return false;
+}
+
 class BackPressure
 {
 public:
@@ -245,6 +286,35 @@ public:
     }
 
     BpState state() const { return state_; }
+
+    /// Own typed messages already counted towards QRS_MIN_USER_MSGS in the
+    /// running run (0 after any sighting below qrsThreshold()).
+    int userMsgsCounted() const { return qrs_user_msgs_; }
+
+    /// WQ-02 (2026-09-05): forecast for the web GUI -- the ring depth the
+    /// sender's *next* own messages would have to reach before QRS fires,
+    /// given the ring as it stands now. qrsThreshold() alone is a necessary
+    /// condition; the trigger is the QRS_MIN_USER_MSGS-th own message that
+    /// lands at/above it. Each further own message adds one to the depth
+    /// (no drain assumed), and messages landing below the line do not
+    /// count, so the firing message lands at
+    ///     max(qrsThreshold() + remaining - 1, depth + remaining).
+    /// Clamped to refuseThreshold(): from there on QRT takes over anyway.
+    /// A snapshot, not a promise -- the ring drains between renders and a
+    /// dip below the line restarts the count.
+    /// @param depth current ring depth (any frame type)
+    int qrsForecastDepth(int depth) const
+    {
+        if(depth < 0)
+            depth = 0;
+        int remaining = QRS_MIN_USER_MSGS - qrs_user_msgs_;
+        if(remaining < 1)
+            remaining = 1;
+        int by_line = qrsThreshold() + remaining - 1;
+        int by_fill = depth + remaining;
+        int t = (by_line > by_fill) ? by_line : by_fill;
+        return (t < refuseThreshold()) ? t : refuseThreshold();
+    }
 
     /// Highest notice already emitted in the running episode (BP_NOTICE_NONE
     /// while no episode is open).

--- a/src/bmx280.cpp
+++ b/src/bmx280.cpp
@@ -305,16 +305,33 @@ float getHum()
 	return fHum;
 }
 
-int getPressALT()
+float getPressALTf()
 {
+	// GPS-08: Selbst-Latch statt Persistierung. Ein Struct-Feld wuerde
+	// FLASH_STRUCT_VERSION kippen und damit die Settings der ganzen Flotte
+	// zuruecksetzen -- und ein alter Druck nach langem Stromlos-Sein waere
+	// schlimmer als gar keiner. fBaseAltidude wird ohnehin binnen eines
+	// 60s-WX-Ticks von baroBaseRelatch() (GPS-Filter-Konvergenz) oder von
+	// getPressASL() (Nodes ohne GPS) gesetzt -- hier wird nur der dazu
+	// passende Druck nachgezogen. --setpress bleibt der manuelle Override.
+	if(fBasePress == 0.0f && fBaseAltidude != 0.0f && fPress != 0.0f)
+		fBasePress = fPress;
+
 	if(fPress == 0.0 || fBasePress == 0.0)
-		return 0;
-		
+		return 0.0f;
+
 	double x=(double)fPress/(double)fBasePress;
 	x=(double)-7990*log(x);
 	x = x + fBaseAltidude;
 
-	return (int)lround(x);
+	return (float)x;
+}
+
+int getPressALT()
+{
+	// GPS-09: float-Praezision ist fuer die GPS-05b-Fusion da;
+	// node_press_alt bleibt bewusst int (siehe bug doc §9).
+	return (int)lround(getPressALTf());
 }
 
 float getPressASL(int current_alt)

--- a/src/bmx280.h
+++ b/src/bmx280.h
@@ -13,6 +13,7 @@ float getTemp();
 float getPress();
 float getHum();
 int getPressALT();
+float getPressALTf();
 float getPressASL(int currect_alt);
 
 #endif

--- a/src/bp_notice_frame.h
+++ b/src/bp_notice_frame.h
@@ -20,10 +20,11 @@
 // BP-06: the destination is now the same target the triggering message was
 // sent to (a group, a DM call, or "*"), not a hardcoded broadcast -- a
 // notice for a message the operator typed into group 20 should show up in
-// the 20 chat, not vanish into "*". msg_app_offline still keeps the frame
-// local: for a DM dst this makes the notice appear in the sender's own DM
-// thread, but the frame is never announced, never retransmitted and never
-// goes on the air, so the DM partner never sees it.
+// the 20 chat, not vanish into "*". What actually keeps the frame off the
+// air is that it is only ever written to BLEtoPhoneBuff / the EXTUDP
+// socket, never to the TX ring, plus BP-11 (bpIsOwnWording(),
+// backpressure.h), which refuses the frame if a client feeds it back into
+// sendMessage().
 static inline void bpNoticeFillFrame(struct aprsMessage &aprsmsg,
                                      const char *node_call,
                                      const char *text,
@@ -40,7 +41,12 @@ static inline void bpNoticeFillFrame(struct aprsMessage &aprsmsg,
     aprsmsg.msg_source_path = node_call;
     aprsmsg.msg_payload = text;
 
-    aprsmsg.msg_app_offline = true; // Rückmeldungen niemals announcen
+    // Bit 0x20 in byte 5: "app was offline, catch-up frame" marker read by
+    // the phone app (set on RX when no phone is connected, see
+    // lora_functions.cpp ~1141). It is NOT a send inhibit -- nothing in the
+    // TX path reads this flag; see the file header comment for what
+    // actually keeps this frame local.
+    aprsmsg.msg_app_offline = true;
 }
 
 // BP-07: bytes, not characters -- see the length budget table in

--- a/src/charset_filter.cpp
+++ b/src/charset_filter.cpp
@@ -43,6 +43,35 @@ namespace
         }
     }
 
+    /* CHR-03: the legacy single-byte range, 0x80 through 0xFF. A byte in
+     * this range that is not part of a valid UTF-8 sequence is kept as the
+     * single byte it is -- the sender meant it as Latin-1 or CP1252, and
+     * this filter relays it rather than deciding for the receiver.
+     *
+     * 0xA0-0xFF is identical in both encodings (NBSP and the Latin-1
+     * graphic characters). 0x80-0x9F is where they differ: CP1252 puts the
+     * Euro sign, the typographic quotes and the dashes there, while
+     * ISO-8859-1 leaves the block as C1 controls. Operator decision
+     * 2026-09-09: pass the whole block, because the senders in this network
+     * that use single-byte umlauts use CP1252 (PinPoint). Consequence,
+     * stated so nobody has to rediscover it: a receiver that reads the
+     * stream as ISO-8859-1 rather than CP1252 sees C1 control codes in
+     * message text. Five of these bytes (0x81, 0x8D, 0x8F, 0x90, 0x9D) are
+     * undefined even in CP1252; they are relayed too, and a receiver
+     * renders them as U+FFFD (mc-chat does exactly that).
+     *
+     * This does NOT contradict is_c1() on the UTF-8 path, which still
+     * strips U+0080-U+009F when they arrive properly encoded as C2 80..C2
+     * 9F. The two cases mean different things: a raw 0x80 in a legacy
+     * stream is a Euro sign, while a deliberately UTF-8-encoded U+0080 is
+     * the C1 control PAD and nothing else.
+     *
+     * There is deliberately no predicate function for this range: every
+     * byte that reaches the fallback below is 0x80-0xFF by construction,
+     * because an ASCII byte always forms a complete one-byte sequence and
+     * never gets there. A `b >= 0x80` test at that point would read like a
+     * live filter while always being true. */
+
     /* Determines the UTF-8 sequence length from a leading byte, or 0 if the
      * byte cannot start a sequence (a stray continuation byte, or one of
      * the bytes 0xF5-0xFF that RFC 3629 never assigns as a lead byte). */
@@ -73,55 +102,66 @@ size_t charset_filter_apply(char *buf, size_t len, charset_filter_mode mode)
         unsigned char b0 = (unsigned char)buf[i];
         int seqlen = lead_seqlen(b0);
 
-        if (seqlen == 0)
+        uint32_t cp = 0;
+        uint32_t min_cp = 0;
+        bool complete = false;
+
+        if (seqlen > 0 && i + (size_t)seqlen <= len)
         {
-            // Not a valid lead byte -- drop just this one byte and let the
-            // next iteration resync on whatever follows.
-            i += 1;
-            continue;
-        }
-
-        if (i + (size_t)seqlen > len)
-        {
-            // Sequence would run past the end of the buffer -- drop the
-            // lead byte only, the trailing bytes get their own chance to
-            // resync as the loop continues.
-            i += 1;
-            continue;
-        }
-
-        uint32_t cp;
-        uint32_t min_cp;
-
-        switch (seqlen)
-        {
-            case 1:  cp = b0;          min_cp = 0;      break;
-            case 2:  cp = b0 & 0x1F;   min_cp = 0x80;    break;
-            case 3:  cp = b0 & 0x0F;   min_cp = 0x800;   break;
-            default: cp = b0 & 0x07;   min_cp = 0x10000; break;
-        }
-
-        bool ok = true;
-
-        for (int k = 1; k < seqlen; k++)
-        {
-            unsigned char bc = (unsigned char)buf[i + (size_t)k];
-
-            if ((bc & 0xC0) != 0x80)
+            switch (seqlen)
             {
-                ok = false;
-                break;
+                case 1:  cp = b0;          min_cp = 0;       break;
+                case 2:  cp = b0 & 0x1F;   min_cp = 0x80;    break;
+                case 3:  cp = b0 & 0x0F;   min_cp = 0x800;   break;
+                default: cp = b0 & 0x07;   min_cp = 0x10000; break;
             }
 
-            cp = (cp << 6) | (uint32_t)(bc & 0x3F);
+            complete = true;
+
+            for (int k = 1; k < seqlen; k++)
+            {
+                unsigned char bc = (unsigned char)buf[i + (size_t)k];
+
+                if ((bc & 0xC0) != 0x80)
+                {
+                    complete = false;
+                    break;
+                }
+
+                cp = (cp << 6) | (uint32_t)(bc & 0x3F);
+            }
         }
 
-        if (!ok || cp < min_cp || (cp >= 0xD800 && cp <= 0xDFFF) || cp > 0x10FFFF)
+        if (!complete)
         {
-            // Invalid continuation, overlong encoding, an encoded
-            // surrogate, or a codepoint beyond U+10FFFF -- drop only the
-            // lead byte and resync from the next one.
+            // CHR-03: these bytes do not form a UTF-8 sequence at all -- a
+            // stray continuation byte, a lead byte whose continuations are
+            // missing or wrong, a sequence cut off by the end of the
+            // buffer, or one of the bytes RFC 3629 never assigns as a lead
+            // (0xC0, 0xC1, 0xF5-0xFF). Every one of those is 0x80-0xFF --
+            // an ASCII byte always forms a complete one-byte sequence and
+            // never lands here -- so this is the legacy single-byte range
+            // and the byte is kept as-is, Latin-1 or CP1252 as the sender
+            // meant it (see the range note at the top of this file).
+            // Exactly one byte is consumed, so the next iteration resyncs
+            // on whatever follows and a run of legacy bytes never eats an
+            // adjacent valid character.
+            buf[out] = (char)b0;
+            out += 1;
             i += 1;
+            continue;
+        }
+
+        if (cp < min_cp || (cp >= 0xD800 && cp <= 0xDFFF) || cp > 0x10FFFF)
+        {
+            // A structurally well-formed sequence that RFC 3629 still
+            // forbids: an overlong encoding, an encoded surrogate, or a
+            // codepoint beyond U+10FFFF. Drop the WHOLE sequence, not just
+            // the lead byte -- with the Latin-1 fallback above in place,
+            // resyncing into the middle of such a sequence would hand its
+            // continuation bytes (0xA0-0xBF) back as Latin-1 characters and
+            // leak a fragment of exactly the payload this branch rejects.
+            i += (size_t)seqlen;
             continue;
         }
 

--- a/src/charset_filter.h
+++ b/src/charset_filter.h
@@ -1,6 +1,6 @@
 /**
- * CHR-01 / CHR-02 (docs/BACKLOG.md §3.8p) -- UTF-8 allowlist character
- * filter for message text and APRS free text.
+ * CHR-01 / CHR-02 / CHR-03 (docs/BACKLOG.md §3.8p) -- UTF-8 plus Latin-1
+ * allowlist character filter for message text and APRS free text.
  *
  * Pure C++, no Arduino/String dependency -- unit-tested natively
  * (test_charset_filter) and linked straight into aprs_functions.cpp /
@@ -10,15 +10,52 @@
  *   - printable ASCII 0x20-0x7E passes.
  *   - C0 controls (0x00-0x1F) and DEL (0x7F) are stripped.
  *   - C1 controls (U+0080-U+009F) are stripped.
- *   - invalid and overlong UTF-8 byte sequences are dropped. Validation is
- *     strict RFC 3629: rejects overlong forms, encoded surrogates
- *     (U+D800-U+DFFF) and any codepoint above U+10FFFF. A byte that cannot
- *     start or continue a valid sequence is dropped one byte at a time, so
- *     a run of invalid bytes never eats an adjacent valid character.
+ *   - UTF-8 validation is strict RFC 3629: a structurally well-formed
+ *     sequence that encodes an overlong form, a surrogate (U+D800-U+DFFF)
+ *     or a codepoint above U+10FFFF is dropped WHOLE, continuation bytes
+ *     included, so no fragment of it can survive via the Latin-1 rule
+ *     below.
+ *   - CHR-03: bytes that form no UTF-8 sequence at all -- a stray
+ *     continuation byte, a lead byte without its continuations, a sequence
+ *     cut off by the end of the buffer, or the bytes 0xC0/0xC1/0xF5-0xFF
+ *     that RFC 3629 never assigns as a lead -- are legacy single-byte
+ *     characters and pass through unchanged. That is the whole range
+ *     0x80-0xFF: 0xA0-0xFF is the same in Latin-1 and CP1252, and
+ *     0x80-0x9F is passed as CP1252 (Euro sign, typographic quotes,
+ *     dashes) by operator decision 2026-09-09, because the senders here
+ *     that use single-byte umlauts use CP1252. Exactly one byte is
+ *     consumed, so a run of legacy bytes never eats an adjacent valid
+ *     character.
+ *
+ *     Two consequences of passing 0x80-0x9F, so nobody has to rediscover
+ *     them: a receiver that reads the stream as ISO-8859-1 instead of
+ *     CP1252 sees C1 control codes in message text, and the five bytes
+ *     undefined even in CP1252 (0x81, 0x8D, 0x8F, 0x90, 0x9D) are relayed
+ *     too and render as U+FFFD at the far end. This does NOT contradict
+ *     the C1 rule above, which still strips U+0080-U+009F arriving as a
+ *     proper C2 80..C2 9F sequence: a raw 0x80 in a legacy stream is a
+ *     Euro sign, a deliberately UTF-8-encoded U+0080 is the control
+ *     character PAD.
  *   - a small table of bidi/zero-width format characters is stripped:
  *     U+200B-U+200F, U+202A-U+202E, U+2060-U+2064, U+FEFF.
  *   - everything else -- umlauts, emoji, any other valid printable UTF-8 --
  *     passes unchanged.
+ *
+ * Consequence of CHR-03, stated plainly: the output is NO LONGER guaranteed
+ * to be valid UTF-8. A sender that puts umlauts on the wire as single
+ * legacy bytes (PinPoint does) now has them relayed byte-for-byte instead
+ * of silently deleted, and it is the receiving end that decides how to
+ * read them -- mc-chat's decoder does exactly this, re-reading every byte
+ * UTF-8 rejects as CP1252 (mc-chat commit 993b512). Nothing is transcoded
+ * here: the filter only ever removes bytes, never rewrites or expands one,
+ * so every caller's in-place buffer contract stays intact.
+ *
+ * The one case the legacy pass-through cannot reach: two adjacent legacy
+ * bytes that happen to form a syntactically valid UTF-8 sequence (e.g.
+ * 0xDF 0xBC, Latin-1 "ss" + "1/4", which is well-formed UTF-8 for U+07FC).
+ * Those are read as UTF-8 and pass as that codepoint. Distinguishing the
+ * two readings needs statistics over the whole text, not a byte-local
+ * decision, and this filter is byte-local by design.
  *
  * CHARSET_FILTER_STRIP_SEPARATORS additionally strips a small set of ASCII
  * bytes that this firmware's own APRS parsers treat as field delimiters.

--- a/src/command_functions.cpp
+++ b/src/command_functions.cpp
@@ -19,6 +19,8 @@
 #include "spectral_scan.h"
 #include "rtc_functions.h"
 #include "maxhop.h"
+#include "settings_sanitize.h" // #1132: resolve_tx_power sentinel normalization
+#include "track_warning.h" // TRK-01: Warnhinweis bei aktivem Track
 #ifdef ESP32
 #include "net_console.h"
 #endif
@@ -27,6 +29,7 @@
 
 #ifdef ESP32
 #include "esp32/esp32_functions.h"
+#include "esp32/esp32_sleep.h"
 #endif
 
 // Sensors
@@ -847,6 +850,10 @@ void commandAction(char *umsg_text, bool ble)
                 printlndeb("--setboostedgain    on/off  enable/disable boosted rx gain");
             #endif
             delay(100);
+            // INS-01: these live inside the INSTRUMENT_ENABLED block in
+            // commandAction() and do not exist in a normal board build, so
+            // --help must not advertise them there.
+            #if INSTRUMENT_ENABLED
             printlndeb("--injectmsg <grp|call> <text>  queue a text as if received via LoRa");
             delay(100);
             printlndeb("--injectraw <hex>  feed a raw frame through the real RX path (decodeAPRS/dedup/relay)");
@@ -856,6 +863,7 @@ void commandAction(char *umsg_text, bool ble)
             printlndeb("--redrawlog on/off, --uistat, --tab list/<n>, --drawer on/off, --playtone start/msg/<file>, --tft on/off/state, --screencrc");
             delay(100);
             printlndeb("--spitrace on/off, --touch tap <x> <y> [ms] / down <x> <y> / up");
+            #endif
             #endif
 
             // DOC-02: everything above predates this pass and is kept as it
@@ -877,7 +885,7 @@ void commandAction(char *umsg_text, bool ble)
             printlndeb("--relay on/off  mesh relay\n");
             delay(100);
             #endif
-            printlndeb("--gps autosymbol/fixsymbol  APRS symbol source\n--via on/off/<call>  set via callsign\n--viadebug on/off\n");
+            printlndeb("--gps autosymbol/fixsymbol  APRS symbol source\n--via on/off/<call>  set via callsign\n--viadebug on/off\n--ackinfo on/off  show who ACKed, not saved to flash\n");
             delay(100);
             printlndeb("--debug csv/man/en/de  debug output format/language\n");
             delay(100);
@@ -893,7 +901,7 @@ void commandAction(char *umsg_text, bool ble)
             printlndeb("--setrtc yyyy.mm.dd hh:mm:ss  set RTC chip\n");
             delay(100);
             #endif
-            printlndeb("--setpress 999.9  set QNH reference\n--setublox <cmd>  u-blox GPS passthrough\n--setl76k <cmd>  L76K GPS passthrough\n");
+            printlndeb("--setpress  latch QNH reference at current altitude\n--setublox <cmd>  u-blox GPS passthrough\n--setl76k <cmd>  L76K GPS passthrough\n");
             delay(100);
             #ifdef BOARD_LED
             printlndeb("--board led on/off  board LED\n");
@@ -915,17 +923,30 @@ void commandAction(char *umsg_text, bool ble)
             printlndeb("--t5 on/off  E-paper power\n");
             delay(100);
             #endif
+            #if INSTRUMENT_ENABLED
             printlndeb("--nopmother on/off  suppress foreign DMs to the EXTUDP peer\n--ntpsync  request an immediate NTP refresh now\n");
+            #else
+            printlndeb("--nopmother on/off  suppress foreign DMs to the EXTUDP peer\n");
+            #endif
             delay(100);
+            #if defined(ESP32)
+            printlndeb("--wifistat  WiFi link/counters\n--udpstat  MeshCom UDP RX/TX counters\n--udplog on/off  one [UDP] line per datagram\n");
+            delay(100);
+            #endif
+            #if defined(NRF52_SERIES)
+            printlndeb("--ethstat  Ethernet link/counters\n--udplog on/off  one [UDP] line per datagram\n");
+            delay(100);
+            #endif
 
-            // DOC-02: INSTRUMENT_ENABLED (src/instrument.h) defaults to 1 on
-            // ESP32 and nRF52 and is never overridden in any platformio.ini
-            // env, so the ~50-command bench/instrument surface (--heap,
+            // DOC-02: the ~50-command bench/instrument surface (--heap,
             // --instr, --injectmsg, --tft, --srvip, --flashpoke, --disptest,
-            // ... see src/instrument.h) ships in every board build today --
-            // there is no clean/dev split to advertise honestly here, so
-            // --help does not enumerate that block command by command.
-            printlndeb("(bench/instrument commands -- INSTRUMENT_ENABLED, on by default in every board build, see src/instrument.h -- not listed individually here)\n");
+            // --ntpsync, ... see src/instrument.h) is compiled out of a normal
+            // board build and only present in a measurement firmware built
+            // with -D INSTRUMENT_ENABLED=1. Announce it only where it exists,
+            // and do not enumerate the block command by command.
+            #if INSTRUMENT_ENABLED
+            printlndeb("(bench/instrument commands -- this is an INSTRUMENT_ENABLED=1 measurement build, see src/instrument.h -- not listed individually here)\n");
+            #endif
         }
 
         return;
@@ -1040,45 +1061,27 @@ void commandAction(char *umsg_text, bool ble)
     else
     if(commandCheck(msg_text+2, (char*)"deepsleep") == 0)
     {
-        #if defined(vEXT_CTRL)
-            digitalWrite(VEXT_CTRL, LOW);   // HWT needs this for GPS and TFT Screen
-            digitalWrite(ADC_CTRL, LOW);
-        #endif
-
+        // NB: vEXT_CTRL (dead, no variant defines the lowercase macro) and the
+        // BOARD_HELTEC/_V3/_V4 Vext-off block that used to live here have moved
+        // into esp32EnterDeepSleep() (src/esp32/esp32_sleep.cpp), which the
+        // generic ESP32 branch below now calls. GPS_SWITCH stays here: it also
+        // has to fire on the WP_DISP (Vision Master E213) branch just below,
+        // which is out of scope for this pass and must not change.
         #if defined(GPS_SWITCH)
             digitalWrite(GPS_SWITCH, LOW);   // externes GPS im deepsleep ausschalten, Flashwerte aber für wakeup bestehen lassen
         #endif
 
-        #if defined(BOARD_HELTEC) || defined(BOARD_HELTEC_V3)
-            printlndeb(F("[INIT]...Disbling Vext for OLED power"));
-            pinMode(Vext, OUTPUT);
-            digitalWrite(Vext, HIGH);   // Vext OFF (active high)
-            delay(50);
-        #endif
-
-        #if defined(BOARD_HELTEC_T114)
-            
-            // GPIO21: LOW - power off GPS
-            // GPIO15: HIGH - power off LCD LED
-            // GPIO25: LOW - power off LORA
-
-            extern bool bDEEP_SLEEP;
-
-            if(bDEEP_SLEEP)
-            {
-                bDEEP_SLEEP = false;
-            }
-            else
-            {
-                stop_advertising();
-                
-                digitalWrite(PIN_VEXT_CTL, LOW);   // GPS
-                digitalWrite(PIN_TFT_LEDA_CTL, HIGH);   // TFT OFF
-                digitalWrite(PIN_TFT_VDD_CTL, HIGH);   // TFT VDD
-                digitalWrite(LORA_NRSET, LOW);   // LORA
-                
-                bDEEP_SLEEP = true;
-            }
+        #if defined(NRF52_SERIES)
+            // Issue 962 (docs/issue-962-deepsleep-verdict.md, section 6.4):
+            // real nRF52 System OFF for all three nRF52 boards (RAK4631,
+            // Heltec T114, T-Echo). Replaces the old T114-only bDEEP_SLEEP
+            // toggle (soft-off, needed a second --deepsleep call to "wake")
+            // and the RAK4631 no-op (this command did nothing at all for
+            // it). See src/nrf52/nrf52_sleep.cpp for the sequence; wake is a
+            // button press, USB plug-in, or RESET -- not a second
+            // --deepsleep call.
+            extern void nrf52EnterDeepSleep();
+            nrf52EnterDeepSleep();
         #else
             #if defined(WP_DISP)
             // GRAU-FIX (v.a. Akku-leer-Pfad): Bei fast leerem Akku konkurriert der energiehungrige
@@ -1109,8 +1112,13 @@ void commandAction(char *umsg_text, bool ble)
             delay(100);
             Platform::prepareToSleep();
             #endif
-            #if not defined(BOARD_RAK4630)
+            #if defined(WP_DISP)
             esp_deep_sleep_start();
+            #else
+            // Issue 962 / Option A: every other ESP32 board -- radio to
+            // sleep, display off, PMU LoRa/GPS rails off, button wake
+            // armed, then esp_deep_sleep_start(). See esp32_sleep.cpp.
+            esp32EnterDeepSleep();
             #endif
         #endif
 
@@ -1620,6 +1628,9 @@ void commandAction(char *umsg_text, bool ble)
     if(commandCheck(msg_text+2, (char*)"track on") == 0)
     {
         bDisplayTrack=true;
+
+        // TRK-01: Warnhinweis bei jeder Bedienung ausgeben, auch wenn Track schon an war
+        printfdeb(TRACK_WARNING_SERIAL "\n");
 
         track_to_meshcom_timer=0;   // damit auch alle 5 minuten zu MeshCom gesendet wird wenn TRACK ON
 
@@ -2338,6 +2349,32 @@ void commandAction(char *umsg_text, bool ble)
         bReturn = true;
 
         save_settings();
+    }
+    else
+    if(commandCheck(msg_text+2, (char*)"ackinfo on") == 0)
+    {
+        // fluechtig: nie in meshcom_settings, nie ins Flash, siehe
+        // docs/ack-implementierungsplan.md 3.5
+        bAckInfo=true;
+
+        if(ble)
+        {
+            addBLECommandBack((char*)"--ackinfo on");
+        }
+
+        return;
+    }
+    else
+    if(commandCheck(msg_text+2, (char*)"ackinfo off") == 0)
+    {
+        bAckInfo=false;
+
+        if(ble)
+        {
+            addBLECommandBack((char*)"--ackinfo off");
+        }
+
+        return;
     }
     else
     if(commandCheck(msg_text+2, (char*)"gateway pos") == 0)
@@ -4699,6 +4736,53 @@ void commandAction(char *umsg_text, bool ble)
     }
     //
     ///////////////////////////////////////////////////////////////////////////
+    // Field diagnostics for gateway operators. Deliberately NOT part of the
+    // INSTRUMENT_ENABLED bench surface below: a node in the field has to be
+    // able to log its UDP / WiFi / Ethernet path without a special build.
+    //
+    #if defined(NRF52_SERIES)
+    else
+    if(commandCheck(msg_text+2, (char*)"ethstat") == 0)
+    {
+        extern void ethStat();
+        ethStat();
+        return;
+    }
+    else
+    if(commandCheck(msg_text+2, (char*)"udplog on") == 0 || commandCheck(msg_text+2, (char*)"udplog off") == 0)
+    {
+        // TM-38 follow-up / TM-39: nRF52 parity for the per-datagram [UDP];rx/tx marker
+        extern bool bUDPLOG;
+        bUDPLOG = (commandCheck(msg_text+2, (char*)"udplog on") == 0);
+        Serial.printf("[UDP];log;%d\n", bUDPLOG ? 1 : 0);
+        return;
+    }
+    #endif
+    #if defined(ESP32)
+    else
+    if(commandCheck(msg_text+2, (char*)"wifistat") == 0)
+    {
+        wifiStat();
+        return;
+    }
+    else
+    if(commandCheck(msg_text+2, (char*)"udpstat") == 0)
+    {
+        // RX/TX counters of the MeshCom UDP socket
+        udpPrintStat();
+        return;
+    }
+    else
+    if(commandCheck(msg_text+2, (char*)"udplog on") == 0 || commandCheck(msg_text+2, (char*)"udplog off") == 0)
+    {
+        // one [UDP];rx / [UDP];tx line per datagram
+        bUDPLOG = (commandCheck(msg_text+2, (char*)"udplog on") == 0);
+        Serial.printf("[UDP];log;%d\n", bUDPLOG ? 1 : 0);
+        return;
+    }
+    #endif
+    //
+    ///////////////////////////////////////////////////////////////////////////
 #if INSTRUMENT_ENABLED
     ///////////////////////////////////////////////////////////////////////////
     // TEMPORARY measurement commands -- see src/instrument.h. Removed together
@@ -4764,13 +4848,6 @@ void commandAction(char *umsg_text, bool ble)
     }
     #if defined(NRF52_SERIES)
     else
-    if(commandCheck(msg_text+2, (char*)"ethstat") == 0)
-    {
-        extern void ethStat();
-        ethStat();
-        return;
-    }
-    else
     if(commandCheck(msg_text+2, (char*)"ethdrop") == 0)
     {
         // TM-35 bench hook: run the firmware's recovery path (resetDHCP), timed
@@ -4778,38 +4855,8 @@ void commandAction(char *umsg_text, bool ble)
         ethDrop();
         return;
     }
-    else
-    if(commandCheck(msg_text+2, (char*)"udplog on") == 0 || commandCheck(msg_text+2, (char*)"udplog off") == 0)
-    {
-        // TM-38 follow-up / TM-39: nRF52 parity for the per-datagram [UDP];rx/tx marker
-        extern bool bUDPLOG;
-        bUDPLOG = (commandCheck(msg_text+2, (char*)"udplog on") == 0);
-        Serial.printf("[UDP];log;%d\n", bUDPLOG ? 1 : 0);
-        return;
-    }
     #endif
     #if defined(ESP32)
-    else
-    if(commandCheck(msg_text+2, (char*)"wifistat") == 0)
-    {
-        wifiStat();
-        return;
-    }
-    else
-    if(commandCheck(msg_text+2, (char*)"udpstat") == 0)
-    {
-        // TM-31 bench hook: RX/TX counters of the MeshCom UDP socket
-        udpPrintStat();
-        return;
-    }
-    else
-    if(commandCheck(msg_text+2, (char*)"udplog on") == 0 || commandCheck(msg_text+2, (char*)"udplog off") == 0)
-    {
-        // TM-31 bench hook: one [UDP];rx / [UDP];tx line per datagram
-        bUDPLOG = (commandCheck(msg_text+2, (char*)"udplog on") == 0);
-        Serial.printf("[UDP];log;%d\n", bUDPLOG ? 1 : 0);
-        return;
-    }
     else
     if(commandCheck(msg_text+2, (char*)"wifidrop") == 0)
     {
@@ -5815,8 +5862,8 @@ void commandAction(char *umsg_text, bool ble)
             printfdeb("...DEBUG %s ...LORADEBUG %s ...GPSDEBUG %s/%i ...SOFTSERDEBUG %s\n...WXDEBUG %s ...BLEDEBUG %s\n",
                 (bDEBUG?"on":"off"), (bLORADEBUG?"on":"off"), (iGPSDEBUG?"on":"off"), iGPSDEBUG, (bSOFTSERDEBUG?"on":"off"),(bWXDEBUG?"on":"off"), (bBLEDEBUG?"on":"off"));
             
-            printfdeb("...DisplayInfo %s ...DisplayCont %s ...DisplyLog %s ...contrast %i\n",
-                (bDisplayInfo?"on":"off"), (bDisplayCont?"on":"off"), (bDisplayLog?"on":"off"), meshcom_settings.node_contrast);
+            printfdeb("...DisplayInfo %s ...DisplayCont %s ...DisplyLog %s ...contrast %i ...ackinfo %s\n",
+                (bDisplayInfo?"on":"off"), (bDisplayCont?"on":"off"), (bDisplayLog?"on":"off"), meshcom_settings.node_contrast, (bAckInfo?"on":"off"));
 
             #if defined(BOARD_T_DECK) || defined(BOARD_T_DECK_PLUS)
             // TD-10: raw-mode verdict of the keyboard controller. "no" or a
@@ -5884,7 +5931,10 @@ void commandAction(char *umsg_text, bool ble)
 
             if(bAnalogCheck)
             {
-                printfdeb("\n...ANALOG PIN %i factor %.4f slope %.4f offset %.0f\n", meshcom_settings.node_analog_pin, meshcom_settings.node_analog_faktor, meshcom_settings.node_analog_slope, meshcom_settings.node_analog_offset);
+                if(meshcom_settings.node_analog_pin <= 0 || meshcom_settings.node_analog_pin >= 99)
+                    printfdeb("\n...ANALOG PIN %i factor %.4f slope %.4f offset %.0f (GPIO not set, measurement paused)\n", meshcom_settings.node_analog_pin, meshcom_settings.node_analog_faktor, meshcom_settings.node_analog_slope, meshcom_settings.node_analog_offset);
+                else
+                    printfdeb("\n...ANALOG PIN %i factor %.4f slope %.4f offset %.0f\n", meshcom_settings.node_analog_pin, meshcom_settings.node_analog_faktor, meshcom_settings.node_analog_slope, meshcom_settings.node_analog_offset);
                 printfdeb("...Value %.2f V\n", fAnalogValue);
                 printfdeb("");
             }
@@ -6186,10 +6236,7 @@ void sendNodeSetting()
     {
         meshcom_settings.node_bw = LORA_BANDWIDTH;
     }
-    if (meshcom_settings.node_power == 0)
-    {
-        meshcom_settings.node_power = TX_OUTPUT_POWER;
-    }
+    meshcom_settings.node_power = resolve_tx_power(meshcom_settings.node_power, TX_OUTPUT_POWER); // #1132: also normalize the -20 "unset" sentinel, not just 0
 
     // if we are on nrf52 we need to change frequency reading to MHz
     #ifdef BOARD_RAK4630

--- a/src/configuration_global.h
+++ b/src/configuration_global.h
@@ -70,7 +70,8 @@ inline bool isUnconfiguredCall(const char *call)
 // beim Sprung 20260724 -> 20260821 passiert: dieser Commit hat esp32_flash.h
 // nicht angefasst, die Einstellungen aller Knoten aber trotzdem verworfen.
 //
-// FLASH_VERSION 20260901 ist der Release-Stempel v4.35p.09.01-stability --
+// FLASH_VERSION 20260909 ist der Release-Stempel von v4.35s.09.09
+// (Release-Stempel davor war 20260906) --
 // rein informativ, loest kein clear_flash() aus.
 //
 // FLASH_STRUCT_VERSION bleibt 20260724: letzte echte Layout-Aenderung war
@@ -78,7 +79,7 @@ inline bool isUnconfiguredCall(const char *call)
 // kamen hinzu. Alles seither (auch die neuen Features wie max_hop_text) nutzt
 // auf ESP32 eigene NVS-Keys bzw. freie Bits bestehender Felder und aendert
 // das Struct-Layout nicht.
-#define FLASH_VERSION 20260901
+#define FLASH_VERSION 20260909
 #define FLASH_STRUCT_VERSION 20260724
 
 // Bestandsschutz. Diese Staende tragen dasselbe Layout wie

--- a/src/esp32/esp32_main.cpp
+++ b/src/esp32/esp32_main.cpp
@@ -16,6 +16,7 @@
 #include "dedup_functions.h"
 #include "ntp_async.h"      // NTP-01: isPending() haelt das GPS-Gate fuer --ntpsync offen
 #include "instrument.h"     // TEMPORARY -- measurement scaffolding, see src/instrument.h
+#include "track_warning.h" // TRK-01: Warnhinweis bei aktivem Track
 #include <maxhop.h>         // CS-01: plausibility of the persisted text hop limit
 #include <RadioLib.h>
 
@@ -638,8 +639,24 @@ void esp32setup()
     ///< Initialize T5-EPAPER GUI
     ///< delay for ESP32-S3 nativ USB [OE3WAS]
     ///< um Terminal verbinden zu können
+#if ARDUINO_USB_CDC_ON_BOOT && ARDUINO_USB_MODE && defined(DISABLE_NET_CONSOLE)
+    // CDC-02: must run BEFORE Serial.begin(). HWCDC::begin() (arduino-esp32
+    // cores/esp32/HWCDC.cpp) creates the 256 B tx ring buffer and enables the
+    // TX ISR; setTxBufferSize() on an already-begun HWCDC deletes and NULLs
+    // that buffer before recreating it, and the ISR dereferences it without a
+    // NULL check, so a live resize races the ISR and can assert/crash. Sizing
+    // before begin() avoids the race. Full rationale at
+    // MeshSerialClass::begin() (src/net_console.cpp).
+    Serial.setTxBufferSize(4096);
+#endif
     Serial.begin(MONITOR_SPEED);
     Serial.setTimeout(50);
+
+#if ARDUINO_USB_CDC_ON_BOOT && ARDUINO_USB_MODE && defined(DISABLE_NET_CONSOLE)
+    // CDC-01: without the net-console wrapper Serial is the HWCDC object
+    // itself; the rationale sits at MeshSerialClass::begin() (net_console.cpp).
+    Serial.setTxTimeoutMs(0);
+#endif
     
 // 1.1.1??   pinMode(45,OUTPUT);
 // 1.1.1??    digitalWrite(45, LOW);
@@ -740,6 +757,9 @@ void esp32setup()
         esp_reset_reason_t rr = esp_reset_reason();
         Serial.printf("[BOOT] RESET_REASON=%d %s\n", (int)rr, resetReasonName(rr));
     }
+#if INSTRUMENT_ENABLED
+    instrument_report_prev_boot();   // CDC-01: loop gaps of the previous boot, from RTC memory
+#endif
 
     lFreeHeap =  ESP.getFreeHeap();
     lFreePsram = ESP.getFreePsram();
@@ -818,6 +838,10 @@ void esp32setup()
     bGATEWAY =  meshcom_settings.node_sset & 0x1000;
     bEXTUDP =  meshcom_settings.node_sset & 0x2000;
     bDisplayCont = meshcom_settings.node_sset & 0x4000;
+
+    // TRK-01: Warnhinweis einmal beim Boot, wenn Track aus den Settings aktiv geladen wurde
+    if(bDisplayTrack)
+        printfdeb("[INIT]..." TRACK_WARNING_SERIAL "\n");
 
     bONEWIRE =  meshcom_settings.node_sset2 & 0x0001;
     bLPS33 =  meshcom_settings.node_sset2 & 0x0002;
@@ -1282,6 +1306,14 @@ void esp32setup()
 
         #if defined(BOARD_TBEAM_1W)
         #ifdef RADIO_LDO_EN
+            // Issue 962 deepsleep (esp32_sleep.cpp): --deepsleep holds this
+            // pin low with gpio_hold_en()/gpio_deep_sleep_hold_en() so it
+            // doesn't float during sleep. That hold survives the wake reset
+            // (esp_idf gpio.h), so the digitalWrite(HIGH) below would be
+            // silently ignored without releasing it first.
+            gpio_hold_dis((gpio_num_t) RADIO_LDO_EN);
+            gpio_deep_sleep_hold_dis();
+
             // T-BEAM-1W Control SX1262, LNA, must set RADIO_LDO_EN to HIGH to power the Radio
             pinMode(RADIO_LDO_EN, OUTPUT);
             digitalWrite(RADIO_LDO_EN, HIGH);
@@ -1296,6 +1328,18 @@ void esp32setup()
             digitalWrite(RADIO_CTRL, HIGH);  // RX Mode
             delay(200);
         #endif
+        #endif
+
+        #if defined(BOARD_WIRELESS_PAPER) || defined(BOARD_E213)
+            // DS-02: prepareToSleep() in src/Platforms/<board>/power_controls.cpp
+            // holds PIN_LORA_NSS HIGH with gpio_hold_en() before deep sleep.
+            // ESP-IDF gpio.h: the hold survives the deep-sleep wake reset and is
+            // released only by gpio_hold_dis(). Without this the SPI chip-select
+            // can never go LOW after the first wake and the radio is dead until a
+            // power cycle. GPIO8 is RTC-capable but the sleep side never arms
+            // gpio_deep_sleep_hold_en(), so no gpio_deep_sleep_hold_dis() is needed.
+            // No-op on a cold boot. Not bench-verified: no WP/E213 hardware.
+            gpio_hold_dis((gpio_num_t) PIN_LORA_NSS);
         #endif
 
         #if defined(EXTERNAL_RADIO)
@@ -2990,6 +3034,7 @@ void esp32loop()
 
         g_ble_uart_is_connected = false;
         isPhoneReady = 0;
+        bAckInfo = false;
         config_to_phone_prepare = false;
         conffin_sent = false;
 
@@ -3255,7 +3300,7 @@ void esp32loop()
                             sdmap_lastKnownLon = meshcom_settings.node_lon;
                         }
 
-                        sdmap_refresh(map_ta, sdmap_lastKnownLat, sdmap_lastKnownLon);
+                        sdmap_refresh(map_ta, sdmap_lastKnownLat, sdmap_lastKnownLon, "boundary");
                         refresh_map(meshcom_settings.node_map);
                     }
                 }

--- a/src/esp32/esp32_pmu.cpp
+++ b/src/esp32/esp32_pmu.cpp
@@ -323,7 +323,7 @@ void setupPMU()
         #ifndef BOARD_TBEAM_V3
             BOARD_HARDWARE = TBEAM_AXP2101;
         #endif
-        
+
         printlndeb("[INIT]...All AXP2101 started");
     }
     else
@@ -334,6 +334,47 @@ void setupPMU()
     }
 
     delay(100);
+
+    #endif
+}
+
+// Issue 962 / --deepsleep: cut the LoRa + GPS rails only. Channel names below
+// are the same ones setupPMU() assigns above -- LoRa/GPS per chip and board,
+// mirrored here so the disable list can never drift from the enable list.
+// The ESP32-feeding rail (DCDC3 on AXP192, DCDC1 on AXP2101, both left
+// unset/protected above) and the OLED rail (DCDC1 on AXP192) are
+// deliberately not touched here: cutting DCDC3 would brown out the ESP32
+// mid-shutdown, and OLED power-down is handled separately via
+// u8g2->setPowerSave(1) in esp32EnterDeepSleep().
+void pmuSleepRails()
+{
+    #if defined(XPOWERS_CHIP_AXP192) || defined(XPOWERS_CHIP_AXP2101)
+
+    if (PMU != NULL)
+    {
+        if (PMU->getChipModel() == XPOWERS_AXP192)
+        {
+            // ttgo_tbeam / ttgo_tbeam_SX1262 / ttgo_tbeam_SX1268: LoRa on
+            // LDO2, GPS on LDO3 (see the AXP192 branch of setupPMU() above).
+            PMU->disablePowerOutput(XPOWERS_LDO2);
+            PMU->disablePowerOutput(XPOWERS_LDO3);
+        }
+        else if (PMU->getChipModel() == XPOWERS_AXP2101)
+        {
+            #if defined(BOARD_TBEAM_V3)
+            // ttgo_tbeam_supreme: LoRa on ALDO3, GPS on ALDO4 (see the
+            // BOARD_TBEAM_V3 branch of setupPMU() above). Sensor/SD/m.2
+            // channels (ALDO1/ALDO2/BLDO1/BLDO2/DCDC3/4/5) stay on.
+            PMU->disablePowerOutput(XPOWERS_ALDO3);
+            PMU->disablePowerOutput(XPOWERS_ALDO4);
+            #else
+            // Generic AXP2101 board: LoRa on ALDO2, GPS on ALDO3 (see the
+            // non-BOARD_TBEAM_V3 branch of setupPMU() above).
+            PMU->disablePowerOutput(XPOWERS_ALDO2);
+            PMU->disablePowerOutput(XPOWERS_ALDO3);
+            #endif
+        }
+    }
 
     #endif
 }

--- a/src/esp32/esp32_pmu.h
+++ b/src/esp32/esp32_pmu.h
@@ -5,4 +5,11 @@
 
 void setupPMU();
 
+// Disable the LoRa and GPS power rails ahead of --deepsleep. No-op on boards
+// without an AXP192/AXP2101 PMU (PMU stays NULL) and a no-op if setupPMU()
+// never found a chip. Leaves the ESP32-feeding rail, the OLED rail and every
+// other channel (SD, sensors, m.2) alone -- only the two channels setupPMU()
+// documents as LoRa/GPS are touched here.
+void pmuSleepRails();
+
 #endif

--- a/src/esp32/esp32_sleep.cpp
+++ b/src/esp32/esp32_sleep.cpp
@@ -1,0 +1,195 @@
+// Issue 962 (docs/issue-962-deepsleep-verdict.md, Option A). See esp32_sleep.h.
+
+#include "esp32_sleep.h"
+
+#include <Arduino.h>
+#include <esp_sleep.h>
+#include <driver/gpio.h>
+
+#include "configuration.h"
+#include "printfdeb_functions.h"
+#include "lora_functions.h"
+#include "esp32_pmu.h"
+#include "batt_functions.h"
+
+// Runtime wake-button GPIO (loop_functions.cpp:186). Seeded from the
+// compile-time BUTTON_PIN at boot but overridable via `--button <pin>` /
+// meshcom_settings.node_button_pin (esp32_main.cpp:889-896); 99 means "no
+// button configured". Arming the wake source on the compile-time macro
+// instead of this variable would ignore a user's remapped pin.
+extern uint8_t iButtonPin;
+
+#if defined(BOARD_T_DECK) || defined(BOARD_T_DECK_PLUS)
+#include <t-deck/lv_obj_functions.h>
+#endif
+
+// Same negative guard command_functions.cpp and loop_functions.cpp use to
+// declare/define the U8G2 display object: boards on a different display
+// technology (e-ink WP_DISP, TFT/LVGL T-Deck family, T5-epaper, T-Connect
+// Pro, BOARD_TRACKER) or with no display driven from this TU (nRF52
+// BOARD_HELTEC_T114/BOARD_T_ECHO) never compile the `u8g2` symbol at all --
+// keep this file's reference to it under the identical guard or those
+// boards fail to link.
+#if !defined(BOARD_E290) && !defined(BOARD_WIRELESS_PAPER) && !defined(BOARD_E213) && !defined(BOARD_T_DECK) && !defined(BOARD_T_DECK_PLUS) && !defined(BOARD_TRACKER) && !defined(BOARD_HELTEC_T114) && !defined(BOARD_T_ECHO) && !defined(BOARD_T5_EPAPER) && !defined(BOARD_T_DECK_PRO) && !defined(BOARD_T_CONNECT_PRO)
+#include <U8g2lib.h>
+extern U8G2 *u8g2;
+#endif
+
+void esp32EnterDeepSleep()
+{
+    // (a) Radio to sleep first, so it stops burning RX current while the
+    // rest of this sequence runs. Guarded exactly like the loraDeepSleep()
+    // declaration in lora_functions.h: only compiled where lora_functions.cpp
+    // has a real `radio` object of a matching RadioLib type in scope, and
+    // never for WP_DISP boards, which keep their own Platform::loraToSleep()
+    // call at the --deepsleep call site in command_functions.cpp.
+    #if (defined(SX127X) || defined(BOARD_E220) || defined(SX1262X) || defined(SX126X) || \
+         defined(SX1262_E22) || defined(USING_SX1262) || defined(SX1268_E22) || \
+         defined(SX1262_V3) || defined(SX1262_E290) || defined(SX1262_V4) || \
+         defined(BOARD_T5_EPAPER)) && !defined(WP_DISP)
+    loraDeepSleep();
+    #endif
+
+    // T-Beam-1W: RADIO_LDO_EN (GPIO40) feeds the SX1262 + LNA and is driven
+    // HIGH once at boot (esp32_main.cpp:1294-1297) and never lowered
+    // elsewhere -- radio.sleep() above puts the chip in low-power mode but
+    // this LDO keeps supplying it. gpio_hold_en() survives the wake reset
+    // (esp_idf gpio.h: "retain the pin state through ... system reset
+    // triggered by ... Deep-sleep events"), so boot's own digitalWrite(HIGH)
+    // would silently be ignored without the matching gpio_hold_dis() added
+    // on the wake side in esp32_main.cpp's radio init.
+    #ifdef RADIO_LDO_EN
+    digitalWrite(RADIO_LDO_EN, LOW);
+    gpio_hold_en((gpio_num_t) RADIO_LDO_EN);
+    #endif
+
+    // (b) Display off. u8g2 boards: real power-down via the U8g2 API.
+    // Heltec V2/V3/V4 additionally gate the OLED off its Vext rail (moved
+    // here from the old --deepsleep body, now covering V4 too -- V3 and V4
+    // share the same Vext-gated OLED design, see batt_functions.cpp's own
+    // "#if defined(BOARD_HELTEC_V3) || defined(BOARD_HELTEC_V4)" pattern for
+    // the same pin).
+    #if !defined(BOARD_E290) && !defined(BOARD_WIRELESS_PAPER) && !defined(BOARD_E213) && !defined(BOARD_T_DECK) && !defined(BOARD_T_DECK_PLUS) && !defined(BOARD_TRACKER) && !defined(BOARD_HELTEC_T114) && !defined(BOARD_T_ECHO) && !defined(BOARD_T5_EPAPER) && !defined(BOARD_T_DECK_PRO) && !defined(BOARD_T_CONNECT_PRO)
+    if (u8g2 != NULL)
+    {
+        u8g2->setPowerSave(1);
+    }
+    #endif
+
+    #if defined(BOARD_HELTEC) || defined(BOARD_HELTEC_V3) || defined(BOARD_HELTEC_V4) || defined(BOARD_STICK_V3)
+    printlndeb(F("[INIT]...Disbling Vext for OLED power"));
+    pinMode(Vext, OUTPUT);
+    digitalWrite(Vext, HIGH);   // Vext OFF (active high)
+    delay(50);
+    #endif
+
+    // T-Deck / T-Deck Plus: no u8g2 (LVGL/TFT), no AXP PMU. tft_off() blanks
+    // the panel and already drives TDECK_TFT_BACKLIGHT (GPIO42) LOW as part
+    // of its own dimming sequence; TDECK_POWERON (GPIO10) is the shared
+    // LoRa/GPS/keyboard rail, driven HIGH once at boot
+    // (tdeck_main.cpp:141-142) and otherwise never lowered. Both held LOW
+    // like the WP e-ink path holds its NSS pin, for the same reason: an
+    // unheld digital output floats once the pin's domain powers down in
+    // deep sleep -- confirmed on the bench as a dim, flickering backlight
+    // with the panel blanked (floating GPIO42 picking up noise on the
+    // pulse-dimming driver's EN line). GPIO10 is RTC-capable (S3 RTC/LP
+    // range 0-21) so gpio_hold_en() alone survives actual sleep; GPIO42 is
+    // not, so it additionally needs the gpio_deep_sleep_hold_en() call
+    // below (esp_idf gpio.h: "the state of the digital gpio cannot be held
+    // during Deep-sleep ... unless gpio_deep_sleep_hold_en is also
+    // called"). Released on the wake side in tdeck_main.cpp's initTDeck().
+    #if defined(BOARD_T_DECK) || defined(BOARD_T_DECK_PLUS)
+    tft_off();
+    digitalWrite(TDECK_POWERON, LOW);
+    gpio_hold_en((gpio_num_t) TDECK_POWERON);
+    digitalWrite(TDECK_TFT_BACKLIGHT, LOW);
+    gpio_hold_en((gpio_num_t) TDECK_TFT_BACKLIGHT);
+    #endif
+
+    // esp_idf gpio.h: gpio_hold_en() on a non-RTC ("digital") pad retains
+    // its state through a reset, but NOT through the actual Deep-sleep
+    // power-down, unless gpio_deep_sleep_hold_en() is also armed -- without
+    // it RADIO_LDO_EN (T-Beam-1W, GPIO40) and TDECK_TFT_BACKLIGHT (GPIO42)
+    // would float for the whole sleep duration, not just survive the wake
+    // reset. Only takes effect during actual Deep-sleep ("When the chip is
+    // in active mode, the digital gpio state can be changed freely even you
+    // have called this function") so it is harmless to call unconditionally
+    // on the boards that need it; released on the wake side alongside each
+    // pin's own gpio_hold_dis().
+    #if defined(RADIO_LDO_EN) || defined(BOARD_T_DECK) || defined(BOARD_T_DECK_PLUS)
+    gpio_deep_sleep_hold_en();
+    #endif
+
+    // (c) PMU: LoRa + GPS rails off. No-op on boards without an AXP192/
+    // AXP2101 PMU (T-Beam family only today).
+    pmuSleepRails();
+
+    // (d) heltec_wireless_tracker ("HWT"): VEXT_CTRL/ADC_CTRL gate its
+    // TFT+GPS rail, driven HIGH at boot (esp32_main.cpp:995-999) and never
+    // lowered elsewhere. The block that used to live in command_functions.cpp
+    // guarded on the lowercase `vEXT_CTRL`, which no variant defines (every
+    // variant spells it `VEXT_CTRL`), so it never actually fired for any
+    // board including the tracker -- fixed here rather than carried forward,
+    // since the tracker calls --deepsleep from its long-press
+    // (onebutton_functions.cpp) and would otherwise leave its TFT/GPS
+    // powered through every sleep. Scoped to BOARD_TRACKER: heltec_t114 and
+    // t_echo also define VEXT_CTRL but are nRF52 and never compile this file.
+    #if defined(BOARD_TRACKER) && defined(VEXT_CTRL)
+    digitalWrite(VEXT_CTRL, LOW);
+    #ifdef ADC_CTRL
+    digitalWrite(ADC_CTRL, LOW);
+    #endif
+    #endif
+
+    // (e) Battery ADC divider off. ADC_BATT_OFF() itself is self-guarded on
+    // ADC_CTRL_PIN, but its declaration only exists under USE_NEW_BATT
+    // (batt_functions.h) -- boards without that macro (e.g. Heltec V3) don't
+    // compile the symbol at all, so the call needs the same guard here.
+    #if defined(USE_NEW_BATT)
+    ADC_BATT_OFF();
+    #endif
+
+    // (f) Arm the button (runtime iButtonPin, not the compile-time
+    // BUTTON_PIN -- a node with `--button <pin>` / node_button_pin set would
+    // otherwise wake on the wrong, unconfigured GPIO) as an ext1 wake
+    // source. 99 means no button is configured on this board; arm nothing
+    // rather than a bogus GPIO 99.
+    //
+    // esp_sleep.h: "internal pullups and pulldowns don't work when RTC
+    // peripherals are shut down ... may be kept enabled using
+    // esp_sleep_pd_config" -- OneButton already configures this pin
+    // INPUT_PULLUP (onebutton_functions.cpp). Several boards (E22-DevKitC/
+    // E22_XML/ttgo-lora32-v21 on GPIO12, LilyGo_T-Beam-1W on GPIO17) have no
+    // external pull-up, so without this the pin floats once asleep and
+    // either wakes immediately (ALL_LOW sees a drifting low) or never wakes
+    // at all. Keeping the whole RTC_PERIPH domain powered is the
+    // ESP-IDF-documented alternative to re-enabling pulls pin-by-pin, which
+    // this deliberately avoids: a manual rtc_gpio_pullup_en() on GPIO12
+    // (MTDI, a boot-strapping pin on modules without the VDD_SDIO efuse)
+    // would risk selecting 1.8V flash I/O and failing to boot.
+    //
+    // esp_sleep_ext1_wakeup_mode_t is a different enum per target
+    // (esp_sleep.h): classic ESP32 only has ESP_EXT1_WAKEUP_ALL_LOW /
+    // _ANY_HIGH (no per-pin "any low"), S2/S3/C3 only have _ANY_LOW /
+    // _ANY_HIGH (ALL_LOW there is a deprecated alias for ANY_LOW). With a
+    // single-GPIO mask "all" and "any" are the same wakeup, so branching on
+    // CONFIG_IDF_TARGET_ESP32 (as esp_sleep.h itself does) picks the name
+    // that exists on each target without a deprecation warning on either.
+    // (A second bit for GPIO0 was deliberately not added: on classic ESP32
+    // ALL_LOW requires every masked pin low simultaneously, so a two-pin
+    // mask would make a single button press unable to wake the node.)
+    if (iButtonPin != 99)
+    {
+        esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
+
+        #if CONFIG_IDF_TARGET_ESP32
+        esp_sleep_enable_ext1_wakeup((1ULL << iButtonPin), ESP_EXT1_WAKEUP_ALL_LOW);
+        #else
+        esp_sleep_enable_ext1_wakeup((1ULL << iButtonPin), ESP_EXT1_WAKEUP_ANY_LOW);
+        #endif
+    }
+
+    // (g) Sleep. BOARD_RAK4630 (nRF52) never reaches this function -- see
+    // the call site in command_functions.cpp.
+    esp_deep_sleep_start();
+}

--- a/src/esp32/esp32_sleep.h
+++ b/src/esp32/esp32_sleep.h
@@ -1,0 +1,16 @@
+#ifndef _ESP32_SLEEP_H_
+#define _ESP32_SLEEP_H_
+
+// Issue 962 (docs/issue-962-deepsleep-verdict.md, Option A): shared entry
+// point for the --deepsleep command on every ESP32 board that is not
+// BOARD_HELTEC_T114 (nRF52, its own toggle-only branch) and not WP_DISP
+// (Wireless Paper / Vision Master E213, already fixed by PR 1050 and left
+// alone here). Puts the radio to sleep, the display into power-save, the
+// PMU LoRa/GPS rails off, the GPS/ADC pins off, arms a button wake source,
+// then calls esp_deep_sleep_start(). No parameters, no sleep reason, no RTC
+// state -- this only replaces the manual command body, nothing else
+// (the low-battery guard from the same doc, Option B, is a separate,
+// deliberately out-of-scope piece of work).
+void esp32EnterDeepSleep();
+
+#endif

--- a/src/extern_tele_json.h
+++ b/src/extern_tele_json.h
@@ -1,0 +1,90 @@
+#ifndef _EXTERN_TELE_JSON_H_
+#define _EXTERN_TELE_JSON_H_
+
+#include <stddef.h>
+#include <ArduinoJson.h>
+
+// TLM-04: the EXTUDP "tele" datagram, built here rather than inline in
+// sendExtern() (extudp_functions.cpp) so the key contract is native-testable
+// (test/test_extern_tele_json). Same pattern as extern_notice_json.h.
+//
+// Both shapes carry the same keys with the same physical meaning:
+//   qfe  station pressure in hPa (APRS /P=)
+//   qnh  pressure reduced to mean sea level in hPa (APRS /Q=)
+// The "lora" shape additionally carries pressure_alt, the barometric
+// pressure altitude in metres against 1013.25 hPa (APRS /F=). Before TLM-04
+// the /F= altitude was written under "qfe", so a relayed BME680 node showed
+// e.g. 191 "hPa" on a dashboard.
+//
+// Both shapes can additionally carry "din": the MCP23017 port A inputs as an
+// eight-character bit string, GPA0 first (mcp17_bits.h convention). For
+// "lora" it comes from the relayed node's APRS /D= field; for "node" it comes
+// from the gateway's own MCP23017 via mcp17PortABits(). The key is omitted
+// entirely -- not even an empty string -- when the sender has no MCP23017,
+// so the JSON stays byte-identical to pre-din firmware for those senders.
+//
+// Rueckgabe: Anzahl geschriebener Bytes; die Schranke ist die Puffergroesse,
+// nicht measureJson() (JSN-01, siehe ble_json_frame.h).
+
+// "node": the gateway's own sensor values.
+static inline size_t externTeleJsonNode(char *out, size_t out_len,
+                                        const char *src,
+                                        float temp1, float temp2, float hum,
+                                        float qfe, float qnh,
+                                        float gas, float co2,
+                                        const char *din)
+{
+    if(out == nullptr || out_len == 0)
+        return 0;
+
+    JsonDocument ctJson;
+
+    ctJson["src_type"] = "node";
+    ctJson["type"] = "tele";
+    ctJson["src"] = src;
+    ctJson["temp1"] = temp1;
+    ctJson["temp2"] = temp2;
+    ctJson["hum"] = hum;
+    ctJson["qfe"] = qfe;
+    ctJson["qnh"] = qnh;
+    ctJson["gas"] = gas;
+    ctJson["co2"] = co2;
+    if(din != nullptr && din[0] != 0)
+        ctJson["din"] = din;
+
+    return serializeJson(ctJson, out, out_len);
+}
+
+// "lora": a relayed node's values as parsed from its position frame.
+static inline size_t externTeleJsonLora(char *out, size_t out_len,
+                                        const char *src, int batt,
+                                        float temp1, float temp2, float hum,
+                                        float qfe, float qnh,
+                                        int pressure_alt,
+                                        float gas, float co2,
+                                        const char *din)
+{
+    if(out == nullptr || out_len == 0)
+        return 0;
+
+    JsonDocument ctJson;
+
+    ctJson["src_type"] = "lora";
+    ctJson["type"] = "tele";
+    ctJson["src"] = src;
+    ctJson["batt"] = batt;
+    ctJson["temp1"] = temp1;
+    ctJson["temp2"] = temp2;
+    ctJson["hum"] = hum;
+    ctJson["qfe"] = qfe;
+    ctJson["qnh"] = qnh;
+    ctJson["pressure_alt"] = pressure_alt;
+    ctJson["gas"] = gas;
+    ctJson["co2"] = co2;
+    if(din != nullptr && din[0] != 0)
+        ctJson["din"] = din;
+
+    return serializeJson(ctJson, out, out_len);
+}
+
+#endif // _EXTERN_TELE_JSON_H_

--- a/src/extudp_functions.cpp
+++ b/src/extudp_functions.cpp
@@ -6,6 +6,8 @@
 #include <debugconf.h>
 #include "ArduinoJson.h"
 #include "extern_notice_json.h"
+#include "extern_tele_json.h"
+#include "mcp17_bits.h"
 
 // PT-01 (native_extern): none of the network transport below (SPI/WiFi/
 // Ethernet headers, the UdpExtern socket object, and every function that
@@ -565,47 +567,32 @@ void sendExtern(bool bUDP, char *src_type, uint8_t buffer[500], uint16_t buflen,
     serializeJson(cJson, c_json, sizeof(c_json));
 
 
-    JsonDocument ctJson;
-
-    // Telemtrie
+    // Telemetrie -- TLM-04: built in extern_tele_json.h, native-testable.
     if(strcmp(src_type, "node") == 0)
     {
-      // build the json with Arduino JSON
-      ctJson["src_type"] = src_type;
-      ctJson["type"] = "tele";
-      ctJson["src"] = aprsmsg.msg_source_path.c_str();
-      ctJson["temp1"] = meshcom_settings.node_temp;
-      ctJson["temp2"] = meshcom_settings.node_temp2;
-      ctJson["hum"] = meshcom_settings.node_hum;
-      ctJson["qfe"] = meshcom_settings.node_press;
-      ctJson["qnh"] = meshcom_settings.node_press_asl;
-      ctJson["gas"] = meshcom_settings.node_gas_res;
-      ctJson["co2"] = meshcom_settings.node_co2;
+      // din: the node's own MCP23017 port A inputs (same string as the
+      // beacon's /D=), "" when the chip is absent -> key omitted.
+      char cdin[MCP17_BITS_LEN + 1] = "";
+      if(bMCP23017)
+          mcp17PortABits(meshcom_settings.node_mcp17in, meshcom_settings.node_mcp17io, cdin);
 
-      // clear the buffer
-      // JSN-01: bound by the buffer, not by measureJson().
-      serializeJson(ctJson, c_tjson, sizeof(c_tjson));
-
+      externTeleJsonNode(c_tjson, sizeof(c_tjson),
+                         aprsmsg.msg_source_path.c_str(),
+                         meshcom_settings.node_temp, meshcom_settings.node_temp2,
+                         meshcom_settings.node_hum,
+                         meshcom_settings.node_press, meshcom_settings.node_press_asl,
+                         meshcom_settings.node_gas_res, meshcom_settings.node_co2,
+                         cdin);
     }
     if(strcmp(src_type, "lora") == 0)
     {
-      // build the json with Arduino JSON
-      ctJson["src_type"] = src_type;
-      ctJson["type"] = "tele";
-      ctJson["src"] = aprsmsg.msg_source_path.c_str();
-      ctJson["batt"] = aprspos.bat;
-      ctJson["temp1"] = aprspos.temp;
-      ctJson["temp2"] = aprspos.temp2;
-      ctJson["hum"] = aprspos.hum;
-      ctJson["qfe"] = aprspos.qfe;
-      ctJson["qnh"] = aprspos.qnh;
-      ctJson["gas"] = aprspos.gasres;
-      ctJson["co2"] = aprspos.co2;
-
-      // clear the buffer
-      // JSN-01: bound by the buffer, not by measureJson().
-      serializeJson(ctJson, c_tjson, sizeof(c_tjson));
-
+      // qfe = /P= (station pressure), not /F= (pressure altitude in metres).
+      externTeleJsonLora(c_tjson, sizeof(c_tjson),
+                         aprsmsg.msg_source_path.c_str(), aprspos.bat,
+                         aprspos.temp, aprspos.temp2, aprspos.hum,
+                         aprspos.press, aprspos.qnh, aprspos.qfe,
+                         aprspos.gasres, aprspos.co2,
+                         aprspos.din);
     }
   }
   else

--- a/src/gps_filter.h
+++ b/src/gps_filter.h
@@ -13,8 +13,15 @@
 #define ALT_KF_Q        0.01f   /* process noise per update, tau ~ 410 s at 3 s cadence */
 #define ALT_KF_R        185.0f  /* measurement noise (m^2), (4 m * 1.7 * 2.0)^2          */
 #define ALT_KF_P0       400.0f  /* initial covariance after a seed                        */
-#define ALT_KF_GATE_M   15.0f   /* innovation gate: larger jumps are rejected             */
-#define ALT_KF_RESEED_N 10      /* consecutive rejects that re-seed the filter            */
+/* GPS-07: gate and re-seed threshold raised together. Validated 2026-09-06
+ * against two corpora (docs/baro-altitude-impl-plan-20260906.md S2.3): with
+ * the old values (15.0f / 10) the DK5EN-93 capture re-seeds 20 times in
+ * under 2 h and the filter delivers essentially no improvement over the raw
+ * signal. Either change alone still re-seeds 5 times on that capture; only
+ * the combination gives 0 re-seeds on both DK5EN-93 and the DK5EN-14
+ * corpus. AltFilter::rejects is a uint8_t, so 60 fits comfortably. */
+#define ALT_KF_GATE_M   30.0f   /* innovation gate: larger jumps are rejected             */
+#define ALT_KF_RESEED_N 60      /* consecutive rejects that re-seed the filter            */
 #define ALT_KF_P_CONV   2.5f    /* P below this value = converged                          */
 #define ALT_KF_DT_REF_MS  3000u /* cadence ALT_KF_Q is expressed for (one ESP32 cycle)     */
 #define ALT_KF_DT_MAX_MS 60000u /* dt clamp: a longer gap injects no more process noise    */

--- a/src/gps_functions.cpp
+++ b/src/gps_functions.cpp
@@ -15,6 +15,11 @@
 #include "gps_functions.h"
 
 #include "gps_filter.h"
+#include "alt_fusion.h"
+
+#if defined(ENABLE_BMX280)
+#include "bmx280.h"
+#endif
 
 #include "printfdeb_functions.h"
 
@@ -110,6 +115,13 @@ static bool s_altConvergedOnce = false;
 // millis() der letzten in den Schaetzer eingespeisten Hoehe. 0 = unbekannt
 // (erste Auswertung nach dem Start/Reset), dann gilt die Nennkadenz.
 static uint32_t s_altLastMs = 0;
+
+// GPS-05b: Komplementaerfilter GPS/Barometer. Laeuft nur auf Boards mit
+// BMx280, deren Druckreferenz scharf ist (fBasePress != 0, siehe GPS-08);
+// alle anderen schreiben weiter den Kalman-Schaetzer nach node_alt. Die
+// Logik liegt Arduino-frei in alt_fusion.cpp.
+static struct AltFusion s_altFusion;
+static uint32_t s_altFusionLastMs = 0;
 
 unsigned long detectedBaud = 0;
 String ver = "";
@@ -890,6 +902,8 @@ void WZ_GPS_Init()
   altFilterReset(&s_alt);
   s_altConvergedOnce = false;
   s_altLastMs = 0;
+  altFusionReset(&s_altFusion);
+  s_altFusionLastMs = 0;
 
   Serial.printf("[GPS ]...Init GPIO RX=%d TX=%d\n", GPS_RX_PIN, GPS_TX_PIN);
   
@@ -1167,6 +1181,8 @@ int WZ_GPS_Loop() {
                 altFilterReset(&s_alt);
                 s_altConvergedOnce = false;
                 s_altLastMs = 0;
+                altFusionReset(&s_altFusion);
+                s_altFusionLastMs = 0;
 
                 meshcom_settings.node_alt = (int)gpsData.altitude;
             }
@@ -1183,7 +1199,37 @@ int WZ_GPS_Loop() {
                     s_altLastMs    = nowMs;
 
                     if(altFilterUpdate(&s_alt, (float)gpsData.altitude, dtMs))
-                        meshcom_settings.node_alt = (int)lroundf(s_alt.x);
+                    {
+                        float altOut = s_alt.x;
+
+                        #if defined(ENABLE_BMX280)
+                        // GPS-05b: Der Kalman-Schaetzer liefert den langsamen
+                        // Anteil, das Barometer die Form der letzten Minuten.
+                        // Der absolute Anker des Barometers (eine einzige
+                        // GPS-Stichprobe, GPS-08) kuerzt sich im Hochpass
+                        // heraus. Ohne scharfe Druckreferenz bleibt es beim
+                        // reinen Kalman-Wert, damit Boards ohne Sensor und die
+                        // erste Minute nach dem Boot unveraendert laufen.
+                        if((bBMPON || bBMEON) && fBasePress != 0.0f)
+                        {
+                            float baroAlt = getPressALTf();
+
+                            if(baroAlt != 0.0f)
+                            {
+                                uint32_t fdtMs = (s_altFusionLastMs == 0) ? 0 : (nowMs - s_altFusionLastMs);
+                                s_altFusionLastMs = nowMs;
+
+                                altOut = altFusionUpdate(&s_altFusion, s_alt.x, baroAlt, fdtMs);
+
+                                if(iGPSDEBUG > 1)
+                                    printfdeb("[GPS ]...alt fused: %.1f m (kf %.1f baro %.1f)\n",
+                                              (double)altOut, (double)s_alt.x, (double)baroAlt);
+                            }
+                        }
+                        #endif
+
+                        meshcom_settings.node_alt = (int)lroundf(altOut);
+                    }
                 }
 
                 // Flanke: erst ab hier ist die Hoehe gut genug, um die
@@ -1252,6 +1298,8 @@ void WZ_GPS_AltSeed(float alt)
     altFilterSeed(&s_alt, alt);
     s_altConvergedOnce = false;
     s_altLastMs        = 0;
+    altFusionReset(&s_altFusion);
+    s_altFusionLastMs  = 0;
 
     baroBaseRelatch(alt);
 }

--- a/src/instrument.cpp
+++ b/src/instrument.cpp
@@ -20,6 +20,7 @@ extern int dbgHeapTotal(void);   // nrf52_main.cpp: __HeapLimit - __HeapBase
 extern int dbgHeapUsed(void);    // mallinfo().uordblks
 #endif
 #include "printfdeb_functions.h"
+#include <string.h>
 
 /* Provided by src/t-deck/lv_obj_functions.cpp, which owns these objects.
  * Only linked for the T-Deck variants -- guarded identically there. */
@@ -48,6 +49,27 @@ static const char  *s_iter_worst_name = NULL;    /* longest section since the la
 static uint32_t     s_iter_worst_us   = 0;
 static uint32_t     s_iter_sect_us    = 0;       /* time inside any section since the last tick */
 static uint32_t     s_gap_reports     = 0;
+
+#if defined(ESP32)
+/* CDC-01 (2026-09-05): a measurement that only shows while the USB host is
+ * away (cable pulled) cannot be read live, and opening the port again resets
+ * the chip. RTC slow memory survives that reset (not a power cycle), so the
+ * loop-gap evidence is mirrored there and reported once at the next boot
+ * ([INSTR-PREV]). Written on every tick: three word stores, negligible. */
+#include <esp_attr.h>
+struct InstrRtcCarry
+{
+    uint32_t magic;
+    uint32_t gaps;
+    uint32_t loop_max_us;
+    uint32_t loop_n;
+    uint32_t up_ms;
+    uint32_t worst_gap_ms;     /* the longest gap above the threshold ... */
+    char     worst_gap_in[12]; /* ... and the section it was attributed to */
+};
+static const uint32_t INSTR_RTC_MAGIC = 0x43444331;   /* 'CDC1' */
+RTC_NOINIT_ATTR static struct InstrRtcCarry s_rtc;
+#endif
 
 void instrument_note_section(const char *name, uint32_t us)
 {
@@ -99,6 +121,26 @@ void instrument_note_loop_tick(void)
         s_loop_us += d;
         if (d > s_loop_max)
             s_loop_max = d;
+#if defined(ESP32)
+        if (s_rtc.magic == INSTR_RTC_MAGIC)
+        {
+            s_rtc.loop_n++;
+            s_rtc.up_ms = now / 1000;
+            if (d > s_rtc.loop_max_us)
+                s_rtc.loop_max_us = d;
+            if (d > INSTR_GAP_REPORT_US)
+            {
+                s_rtc.gaps++;
+                if (d / 1000 > s_rtc.worst_gap_ms)
+                {
+                    s_rtc.worst_gap_ms = d / 1000;
+                    const char *nm = s_iter_worst_name != NULL ? s_iter_worst_name : "unattributed";
+                    strncpy(s_rtc.worst_gap_in, nm, sizeof(s_rtc.worst_gap_in) - 1);
+                    s_rtc.worst_gap_in[sizeof(s_rtc.worst_gap_in) - 1] = '\0';
+                }
+            }
+        }
+#endif
         if (d > INSTR_GAP_REPORT_US)
         {
             /* Attribute the gap: the longest section of that iteration, or
@@ -121,6 +163,26 @@ void instrument_note_loop_tick(void)
     s_iter_sect_us = 0;
 }
 
+void instrument_report_prev_boot(void)
+{
+#if defined(ESP32)
+    /* Raw Serial.printf, not printfdeb: this is a bench marker that must
+     * survive --debug off (see the FL-01 note in tdeck_main.cpp). */
+    if (s_rtc.magic == INSTR_RTC_MAGIC)
+        Serial.printf("[INSTR-PREV];valid;1;gaps;%lu;loop_max_us;%lu;loop_n;%lu;up_ms;%lu;threshold_ms;%lu;worst_ms;%lu;in;%s\n",
+                      (unsigned long)s_rtc.gaps, (unsigned long)s_rtc.loop_max_us,
+                      (unsigned long)s_rtc.loop_n, (unsigned long)s_rtc.up_ms,
+                      (unsigned long)(INSTR_GAP_REPORT_US / 1000),
+                      (unsigned long)s_rtc.worst_gap_ms,
+                      s_rtc.worst_gap_in[0] ? s_rtc.worst_gap_in : "-");
+    else
+        Serial.printf("[INSTR-PREV];valid;0\n");
+    s_rtc.magic = INSTR_RTC_MAGIC;
+    s_rtc.gaps = 0; s_rtc.loop_max_us = 0; s_rtc.loop_n = 0; s_rtc.up_ms = 0;
+    s_rtc.worst_gap_ms = 0; s_rtc.worst_gap_in[0] = '\0';
+#endif
+}
+
 void instrument_reset(void)
 {
     s_flush_n = 0; s_flush_us = 0; s_flush_max = 0;
@@ -131,6 +193,13 @@ void instrument_reset(void)
         s_sect[i].n = 0; s_sect[i].us = 0; s_sect[i].max = 0;   /* keep the name: slot order is stable */
     }
     s_gap_reports = 0;
+#if defined(ESP32)
+    /* CDC-01: the RTC carry starts here too, so an armed measurement does
+     * not include the boot-time gap (WiFi/GPS start, ~3 s). */
+    s_rtc.magic = INSTR_RTC_MAGIC;
+    s_rtc.gaps = 0; s_rtc.loop_max_us = 0; s_rtc.loop_n = 0; s_rtc.up_ms = 0;
+    s_rtc.worst_gap_ms = 0; s_rtc.worst_gap_in[0] = '\0';
+#endif
     printfdeb("[INSTR];reset\n");
 }
 

--- a/src/instrument.h
+++ b/src/instrument.h
@@ -20,18 +20,22 @@
  *
  * REMOVAL: this feature lives in exactly two new files (src/instrument.h,
  * src/instrument.cpp) plus four small guarded hook sites. `git revert` of the
- * commit that introduced it removes it completely. Alternatively define
- * INSTRUMENT_ENABLED=0 to compile it out while keeping the source.
+ * commit that introduced it removes it completely. It is compiled out by
+ * default; -D INSTRUMENT_ENABLED=1 builds a measurement firmware.
  */
 
 #pragma once
 
+/* Default OFF. This is bench scaffolding, not a field feature: with it on,
+ * [INSTR-LOOP] gap lines go to the serial console unconditionally (printfdeb()
+ * is not gated by --debug), and users read them as error messages. Build a
+ * measurement firmware with -D INSTRUMENT_ENABLED=1; the platform guard below
+ * still keeps it out of the native/host builds, which have no Arduino core. */
 #if !defined(INSTRUMENT_ENABLED)
-  #if defined(ESP32) || defined(NRF52_SERIES)
-    #define INSTRUMENT_ENABLED 1      /* nRF52 since TM-12: loop period + heap, no PSRAM fields */
-  #else
-    #define INSTRUMENT_ENABLED 0
-  #endif
+  #define INSTRUMENT_ENABLED 0
+#elif INSTRUMENT_ENABLED && !defined(ESP32) && !defined(NRF52_SERIES)
+  #undef  INSTRUMENT_ENABLED
+  #define INSTRUMENT_ENABLED 0        /* no Arduino core on the native/host builds */
 #endif
 
 #if INSTRUMENT_ENABLED
@@ -57,6 +61,11 @@ void instrument_report_gui(void);
 
 /** Zero the accumulators. A measurement run starts here. */
 void instrument_reset(void);
+
+/** CDC-01: print the loop-gap evidence of the PREVIOUS boot ([INSTR-PREV],
+ *  kept in RTC memory across a chip reset) and arm the carry for this boot.
+ *  Call once at boot after Serial is up. ESP32 only; no-op elsewhere. */
+void instrument_report_prev_boot(void);
 
 /** TM-13: per-subsystem stall attribution. A section is a named scope in the
  *  main loop (lora_rx, gps, udp, lvgl, ...); its duration is accumulated per

--- a/src/loop_functions.cpp
+++ b/src/loop_functions.cpp
@@ -7,6 +7,7 @@
 #endif
 
 #include "loop_functions.h"
+#include "ack_attribution.h"
 #include "txring_functions.h"
 #include "bp_notice_frame.h"
 #include "dedup_functions.h"
@@ -28,6 +29,7 @@
 #include "via_functions.h"
 #include "charset_filter.h"
 #include "setlog_lines.h"
+#include "mcp17_bits.h"
 
 bool gpsDetected = false;
 bool gpsInitDone = false;
@@ -378,8 +380,16 @@ U8G2 *u8g2;
     U8G2_SSD1306_128X64_NONAME_F_HW_I2C u8g2_1(U8G2_R0);  //RESET CLOCK DATA
     U8G2_SH1106_128X64_NONAME_F_HW_I2C u8g2_2(U8G2_R0);  //RESET CLOCK DATA
 #elif defined(BOARD_TBEAM_V3)
-    U8G2_SSD1306_128X64_NONAME_1_SW_I2C u8g2_1(U8G2_R0, 18, 17, U8X8_PIN_NONE);
-    U8G2_SH1106_128X64_NONAME_1_SW_I2C u8g2_2(U8G2_R0, 18, 17, U8X8_PIN_NONE);
+    // Wie bei Heltec V3/V4 (TM-09): Software-Bitbanging mit 1-Seiten-Puffer
+    // kostete ein Bild ~570 ms auf dem Hauptschleifen-Task (Feldmeldung
+    // T-Beam Supreme, [INSTR-LOOP];gap;...;in;display_tick, 4x/min beim
+    // 15-s-Uhr-Refresh). Anders als dort liegt das OLED hier auf DEMSELBEN
+    // Bus wie PMU/RTC/Sensoren (SDA_PIN 17 / SCL_PIN 18), also Wire statt
+    // Wire1 -- u8g2 ruft Wire.begin(17, 18) mit genau diesen Pins auf.
+    // Vollbild-Puffer (_F_) statt _1_: ein Transfer je Bild, und ein
+    // unveraendertes Bild kann uebersprungen werden (TM-10).
+    U8G2_SSD1306_128X64_NONAME_F_HW_I2C u8g2_1(U8G2_R0, U8X8_PIN_NONE, 18, 17);
+    U8G2_SH1106_128X64_NONAME_F_HW_I2C u8g2_2(U8G2_R0, U8X8_PIN_NONE, 18, 17);
 #elif defined(BOARD_TBEAM_1W)
     DISPLAY_MODEL u8g2_1(U8G2_R0, U8X8_PIN_NONE);  //RESET CLOCK DATA
     DISPLAY_MODEL u8g2_2(U8G2_R0, U8X8_PIN_NONE);
@@ -469,6 +479,7 @@ std::atomic<uint32_t> stat_util_tx_5m{0};  // TX-Luftzeit im 5-min-Fenster (ms)
 std::atomic<uint8_t> stat_ring_max{0};
 
 int isPhoneReady = 0;      // flag we receive from phone when itis ready to receive data
+bool bAckInfo = false;     // --ackinfo on: volatile session flag, reset on BLE disconnect, never in flash
 
 // APP Time OK
 bool bPhoneTimeValid = false;
@@ -2733,6 +2744,8 @@ void initAnalogPin()
             ANAGPIO = ANALOG_PIN;
             meshcom_settings.node_analog_pin = ANALOG_PIN;
             save_settings();
+
+            printfdeb("%s [ANALOG] GPIO not set, using board default GPIO %i (--analog gpio N to change)\n", getTimeString().c_str(), ANAGPIO);
         }
 
         pinMode(ANAGPIO, INPUT);
@@ -3146,6 +3159,15 @@ void setlogPrint(const char *body)
     printfdeb("%s [LOG] %s\n", ts, body);
 }
 
+// WQ-01 (2026-09-05): queue panel on the rxlog web page -- Kopie des zuletzt
+// abgeschlossenen 5-Minuten-STAT-Fensters. setlogFillStat() fuellt und
+// leert die Intervallzaehler in jedem Fall auf jedem Tick (siehe unten);
+// diese Kopie macht das Ergebnis danach lesbar, ohne den naechsten
+// Druckaufruf abzuwarten. stat_last_window_ms == 0 heisst "seit dem Boot
+// noch kein Fenster abgeschlossen".
+struct setlogStatFields stat_last_window = {0};
+uint32_t stat_last_window_ms = 0;
+
 // SL-05 -- Felder der STAT-Zeile fuellen. Die Intervallzaehler werden hier
 // geleert (exchange(0)); stat_drop_count[] wird nur gelesen, das Nullen bleibt
 // plattformseitig (ESP32 memset, nRF52 unter taskENTER_CRITICAL()).
@@ -3184,6 +3206,11 @@ void setlogFillStat(struct setlogStatFields *f, uint32_t heap)
     f->flash          = FLASH_VERSION;
     f->up_s           = millis() / 1000UL;
     f->t_ms           = millis();
+
+    // WQ-01 (2026-09-05): queue panel on the rxlog web page -- Kopie des
+    // fertigen Fensters fuer Leser, die nicht selbst drucken (Web-GUI).
+    stat_last_window = *f;
+    stat_last_window_ms = f->t_ms;
 }
 
 void charBuffer_aprs(struct aprsMessage &aprsmsg)
@@ -3419,6 +3446,40 @@ void SendPong(String msg_call, unsigned int msg_id)
 // Thresholds come from MAX_RING, which differs per board (10 / 20, MEM-01,
 // configuration_global.h) — a hardcoded 16 would warn at 160 % on a T-Beam.
 static BackPressure bp_state(MAX_RING);
+
+// WQ-01 (2026-09-05): queue panel on the rxlog web page -- read-only getters
+// onto bp_state for callers outside this TU (the web GUI). Plain int return
+// values keep the enum (BpState, backpressure.h) out of the shared header.
+int bpCurrentState(void)
+{
+    return (int)bp_state.state();
+}
+
+int bpRefuseThreshold(void)
+{
+    return bp_state.refuseThreshold();
+}
+
+int bpQrsThreshold(void)
+{
+    return bp_state.qrsThreshold();
+}
+
+int bpQrsForecast(int depth)
+{
+    return bp_state.qrsForecastDepth(depth);
+}
+
+const char* bpStateName(void)
+{
+    switch(bp_state.state())
+    {
+        case BP_QUIET: return "QUIET";
+        case BP_QRS:   return "QRS";
+        case BP_QRT:   return "QRT";
+        default:       return "QUIET";
+    }
+}
 
 // Set by each caller immediately before sendMessage(), cleared right after.
 static MsgOrigin bp_origin = ORIGIN_NONE;
@@ -3893,6 +3954,24 @@ int sendMessage(char *msg_text, int len)
         }
     }
 
+    // BP-11: the node's own back-pressure wording fed back in by a client
+    // (see bpIsOwnWording() in backpressure.h). Checked here, after the
+    // {ZIEL} parse, because the observed shape is "{*}QRT NOT SENT - ..."
+    // -- a client re-sending the nack frame with its dst -- and a check on
+    // the raw text would miss it. Before bp_origin_dst, before refusing()
+    // and before any msg-id is minted: a blocked echo leaves no trace in
+    // the BP state machine and gets NO nack and NO notice back -- a
+    // receipt for an echo is what opens the next loop. Unconditional on
+    // bp_origin: every sendMessage() caller is a local text input (BLE,
+    // serial, web, EXTUDP, T-Deck), relay traffic never comes through here.
+    // Marker carries no text, ever (BP-10 H3: a raw text in a [BP] line can
+    // forge a marker for tools/serial_monitor.py and loganalyse.sh).
+    if(bpIsOwnWording(strMsg.c_str()))
+    {
+        Serial.printf("[BP];echo;ms;%lu\n", (unsigned long)millis());
+        return BP_SEND_INVALID;
+    }
+
     // BP-06: strDestinationCall is authoritative here (fully parsed,
     // upper-cased, trimmed) -- set bp_origin_dst before the refuse check
     // below so a refused message's nack is addressed to the target the
@@ -4063,17 +4142,10 @@ int sendMessage(char *msg_text, int len)
             // set Info message send and Server reached, not on DM
             if(!bDM && (aprsmsg.msg_destination_call == "*" || CheckGroup(strDestinationCall)))
             {
-                uint8_t print_buff[8];
+                uint8_t ack_buff[ACK_PHONE_MAX_LEN];
+                uint16_t plen = buildAckPhoneFrame(ack_buff, aprsmsg.msg_id, 0x01, meshcom_settings.node_call);
 
-                print_buff[0]=0x41;
-                print_buff[1]=aprsmsg.msg_id & 0xFF;
-                print_buff[2]=(aprsmsg.msg_id >> 8) & 0xFF;
-                print_buff[3]=(aprsmsg.msg_id >> 16) & 0xFF;
-                print_buff[4]=(aprsmsg.msg_id >> 24) & 0xFF;
-                print_buff[5]=0x01;     // 0x01 ... server reached
-                print_buff[6]=0x00;     // msg always 0x00 at the end
-
-                addBLEOutBuffer(print_buff, (uint16_t)7);
+                addBLEOutBuffer(ack_buff, plen);
             }
         }
 
@@ -4191,7 +4263,9 @@ String PositionToAPRS(bool bConvPos, bool bSsendTele, bool bFuss, double plat, c
 
     char cinaU[15]={0};
     char cinaI[15]={0};
-    
+
+    char cdigital[15]={0};
+
     char ctele[15]={0};
 
     if(strcmp(meshcom_settings.node_atxt, "none") != 0 && meshcom_settings.node_atxt[0] != 0x00)
@@ -4345,6 +4419,15 @@ String PositionToAPRS(bool bConvPos, bool bSsendTele, bool bFuss, double plat, c
         }
     }
 
+    // /D= MCP23017 port A inputs (issue 1076 companion): GPA0 first,
+    // output pins read '0'. Only when the chip answered at boot.
+    if(bMCP23017)
+    {
+        char cbits[MCP17_BITS_LEN + 1];
+        mcp17PortABits(meshcom_settings.node_mcp17in, meshcom_settings.node_mcp17io, cbits);
+        snprintf(cdigital, sizeof(cdigital), "/D=%s", cbits);
+    }
+
     /////////////////////////////////////////////////////////////////
     // send Group-Call settings zu MesCom-Server
     String strGRC="";
@@ -4391,6 +4474,7 @@ String PositionToAPRS(bool bConvPos, bool bSsendTele, bool bFuss, double plat, c
     strncat(strconcat, cversion, sizeof(strconcat) - strlen(strconcat) - 1);    
     strncat(strconcat, cinaU, sizeof(strconcat) - strlen(strconcat) - 1);   
     strncat(strconcat, cinaI, sizeof(strconcat) - strlen(strconcat) - 1);
+    strncat(strconcat, cdigital, sizeof(strconcat) - strlen(strconcat) - 1);
     strncat(strconcat, ctele, sizeof(strconcat) - strlen(strconcat) - 1);
 
     // wenn die concatenation zu lang ist, dann catxt und cname löschen
@@ -5050,6 +5134,13 @@ void sendTelemetry(int ID)
     // Values to APRS.FI
     if(iNextTelemetry >= 4)
     {
+        // digital slot (issue 1076): MCP23017 port A inputs, GPA0 first.
+        // Stays "00000000" -- byte-identical to today -- on boards without
+        // the chip (bMCP23017 false).
+        char cbits[MCP17_BITS_LEN + 1] = "00000000";
+        if(bMCP23017)
+            mcp17PortABits(meshcom_settings.node_mcp17in, meshcom_settings.node_mcp17io, cbits);
+
         char cv[20];
         snprintf(cv, sizeof(cv), "%-9.9s:T#%03i", stationCall.c_str(), meshcom_settings.node_msgid);
 
@@ -5079,7 +5170,9 @@ void sendTelemetry(int ID)
             for(int pad = realCount; pad < 5; pad++)
                 strTelemetry.concat(",0");
 
-            strTelemetry.concat(",00000000,");
+            strTelemetry.concat(",");
+            strTelemetry.concat(cbits);
+            strTelemetry.concat(",");
             strTelemetry.concat(meshcom_settings.node_parm_t);
             strTelemetry.concat(",");
             strTelemetry.concat(meshcom_settings.node_parm_id);
@@ -5181,9 +5274,24 @@ void sendTelemetry(int ID)
                     strValue.concat(cv);
                 }
             }
+
+            // digital slot (issue 1076): this path sent none before -- only
+            // append it when the chip actually answered at boot, so nodes
+            // without an MCP23017 keep a byte-identical frame. APRS puts the
+            // digital byte in slot 6, so pad the analog slots to five first
+            // (ivcount == values emitted, capped at 5 by the break above) or
+            // a three-value node would ship its bits as analog value 4.
+            if(bMCP23017)
+            {
+                for(int pad = ivcount; pad < 5; pad++)
+                    strTelemetry.concat(",0");
+
+                strTelemetry.concat(",");
+                strTelemetry.concat(cbits);
+            }
         }
 
-        
+
         snprintf(msg_text, sizeof(msg_text), "%s", strTelemetry.c_str());
 
         iNextTelemetry++;

--- a/src/loop_functions_extern.h
+++ b/src/loop_functions_extern.h
@@ -11,6 +11,12 @@
 
 #include <atomic>
 
+// WQ-01 (2026-09-05): queue panel on the rxlog web page -- pulls in
+// struct setlogStatFields (below) for the last-window copy. Plain C-style
+// header (stdint/stdbool/stddef/string only, no Arduino dependency), so it
+// compiles cleanly for every TU that includes this extern header.
+#include "setlog_lines.h"
+
 extern bool gpsDetected;
 extern bool gpsInitDone;
 
@@ -158,6 +164,7 @@ extern unsigned int msg_counter;
 extern uint8_t RcvBuffer[UDP_TX_BUF_SIZE * 2];
 
 extern uint8_t own_msg_id[MAX_RING][5];
+extern bool bAckInfo;
 
 // TELEMTRY global variables
 extern int iNextTelemetry;
@@ -212,6 +219,15 @@ int addTxRingEntry(const uint8_t* frame, uint16_t len, uint8_t ring_status,
 
 void setMsgOrigin(MsgOrigin origin);
 MsgOrigin getMsgOrigin(void);
+
+// WQ-01 (2026-09-05): queue panel on the rxlog web page -- read-only view
+// onto bp_state (loop_functions.cpp). Plain int, not BpState, so callers
+// that only need this extern header don't need the enum.
+int bpCurrentState(void);      // (int)BpState: 0 QUIET, 1 QRS, 2 QRT
+int bpRefuseThreshold(void);
+int bpQrsThreshold(void);
+int bpQrsForecast(int depth); // WQ-02: depth at which the next own msgs raise QRS
+const char* bpStateName(void); // "QUIET" / "QRS" / "QRT"
 
 // E5 (2026-09-01): msg_id must stay unique across every BP frame or the chat
 // app's dedup filter swallows whichever of two notices lands in the same
@@ -343,8 +359,13 @@ void setlogPrint(const char *body);
 // SL-05: fills the STAT fields from the interval counters (drains them), the
 // mheard/trickle/version globals and uptime; heap is platform-specific and passed in.
 // stat_drop_count[] is read, not cleared -- the platform tick clears it.
-struct setlogStatFields;
 void setlogFillStat(struct setlogStatFields *f, uint32_t heap);
+
+// WQ-01 (2026-09-05): queue panel on the rxlog web page -- copy of the last
+// completed 5-minute STAT window, updated at the end of every setlogFillStat()
+// call. stat_last_window_ms == 0 means no window has completed since boot.
+extern struct setlogStatFields stat_last_window;
+extern uint32_t stat_last_window_ms;
 
 
 // Trickle-HEY state

--- a/src/lora_functions.cpp
+++ b/src/lora_functions.cpp
@@ -4,6 +4,7 @@
 #include "printfdeb_functions.h"
 #include "txring_functions.h"
 #include "ack_functions.h"
+#include "ack_attribution.h"
 #include "capture_functions.h"
 #include "dedup_functions.h"
 #include "setlog_lines.h"
@@ -85,6 +86,26 @@
 
 #if defined(BOARD_T_DECK) || defined(BOARD_T_DECK_PLUS)
 #include <t-deck/lv_obj_functions.h>
+#endif
+
+// Issue 962 / --deepsleep: RadioLib radio.sleep() for every board where this
+// TU has the real `radio` object in scope (see the #ifdef ladder above).
+// Mirrors the working precedent at src/t5-epaper/peri_lora.cpp:276.
+// WP_DISP boards keep their own Platform::loraToSleep() call instead (see
+// lora_functions.h for why). T-Deck Pro is NOT excluded here: its variant
+// defines SX1262X, and the `SX1262 radio` that extern resolves to is the
+// real global object in esp32_main.cpp (guarded by the same SX1262X), not
+// the unrelated `static` (file-local) radio in src/t-deck-pro/peri_lora.cpp,
+// which is dead scaffolding -- every function body in that file besides the
+// static declarations is commented out, so its local `radio` is never used.
+#if (defined(SX127X) || defined(BOARD_E220) || defined(SX1262X) || defined(SX126X) || \
+     defined(SX1262_E22) || defined(USING_SX1262) || defined(SX1268_E22) || \
+     defined(SX1262_V3) || defined(SX1262_E290) || defined(SX1262_V4) || \
+     defined(BOARD_T5_EPAPER)) && !defined(WP_DISP)
+void loraDeepSleep()
+{
+    radio.sleep();
+}
 #endif
 
                                         // flag to indicate if we are after receiving
@@ -329,7 +350,11 @@ static bool handleACK(uint8_t *payload, uint16_t size, int rssi, int snr)
 
     uint8_t print_buff[30];
 
-    memcpy(print_buff, payload, 12);
+    uint8_t n = ackWireAppendixLen(payload, size);
+    memcpy(print_buff, payload, 12 + n);
+
+    if(n == ACK_WIRE_APPENDIX_LEN && bLORADEBUG)
+        printfdeb("[MC-DBG] ACK_APPENDIX hash=%06X len=%u\n", ackWireHash(payload), (unsigned)size);
 
     // SL-01: Dedup-Verdikt vor dem Druck, damit die [LOG]-Zeile `DUP:` fuehren
     // kann. is_new_packet() ist eine reine Suche ohne Seiteneffekt.
@@ -361,15 +386,23 @@ static bool handleACK(uint8_t *payload, uint16_t size, int rssi, int snr)
 
         if(itxcheck >= 0)
         {
-            if(own_msg_id[itxcheck][4] < 2)   // 00...not heard, 01...heard, 02...ACK
+            // Status frame to the phone is origin-gated: own_msg_id[] also holds
+            // foreign msg_ids that a gateway only forwarded from the server to LoRa
+            // (see docs/ack-heard-foreign-msgids-fix.md). The state write below stays
+            // unconditional so the web rxlog heard/ACK ticks keep working as today.
+            if(bAckInfo || own_msg_id[itxcheck][4] < 2)   // 00...not heard, 01...heard, 02...ACK
             {
-                print_buff[5] = MSG_TYPE_ACK;
-                addBLEOutBuffer(print_buff+5, 7);
-
-                if(bDisplayInfo)
+                if(ackMsgIdFromNode(msg_id, _GW_ID))
                 {
-                    printfdeb("\n%s", getTimeString().c_str());
-                    printfdeb(" ACK to Phone  %02X %02X%02X%02X%02X %02X %02X", print_buff[5], print_buff[9], print_buff[8], print_buff[7], print_buff[6], print_buff[10], print_buff[11]);
+                    uint8_t phone_buff[ACK_PHONE_MAX_LEN];
+                    uint16_t plen = buildAckPhoneFrame(phone_buff, msg_id, 0x01, "");
+                    addBLEOutBuffer(phone_buff, plen);
+
+                    if(bDisplayInfo)
+                    {
+                        printfdeb("\n%s", getTimeString().c_str());
+                        printfdeb(" ACK to Phone  %02X %02X%02X%02X%02X %02X %02X", phone_buff[0], phone_buff[4], phone_buff[3], phone_buff[2], phone_buff[1], phone_buff[5], phone_buff[6]);
+                    }
                 }
 
                 own_msg_id[itxcheck][4] = 0x02;   // 02...ACK
@@ -388,7 +421,7 @@ static bool handleACK(uint8_t *payload, uint16_t size, int rssi, int snr)
             {
                 print_buff[5]--;
 
-                addTxRingEntry(print_buff, 12, RING_STATUS_DONE, "rx_ack_fwd", 0);
+                addTxRingEntry(print_buff, 12 + n, RING_STATUS_DONE, "rx_ack_fwd", 0);
 
                 if(bDisplayInfo)
                 {
@@ -835,25 +868,26 @@ void OnRxDone(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr)
 
             if(icheck >= 0) // own msg_id
             {
-                if(msg_type_b_lora == MSG_TYPE_TEXT && own_msg_id[icheck][4] == 0x00)   // 00...not heard, 01...heard, 02...ACK
+                // Status frame to the phone is origin-gated: own_msg_id[] also holds
+                // foreign msg_ids that a gateway only forwarded from the server to LoRa
+                // (see docs/ack-heard-foreign-msgids-fix.md). The state write below stays
+                // unconditional so the web rxlog heard/ACK ticks keep working as today.
+                if(msg_type_b_lora == MSG_TYPE_TEXT && (bAckInfo || own_msg_id[icheck][4] == 0x00))   // 00...not heard, 01...heard, 02...ACK
                 {
-                    print_buff[0]=MSG_TYPE_ACK;
-                    print_buff[1]=RcvBuffer[1];
-                    print_buff[2]=RcvBuffer[2];
-                    print_buff[3]=RcvBuffer[3];
-                    print_buff[4]=RcvBuffer[4];
-                    print_buff[5]=0x00;  // ONLY HEARD
-                    print_buff[6]=0x00;
-                    
-                    addBLEOutBuffer(print_buff, 7);
-
-                    if(bDisplayInfo)
+                    if(ackMsgIdFromNode(aprsmsg.msg_id, _GW_ID))
                     {
-                        printfdeb("%s", getTimeString().c_str());
-                        printfdeb(" HEARD from <%s> to Phone  %02X %02X%02X%02X%02X %02X %02X\n", aprsmsg.msg_source_path.c_str(), print_buff[0], print_buff[4], print_buff[3], print_buff[2], print_buff[1], print_buff[5], print_buff[6]);
-                        bNewLine=true;
+                        uint16_t plen = buildAckPhoneFrame(print_buff, aprsmsg.msg_id, 0x00, aprsmsg.msg_source_last.c_str());
+
+                        addBLEOutBuffer(print_buff, plen);
+
+                        if(bDisplayInfo)
+                        {
+                            printfdeb("%s", getTimeString().c_str());
+                            printfdeb(" HEARD from <%s> to Phone  %02X %02X%02X%02X%02X %02X %02X\n", aprsmsg.msg_source_path.c_str(), print_buff[0], print_buff[4], print_buff[3], print_buff[2], print_buff[1], print_buff[5], print_buff[6]);
+                            bNewLine=true;
+                        }
                     }
-            
+
                     if(own_msg_id[icheck][4] != 0x02)
                         own_msg_id[icheck][4]=0x01; // 0x01 HEARD
                 }
@@ -997,14 +1031,8 @@ void OnRxDone(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr)
                                         unsigned int iAckId = (aprsmsg.msg_payload.substring(iAckPos+4)).toInt();
                                         msg_counter = ((_GW_ID & 0x3FFFFF) << 10) | (iAckId & 0x3FF);
 
-                                        print_buff[0]=MSG_TYPE_ACK;
-                                        print_buff[1]=msg_counter & 0xFF;
-                                        print_buff[2]=(msg_counter >> 8) & 0xFF;
-                                        print_buff[3]=(msg_counter >> 16) & 0xFF;
-                                        print_buff[4]=(msg_counter >> 24) & 0xFF;
-                                        print_buff[5]=0x02;  // ACK
-                                        print_buff[6]=0x00;
-                                        
+                                        uint16_t plen = buildAckPhoneFrame(print_buff, msg_counter, 0x02, aprsmsg.msg_source_call.c_str());
+
                                         if(bDisplayInfo)
                                         {
                                             printfdeb("\n");
@@ -1025,7 +1053,7 @@ void OnRxDone(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr)
                                                             dmSlot, msg_counter);
                                         }
 
-                                        addBLEOutBuffer(print_buff, 7);
+                                        addBLEOutBuffer(print_buff, plen);
                                     }
                                     else
                                     if(iEnqPos > 0)
@@ -1190,10 +1218,11 @@ void OnRxDone(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr)
                                             // und an alle geht Wolke mit Hackerl an BLE senden
                                             if(aprsmsg.msg_destination_call == "*")
                                             {
-                                                print_buff[5]=MSG_TYPE_ACK;
-                                                print_buff[10]=0x01;     // switch ack GW / Node currently fixed to 0x00
-                                                print_buff[11]=0x00;     // msg always 0x00 at the end
-                                                addBLEOutBuffer(print_buff+5, 7);
+                                                // Gateway hoert seine eigene Meldung zurueck und ist selbst der
+                                                // Quittierende: Status 0x01 mit eigenem Rufzeichen.
+                                                uint8_t phone_buff[ACK_PHONE_MAX_LEN];
+                                                uint16_t plen = buildAckPhoneFrame(phone_buff, aprsmsg.msg_id, 0x01, meshcom_settings.node_call);
+                                                addBLEOutBuffer(phone_buff, plen);
                                             }
                                         }
                                         else

--- a/src/lora_functions.h
+++ b/src/lora_functions.h
@@ -6,6 +6,20 @@
 #include <debugconf.h>
 #include <aprs_functions.h>
 
+// Issue 962 / --deepsleep: put the RadioLib radio object to sleep so it stops
+// burning RX current before esp_deep_sleep_start(). Only declared/compiled
+// where lora_functions.cpp already has an extern `radio` of a matching
+// RadioLib type in scope (see the #ifdef ladder at the top of that file) --
+// a no-op declaration would either fail to link or bind to the wrong object.
+// WP_DISP boards (Wireless Paper, Vision Master E213) are excluded: they
+// keep their own Platform::loraToSleep() call at the --deepsleep call site.
+#if (defined(SX127X) || defined(BOARD_E220) || defined(SX1262X) || defined(SX126X) || \
+     defined(SX1262_E22) || defined(USING_SX1262) || defined(SX1268_E22) || \
+     defined(SX1262_V3) || defined(SX1262_E290) || defined(SX1262_V4) || \
+     defined(BOARD_T5_EPAPER)) && !defined(WP_DISP)
+void loraDeepSleep();
+#endif
+
 void OnRxDone(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr);
 void OnRxTimeout(void);
 void OnRxError(void);

--- a/src/mcp17_bits.h
+++ b/src/mcp17_bits.h
@@ -1,0 +1,30 @@
+#ifndef _MCP17_BITS_H_
+#define _MCP17_BITS_H_
+
+#include <stdint.h>
+
+// MCP23017 port A inputs as an eight-character bit string, shared by the
+// position beacon (/D=, PositionToAPRS()) and the digital slot of the APRS
+// T# telemetry frame (sendTelemetry(), upstream issue 1076).
+//
+// Order follows the APRS BITS convention: out[0] is GPA0, out[7] is GPA7.
+// `in` is meshcom_settings.node_mcp17in as read by loopMCP23017()
+// (io_functions.cpp: bit n == pin n), `io_mask` is node_mcp17io (1 == pin
+// configured as OUTPUT). Output pins always read '0' so a stale input word
+// after a --setio change cannot leak into the frame. Port B (bits 8-15) is
+// ignored. Arduino-free so the contract is native-testable
+// (test/test_mcp17_bits).
+#define MCP17_BITS_LEN 8
+
+static inline void mcp17PortABits(uint16_t in, uint16_t io_mask,
+                                  char out[MCP17_BITS_LEN + 1])
+{
+    for(int bit = 0; bit < MCP17_BITS_LEN; bit++)
+    {
+        uint16_t m = (uint16_t)(1u << bit);
+        out[bit] = ((in & m) && !(io_mask & m)) ? '1' : '0';
+    }
+    out[MCP17_BITS_LEN] = 0;
+}
+
+#endif // _MCP17_BITS_H_

--- a/src/net_console.cpp
+++ b/src/net_console.cpp
@@ -222,7 +222,46 @@ static void authTask(void* arg)
 
 
 // ── MeshSerialClass ───────────────────────────────────────────────────────────
-void MeshSerialClass::begin(unsigned long baud) { s_hwSerial.begin(baud); }
+void MeshSerialClass::begin(unsigned long baud)
+{
+#if ARDUINO_USB_CDC_ON_BOOT && ARDUINO_USB_MODE
+    // CDC-02 (2026-09-06, DK5EN-14): HWCDC::begin() (arduino-esp32 2.0.14,
+    // HWCDC.cpp:171-197) creates the 256 B TX ring buffer and enables the
+    // SERIAL_IN_EMPTY ISR; setTxBufferSize() (HWCDC.cpp:228-241) frees that
+    // buffer and briefly leaves tx_ring_buf NULL while allocating the new
+    // one. The ISR (HWCDC.cpp:92) dereferences tx_ring_buf with no NULL
+    // check, so calling setTxBufferSize() after begin() races a host
+    // port-open against the ISR and hits "assert failed:
+    // xRingbufferReceiveUpToFromISR ringbuf.c:1269". Sizing the buffer
+    // before the first begin() is race-free, since no ISR exists yet. The
+    // once-flag guards against T5-ePaper/T-Deck Pro, where begin() runs
+    // twice per boot (esp32_main.cpp and again via idf_setup()/
+    // initTDeck_pro()) -- the second call must not resize a live buffer.
+    static bool s_txBufSized = false;
+    if (!s_txBufSized)
+    {
+        s_hwSerial.setTxBufferSize(4096);
+        s_txBufSized = true;
+    }
+#endif
+    s_hwSerial.begin(baud);
+#if ARDUINO_USB_CDC_ON_BOOT && ARDUINO_USB_MODE
+    // CDC-01 (2026-09-05, DK5EN-14): on the S3 boards s_hwSerial is the
+    // native USB-JTAG/CDC (HWCDC). arduino-esp32 2.0.14 raises its TX
+    // timeout from 0 to 100 ms on the first successful host read and never
+    // lowers it again, so once the cable is pulled or the terminal closed,
+    // every print that does not fit the 256 B ring buffer blocks the main
+    // loop for 100 ms -- [BALL] per cursor step, GPS lines every 3 s, [LOG]
+    // lines -- and the trackball cursor and the touch input freeze in that
+    // rhythm. Asking for 0 explicitly is honoured by the core
+    // (tx_timeout_change_request) and means "drop when full, never block".
+    // The larger TX ring keeps bench logs intact under a connected host:
+    // bursts (--redrawlog) that used to wait 100 ms for room now need the
+    // room to exist. Bench proof: tdeck_harness.py --scenario cdc_backpressure.
+    // (buffer sized above, before begin() -- see CDC-02.)
+    s_hwSerial.setTxTimeoutMs(0);
+#endif
+}
 int  MeshSerialClass::available()               { return s_hwSerial.available(); }
 int  MeshSerialClass::read()                    { return s_hwSerial.read(); }
 int  MeshSerialClass::peek()                    { return s_hwSerial.peek(); }

--- a/src/nrf52/nrf52_ble.cpp
+++ b/src/nrf52/nrf52_ble.cpp
@@ -19,6 +19,7 @@
 #include <command_functions.h>
 
 extern int isPhoneReady;
+extern bool bAckInfo;
 extern bool ble_busy_flag;
 extern uint16_t swap2bytes(uint16_t value);
 extern void commandAction(char *msg_text, int len, bool ble);
@@ -211,6 +212,7 @@ void stop_advertising()
 	// disconnect
 	g_ble_uart_is_connected = false;
 	isPhoneReady = 0;
+	bAckInfo = false;
 	Bluefruit.setTxPower(0);
 	DEBUG_MSG("BLE", "Disconnected");
 }
@@ -229,6 +231,7 @@ void connect_callback(uint16_t conn_handle)
 	// isPhoneReady and config_to_phone_prepare are set only after
 	// successful app-layer PIN authentication via the hello message.
 	isPhoneReady = 0;
+	bAckInfo = false;
 	config_to_phone_prepare = false;
 	conffin_sent = false;
 	g_ble_uart_is_connected = true;
@@ -246,6 +249,7 @@ void disconnect_callback(uint16_t conn_handle, uint8_t reason)
 	(void)reason;
 	g_ble_uart_is_connected = false;
 	isPhoneReady = 0;
+	bAckInfo = false;
 	config_to_phone_prepare = false;
 	conffin_sent = false;
 	Bluefruit.setTxPower(0);

--- a/src/nrf52/nrf52_functions.cpp
+++ b/src/nrf52/nrf52_functions.cpp
@@ -142,12 +142,13 @@ extern bool bDEEP_SLEEP;
 
 void boardPWROff()
 {
-    Batterie_Vide_logo();
-    // Arrêt alimentation périphériques 
-    digitalWrite(Power_On_Pin,LOW);
-    //digitalWrite(GreenLed_Pin,LOW);
-    //digitalWrite(RedLed_Pin,HIGH);        
-    bDEEP_SLEEP = true;
+    // Issue 962 (docs/issue-962-deepsleep-verdict.md, section 6.4): real
+    // nRF52 System OFF now lives in nrf52_sleep.cpp and covers everything
+    // this function used to do by hand (Batterie_Vide_logo(), Power_On_Pin
+    // LOW) plus radio sleep, BLE advertising stop, bus teardown and a real
+    // wake-armed sleep instead of the old bDEEP_SLEEP/delay(60000) soft-off.
+    extern void nrf52EnterDeepSleep();
+    nrf52EnterDeepSleep();
 }
 
 void boardInit()

--- a/src/nrf52/nrf52_main.cpp
+++ b/src/nrf52/nrf52_main.cpp
@@ -7,6 +7,7 @@
 
 #include <Arduino.h>
 #include "instrument.h"
+#include "track_warning.h" // TRK-01: Warnhinweis bei aktivem Track
 #include <maxhop.h>         // CS-01: plausibility of the persisted text hop limit
 #include <SPI.h>
 
@@ -14,6 +15,7 @@
 #include <time.h>
 #include <nrf52_functions.h>
 #include <nrf52_radio.h>
+#include <settings_sanitize.h> // #1132: resolve_tx_power sentinel normalization
 #include <extudp_functions.h>
 
 #include <TinyGPSPlus.h>
@@ -566,6 +568,10 @@ void nrf52setup()
     bEXTUDP =  meshcom_settings.node_sset & 0x2000;
     bDisplayCont =  meshcom_settings.node_sset & 0x4000;
 
+    // TRK-01: Warnhinweis einmal beim Boot, wenn Track aus den Settings aktiv geladen wurde
+    if(bDisplayTrack)
+        Serial.printf("[INIT]..." TRACK_WARNING_SERIAL "\n");
+
     bONEWIRE =  meshcom_settings.node_sset2 & 0x0001;
     bLPS33 =  meshcom_settings.node_sset2 & 0x0002;
     bBME680ON = meshcom_settings.node_sset2 & 0x0004;
@@ -1042,6 +1048,7 @@ void nrf52setup()
     );
 
     // Set Radio TX configuration
+    meshcom_settings.node_power = resolve_tx_power(meshcom_settings.node_power, TX_OUTPUT_POWER); // #1132: normalize -20/0 sentinel like ESP32 does
     Serial.printf("[LoRa]...RF_POWER: %i dBm\n", getPower());
 
     Radio.SetTxConfig(

--- a/src/nrf52/nrf52_sleep.cpp
+++ b/src/nrf52/nrf52_sleep.cpp
@@ -1,0 +1,122 @@
+// Issue 962 (docs/issue-962-deepsleep-verdict.md, section 6.4). See nrf52_sleep.h.
+
+#include "nrf52_sleep.h"
+
+#include <Arduino.h>
+#include <SPI.h>
+#include <Wire.h>
+#include <LoRaWan-Arduino.h>   // defines the global `Radio` (radio/radio.h), used by
+                               // nrf52_radio.cpp the same way
+
+#include <configuration.h>    // angle-bracket include resolves per env (-I variants/<env>)
+                               // to that board's own variants/<env>/configuration.h --
+                               // pulls in PIN_VEXT_CTL / PIN_TFT_LEDA_CTL / PIN_TFT_VDD_CTL
+                               // on Heltec T114; nothing needed from here for RAK4631 or T-Echo
+
+#if defined(BOARD_T_ECHO)
+#include "t_echo_utilities.h"   // Power_On_Pin -- a lightweight pin-macro header (no epaper libs)
+#endif
+
+// stop_advertising() (nrf52_ble.cpp) is declared in WisBlock-API.h, which also
+// drags in mbed/rtos/ArduinoJson -- forward-declare it directly here instead,
+// the same way command_functions.cpp already reaches across translation units
+// for e.g. `extern bool bDEEP_SLEEP;`.
+extern void stop_advertising();
+
+#if defined(BOARD_T_ECHO)
+// Battery-empty e-ink screen (nrf52_functions.cpp) -- not declared in
+// nrf52_functions.h, same forward-declare approach as stop_advertising() above.
+extern void Batterie_Vide_logo(void);
+#endif
+
+// Runtime wake-button GPIO (loop_functions.cpp:186). Seeded from the
+// compile-time BUTTON_PIN at boot but overridable via `--button <pin>` /
+// meshcom_settings.node_button_pin (nrf52_main.cpp:611-613); 99 means "no
+// button configured" -- the same sentinel the ESP32 side uses
+// (esp32_main.cpp:890-896, esp32_sleep.cpp) for the identical purpose.
+extern uint8_t iButtonPin;
+
+void nrf52EnterDeepSleep()
+{
+    // (a) Radio to sleep first, so it stops burning RX current while the rest
+    // of this sequence runs. All three nRF52 boards use SX126x-Arduino and
+    // share the same `Radio` global (nrf52_radio.cpp).
+    Radio.Sleep();
+
+    // (b) BLE: stop advertising and clear connection-state flags
+    // (Bluefruit.Advertising.stop(), nrf52_ble.cpp). There is no simple
+    // stored "current connection handle" global in this codebase to hand a
+    // graceful Bluefruit.disconnect() (only per-callback parameters exist,
+    // and BLEPeriph exposes no accessor for it) -- System OFF drops any BLE
+    // link regardless, so this is enough.
+    stop_advertising();
+
+    // (c) Display off. RAK4631 has none.
+    #if defined(BOARD_HELTEC_T114)
+    digitalWrite(PIN_TFT_LEDA_CTL, HIGH);   // TFT backlight off
+    digitalWrite(PIN_TFT_VDD_CTL, HIGH);    // TFT VDD off
+    #endif
+
+    #if defined(BOARD_T_ECHO)
+    Batterie_Vide_logo();   // battery-empty e-ink screen, same as the old boardPWROff()
+    #endif
+
+    // (d) Peripheral rail off, one switch per board. BOARD_HELTEC_T114 and
+    // BOARD_T_ECHO are mutually exclusive with each other and with the bare
+    // RAK4631 build, so this #elif chain never double-fires.
+    //
+    // BOARD_RAK4630 is NOT RAK4631-exclusive: platformio.ini defines it in
+    // nrf52_base.build_flags, which all three nRF52 envs extend (comment at
+    // platformio.ini:97-102 -- "wird von heltec_t114 und t_echo ABSICHTLICH
+    // mitgeerbt"), so heltec_t114 and t_echo also compile with BOARD_RAK4630
+    // defined. The #elif below only reaches the RAK4631-only WB_IO2 cut
+    // because the two prior arms already claim BOARD_HELTEC_T114 and
+    // BOARD_T_ECHO; confirmed against variants/wiscore_rak4631/variant.h
+    // (WB_IO2 = pin 34) and RAK19007's "IO2=0 -> 3V3_S off" documentation.
+    #if defined(BOARD_HELTEC_T114)
+    digitalWrite(PIN_VEXT_CTL, LOW);   // GPS/peripheral rail off
+    #elif defined(BOARD_T_ECHO)
+    digitalWrite(Power_On_Pin, LOW);   // peripheral rail off
+    #elif defined(BOARD_RAK4630)
+    digitalWrite(WB_IO2, 0);   // 3V3_S off: W5100S, RAK12500 GPS, every WisBlock slot
+    #endif
+
+    // (e) Peripheral buses / USB down, so no clock or pull-up leaks through
+    // System OFF (Meshtastic's nRF52 cpuDeepSleep() runs the same four calls
+    // before sd_power_system_off()).
+    Serial.end();
+    // Uart::end() (Adafruit core) busy-waits on TXSTOPPED && RXTO after
+    // issuing STOPRX/STOPTX -- those events never latch on a UARTE that was
+    // never begun (or already ended), so an unconditional end() hangs
+    // forever here. gps_functions.cpp's gpsScanBauds() calls Serial1.end()
+    // after every baud probe on T114/T-Echo regardless of whether a GPS
+    // answered, so a node with no GPS attached (or a silent one) boots with
+    // Serial1 already ended -- exactly the case an unconditional call here
+    // would hit. Uart::operator bool() reports _begun; only end() a port
+    // that is.
+    if (Serial1) Serial1.end();
+    Wire.end();
+    SPI.end();
+
+    // (f) Wake source + sleep. All three boards define BUTTON_PIN
+    // unconditionally, so iButtonPin is a real pin in practice -- still
+    // guarded, for defensiveness and consistency with the ESP32 side's
+    // treatment of an unconfigured/out-of-range button. `--button` accepts
+    // 0..99 and iButtonPin takes that value verbatim (nrf52_main.cpp), but
+    // systemOff()'s `g_ADigitalPinMap[pin]` lookup (wiring.c) does no bounds
+    // check against PINS_COUNT (48 on all three variants) the way
+    // pinMode()/digitalWrite() do -- an out-of-range pin would read past the
+    // map. A node with no button configured, or misconfigured with
+    // `--button` above 47, wakes only on RESET or USB plug-in (VBUS
+    // DETECT), which sd_power_system_off() still honours.
+    if (iButtonPin < PINS_COUNT)
+    {
+        systemOff(iButtonPin, LOW);   // active-low button, internal pull-up configured by systemOff() itself
+    }
+    else
+    {
+        sd_power_system_off();
+    }
+    // Neither call returns; wake is a hardware reset, exactly like
+    // esp_deep_sleep_start() on the ESP32 side.
+}

--- a/src/nrf52/nrf52_sleep.h
+++ b/src/nrf52/nrf52_sleep.h
@@ -1,0 +1,18 @@
+#ifndef _NRF52_SLEEP_H_
+#define _NRF52_SLEEP_H_
+
+// Issue 962 (docs/issue-962-deepsleep-verdict.md, section 6.4): shared entry
+// point for the --deepsleep command and the T-Echo long-press power-off
+// (boardPWROff(), nrf52_functions.cpp) on all three nRF52 boards (RAK4631,
+// Heltec T114, T-Echo). Puts the SX126x radio to sleep, stops BLE
+// advertising, switches off the display where one exists (T114 TFT,
+// T-Echo e-ink), cuts the peripheral rail (RAK4631 WB_IO2 / T114
+// PIN_VEXT_CTL / T-Echo Power_On_Pin), tears down the peripheral buses,
+// then enters real nRF52 System OFF (systemOff() / sd_power_system_off()).
+// This call does not return -- wake is a hardware reset, exactly like
+// esp_deep_sleep_start() on the ESP32 side. No parameters, no sleep-reason
+// state: the low-battery LPCOMP wake from the same doc section (6.4.1 step
+// 8) is separate, deliberately out-of-scope work.
+void nrf52EnterDeepSleep();
+
+#endif

--- a/src/setlog_lines.cpp
+++ b/src/setlog_lines.cpp
@@ -126,3 +126,20 @@ int setlogFormatGwu(char *buf, size_t n, uint32_t msg_id, char typ,
                                 (unsigned long)msg_id, typ, (unsigned)hop,
                                 (unsigned long)t_ms), n);
 }
+
+// WQ-01 (2026-09-05): queue panel on the rxlog web page.
+//
+// window_min = round(ring_size * interval_s / (newid * 60)); siehe
+// setlog_lines.h fuer die Herleitung. 64-bit Zwischenwerte vermeiden einen
+// Ueberlauf bei ring_size * interval_s; das Runden auf die naechste Minute
+// geschieht per Halbaddition vor der Ganzzahldivision.
+uint32_t setlogDedupWindowMin(uint32_t newid, uint32_t interval_s, uint32_t ring_size)
+{
+    if(newid == 0 || interval_s == 0)
+        return 0;
+
+    uint64_t numerator = (uint64_t)ring_size * (uint64_t)interval_s;
+    uint64_t denominator = (uint64_t)newid * 60ULL;
+
+    return (uint32_t)((numerator + denominator / 2) / denominator);
+}

--- a/src/setlog_lines.h
+++ b/src/setlog_lines.h
@@ -126,6 +126,29 @@ int setlogFormatGwu(char *buf, size_t n, uint32_t msg_id, char typ,
                     uint8_t hop, uint32_t t_ms);
 
 //////////////////////////////////////////////////////////////////////////////
+// WQ-01 (2026-09-05): queue panel on the rxlog web page -- reines
+// Rechenhilfsmittel fuer das Dedup-Fenster, keine Formatierer-Funktion.
+//
+// Effektives Dedup-Gedaechtnisfenster in ganzen Minuten:
+//
+//     window_min = round(ring_size * interval_s / (newid * 60))
+//
+// Herleitung: newid neue msg_id in interval_s Sekunden fuellen den Ring mit
+// ring_size Slots. Bei dieser Rate braucht der Ring ring_size / (newid /
+// interval_s) Sekunden, um sich einmal komplett umzudrehen -- das ist das
+// Zeitfenster, in dem eine bereits gesehene msg_id noch als Duplikat erkannt
+// wird, bevor ihr Slot ueberschrieben ist. Umgeformt auf Minuten:
+// ring_size * interval_s / (newid * 60).
+//
+// Die Feldmessung in src/dedup_functions.h beziffert den sicheren Korridor
+// mit ungefaehr 40 bis 48 Minuten; dieser Helfer liefert den aktuellen Wert
+// zum Vergleich gegen diesen Korridor.
+//
+// newid == 0 oder interval_s == 0 liefert 0 (Aufrufer zeigt "n/a" -- eine
+// Rate von null neuen IDs hat kein sinnvolles Fenster).
+uint32_t setlogDedupWindowMin(uint32_t newid, uint32_t interval_s, uint32_t ring_size);
+
+//////////////////////////////////////////////////////////////////////////////
 // SL-06/SL-03 -- Herkunftskennung fuer ringSource[].
 //
 // Bewusst `inline` im Header und nicht in setlog_lines.cpp: txring_functions.cpp

--- a/src/settings_sanitize.cpp
+++ b/src/settings_sanitize.cpp
@@ -118,6 +118,13 @@ bool sanitize_max_hop_text(int &v, sanitize_log_fn log)
     return true;
 }
 
+int resolve_tx_power(int stored, int board_default)
+{
+    if (stored == 0 || stored == POWER_NOT_SET)
+        return board_default;
+    return stored;
+}
+
 bool sanitize_cstring(char *s, size_t n)
 {
     if (s == NULL || n == 0)

--- a/src/settings_sanitize.h
+++ b/src/settings_sanitize.h
@@ -50,3 +50,9 @@ bool sanitize_cstring(char *s, size_t n);
  * hands over a 0 and a corrupt one anything at all. Resets both to the
  * compile-time default (see maxhop.h). Returns true if the value was corrected. */
 bool sanitize_max_hop_text(int &v, sanitize_log_fn log);
+
+/* #1132: resolves the stored TX power to the value the radio and the app should
+ * use. Both "not set" sentinels count: 0 (structs written before v4.35p and the
+ * compat merge) and -20 (default since upstream 50c1ce59). Anything else is
+ * returned unchanged; range clamping stays in getPower(). */
+int resolve_tx_power(int stored, int board_default);

--- a/src/t-deck/event_functions.cpp
+++ b/src/t-deck/event_functions.cpp
@@ -671,7 +671,12 @@ void btn_event_handler_setup(lv_event_t * e)
 
         tdeck_refresh_SET_view();
 
-        lv_tabview_set_act(tv, 0, LV_ANIM_ON);
+        // TD-12: an animated switch here can be stalled mid-way by a second
+        // press landing on a focusable widget while the scroll animation is
+        // running -- SCROLL_ON_FOCUS deletes the running animation and the
+        // replacement scroll is zeroed by LV_DIR_NONE on the tabview content.
+        // An immediate jump leaves no window for that.
+        lv_tabview_set_act(tv, 0, LV_ANIM_OFF);
     }
     else
         if(code == LV_EVENT_VALUE_CHANGED)
@@ -731,7 +736,15 @@ void btn_event_handler_send(lv_event_t * e)
         {
             lv_textarea_set_text(text_input, "");
         }
-        lv_tabview_set_act(tv, 0, LV_ANIM_ON);
+
+        // TD-12: same rationale as the Save Setting handler above -- an
+        // animated switch can be stalled mid-way by a second press on a
+        // focusable widget (SCROLL_ON_FOCUS kills the running scroll
+        // animation, LV_DIR_NONE zeroes the replacement), so jump instead
+        // of animating. SCROLL_END still fires synchronously inside
+        // lv_obj_scroll_by, so tabview_event_cb and the msg_controls
+        // hide/show logic behave exactly as before.
+        lv_tabview_set_act(tv, 0, LV_ANIM_OFF);
     }
     else if(code == LV_EVENT_VALUE_CHANGED)
     {
@@ -884,6 +897,14 @@ void btn_event_handler_zoomout(lv_event_t * e)
 void tabview_event_cb(lv_event_t * e)
 {
     if(lv_event_get_code(e) == LV_EVENT_VALUE_CHANGED) {
+        // TD-14: the tab button matrix carries LV_OBJ_FLAG_EVENT_BUBBLE
+        // (lv_tabview.c:233), so its own VALUE_CHANGED bubbles up to `tv`
+        // and this callback fires a second time for the same tab switch --
+        // once with target == tv (from cont_scroll_end_event_cb) and once
+        // with target == the btnmatrix. Keep only the first.
+        if (lv_event_get_target(e) != lv_event_get_current_target(e))
+            return;
+
         int tab_idx = lv_tabview_get_tab_act(tv);
 
         switch (tab_idx)
@@ -908,6 +929,13 @@ void tabview_event_cb(lv_event_t * e)
                     sdmap_lastKnownLon = meshcom_settings.node_lon;
                 }
 
+                // TD-14: hide the tab bar before composing so the single
+                // remaining rebuild already measures the bar-collapsed
+                // viewport (sdmap_refresh calls lv_obj_update_layout itself,
+                // which applies the pending hide). The generic call at the
+                // end of this callback still runs but is then a no-op.
+                tdeck_hide_tab_menu();
+
                 // TD-07: do not yank the view back to the own position on tab
                 // switch while the user has panned -- see tdeck_map_pan(). The
                 // own-position marker still gets repositioned either way (it
@@ -915,7 +943,7 @@ void tabview_event_cb(lv_event_t * e)
                 // refresh_map() only moves marker widgets against whatever
                 // origin the last sdmap_refresh() set, it does not redraw tiles.
                 if (!tdeck_map_user_panned())
-                    sdmap_refresh(map_ta, sdmap_lastKnownLat, sdmap_lastKnownLon);
+                    sdmap_refresh(map_ta, sdmap_lastKnownLat, sdmap_lastKnownLon, "tab");
                 refresh_map(meshcom_settings.node_map);
 
                 break;

--- a/src/t-deck/lv_obj_functions.cpp
+++ b/src/t-deck/lv_obj_functions.cpp
@@ -1923,7 +1923,7 @@ void tdeck_map_zoom(int dir)
     }
     if (dir > 0) sdmap_zoom_in();
     else         sdmap_zoom_out();
-    sdmap_refresh(map_ta, sdmap_lastKnownLat, sdmap_lastKnownLon);
+    sdmap_refresh(map_ta, sdmap_lastKnownLat, sdmap_lastKnownLon, "zoom");
     refresh_map(meshcom_settings.node_map);
     add_map_point(meshcom_settings.node_call, sdmap_lastKnownLat, sdmap_lastKnownLon, true);
 }
@@ -1970,7 +1970,7 @@ void tdeck_map_pan(int dxPx, int dyPx)
     // dominating at ~170 ms/tile. Each pan keypress pays this cost; a held
     // key repeats it per repeat event, so it is discrete-step usable but not
     // smooth. Accepted for v1 per operator decision.
-    sdmap_refresh(map_ta, s_map_pan_lat, s_map_pan_lon);
+    sdmap_refresh(map_ta, s_map_pan_lat, s_map_pan_lon, "pan");
     refresh_map(meshcom_settings.node_map);
     // The GPS/own-position marker always tracks the real position, never the
     // pan point (TD-07 requirement: pan must not fight the marker draw).
@@ -2014,7 +2014,7 @@ void tdeck_map_recenter()
         sdmap_lastKnownLat = meshcom_settings.node_lat;
         sdmap_lastKnownLon = meshcom_settings.node_lon;
     }
-    sdmap_refresh(map_ta, sdmap_lastKnownLat, sdmap_lastKnownLon);
+    sdmap_refresh(map_ta, sdmap_lastKnownLat, sdmap_lastKnownLon, "recenter");
     refresh_map(meshcom_settings.node_map);
     add_map_point(meshcom_settings.node_call, sdmap_lastKnownLat, sdmap_lastKnownLon, true);
 }
@@ -2085,7 +2085,7 @@ void set_map(int iMap)
             {
                 double centerLat, centerLon;
                 tdeck_map_view_center(&centerLat, &centerLon);
-                sdmap_refresh(map_ta, centerLat, centerLon);
+                sdmap_refresh(map_ta, centerLat, centerLon, "setmap");
             }
             map_x[iMap] = sdmap_view_w();
             map_y[iMap] = sdmap_view_h();
@@ -3851,7 +3851,7 @@ void tdeck_add_pos_point(String callsign, double u_dlat, char lat_c, double u_dl
         // GPS position above and the marker draw at the call site below, but
         // must not snap the viewport back while the user has panned.
         if (!tdeck_map_user_panned())
-            sdmap_refresh(map_ta, sdmap_lastKnownLat, sdmap_lastKnownLon);
+            sdmap_refresh(map_ta, sdmap_lastKnownLat, sdmap_lastKnownLon, "beacon");
     }
 
     #endif

--- a/src/t-deck/tdeck_main.cpp
+++ b/src/t-deck/tdeck_main.cpp
@@ -19,6 +19,7 @@
 #include <time_functions.h>
 
 #include <Arduino.h>
+#include <driver/gpio.h>
 #include <SPI.h>
 #include <RadioLib.h>
 #include <Wire.h>
@@ -136,6 +137,19 @@ void initTDeck()
     setCpuFrequencyMhz(160);
 
     Serial.println("[INIT]...initTDeck");
+
+    // Issue 962 deepsleep (esp32_sleep.cpp): --deepsleep holds TDECK_POWERON
+    // and TDECK_TFT_BACKLIGHT low with gpio_hold_en()/gpio_deep_sleep_hold_en()
+    // so they don't float during sleep. That hold survives the wake reset
+    // (esp_idf gpio.h) -- without releasing it here first, the digitalWrite()
+    // calls below (and setBrightness()'s later restore of the backlight) are
+    // silently ignored and the board stays without LoRa/GPS/SD/keyboard power
+    // until a full USB unplug/replug clears the latch. Release before
+    // reconfiguring, matching the working template in
+    // src/t5-epaper/t5epaper_main.cpp:579-581.
+    gpio_hold_dis((gpio_num_t) TDECK_POWERON);
+    gpio_hold_dis((gpio_num_t) TDECK_TFT_BACKLIGHT);
+    gpio_deep_sleep_hold_dis();
 
     //! The board peripheral power control pin needs to be set to HIGH when using the peripheral
     pinMode(TDECK_POWERON, OUTPUT);
@@ -464,8 +478,8 @@ void setupLvgl()
 
     // G07: the 4th parameter is size_in_px_cnt, not a byte count
     // (lv_hal_disp.h:223). LVGL_BUFFER_SIZE is TFT_WIDTH*TFT_HEIGHT*sizeof(lv_color_t),
-    // i.e. twice the pixel count. Harmless while full_refresh=1 and buf2==NULL keep
-    // the partial-render paths unreachable; with partial refresh it is a ~150 KB overflow.
+    // i.e. twice the pixel count. This must stay a pixel count now that
+    // full_refresh=0 makes the partial-render paths reachable.
     lv_disp_draw_buf_init( &draw_buf, buf, NULL, TFT_WIDTH * TFT_HEIGHT );
 
     /*Initialize the display*/
@@ -477,7 +491,11 @@ void setupLvgl()
     disp_drv.ver_res = TFT_WIDTH;
     disp_drv.flush_cb = disp_flush;
     disp_drv.draw_buf = &draw_buf;
-    disp_drv.full_refresh = 0;   // EXPERIMENT: partial refresh, no other changes
+    // TD-05: partial refresh. full_refresh=1 forced a ~45 ms blocking, non-DMA
+    // pushColors of the whole framebuffer on every invalidation -- including the
+    // 1 Hz clock tick -- while holding the SPI bus that also fronts SD and LoRa.
+    // Settled on hardware (DK5EN-14); see BACKLOG.md 3.8b/3.8e.
+    disp_drv.full_refresh = 0;
     disp_drv.monitor_cb = tdeck_dbg_monitor_cb;
     disp_drv.render_start_cb = tdeck_dbg_render_start_cb;
     lv_disp_drv_register( &disp_drv );
@@ -1206,15 +1224,44 @@ static void mouse_read(lv_indev_drv_t *indev, lv_indev_data_t *data)
         {
             // Pegelvergleich (alter Weg, Taste immer so)
             // Bench-Harness: ein eingereihter Schritt wirkt wie eine Flanke
-            if (s_dbg_ball_pending[i] > 0)
+            // TD-13: an injected button click models a physical press -- press
+            // edge, DBG_CLICK_HOLD_POLLS polls held low, release edge -- so the
+            // harness exercises the same edge sequence as a finger. Two back-to-back
+            // press edges without a release between them (the previous inject
+            // shape) looked like one long press to LVGL and could not reproduce
+            // the double click; the hold is what separates the two pulses.
+            static uint8_t s_dbg_click_phase = 0;     // 0 idle, 1..HOLD held, then release
+            const uint8_t DBG_CLICK_HOLD_POLLS = 3;
+            if (i == 4 && (s_dbg_ball_pending[i] > 0 || s_dbg_click_phase != 0))
+            {
+                if (s_dbg_click_phase == 0)
+                {
+                    s_dbg_ball_pending[i]--;
+                    dir = false;                     // press edge (active low)
+                    s_dbg_click_phase = 1;
+                }
+                else if (s_dbg_click_phase < DBG_CLICK_HOLD_POLLS)
+                {
+                    dir = false;                     // held
+                    s_dbg_click_phase++;
+                }
+                else
+                {
+                    dir = true;                      // release edge
+                    s_dbg_click_phase = 0;
+                }
+            }
+            else if (s_dbg_ball_pending[i] > 0)
             {
                 s_dbg_ball_pending[i]--;
                 dir = !last_dir[i];
             }
             if (dir != last_dir[i])
             {
+                // TD-13: the push button is a pulse on the press edge only; the release
+                // edge produced a second LVGL click that toggled the drawer shut.
+                steps = (i == 4 && dir) ? 0 : 1;
                 last_dir[i] = dir;
-                steps = 1;
             }
         }
         for (int k = 0; k < steps; k++)

--- a/src/t-deck/tdeck_sdmap.cpp
+++ b/src/t-deck/tdeck_sdmap.cpp
@@ -31,6 +31,19 @@ static lv_img_dsc_t sdmap_dsc;
 static double sdmap_lastLat = 0.0;
 static double sdmap_lastLon = 0.0;
 
+// TD-14: dedupe guard. A repeat sdmap_refresh() call with an identical view
+// (bubbled VALUE_CHANGED duplicate from the tab bar, a beacon/boundary
+// refresh, switching back to an unchanged map) is composed for nothing --
+// every real change (set_map, zoom, pan) touches at least one of these keys,
+// so this only ever absorbs true repeats.
+static bool   sdmap_lastValid        = false;
+static int    sdmap_lastComposedSet  = -1;
+static int    sdmap_lastComposedZoom = -1;
+static double sdmap_lastComposedLat  = 0.0;
+static double sdmap_lastComposedLon  = 0.0;
+static int    sdmap_lastComposedVw   = -1;
+static int    sdmap_lastComposedVh   = -1;
+
 static double sdmap_lon2xf(double lon, int zoom)
 {
     return (lon + 180.0) / 360.0 * (double)(1 << zoom);
@@ -77,6 +90,7 @@ void sdmap_set_active_set(int idx)
     if (idx < 0) idx = 0;
     if (idx >= SDMAP_SET_COUNT) idx = SDMAP_SET_COUNT - 1;
     sdmap_activeSet = idx;
+    sdmap_lastValid = false;   // TD-14: a different set invalidates the dedupe key
 
     if (sdmap_zoom < sdmap_setMinZoom[idx])
         sdmap_zoom = sdmap_setMinZoom[idx];
@@ -248,7 +262,7 @@ static unsigned char * sdmap_load_tile_rgba(int zoom, int tx, int ty, unsigned *
 // Compose the visible map: a viewport-sized image built from every tile that
 // intersects the viewport, with (lat, lon) at the centre. The viewport is smaller
 // than one tile, so at most 2x2 tiles are read. Missing tiles stay grey.
-bool sdmap_refresh(lv_obj_t * img, double lat, double lon)
+bool sdmap_refresh(lv_obj_t * img, double lat, double lon, const char * why)
 {
     uint32_t t0 = millis();
     sdmap_tReadMs = 0; sdmap_tDecodeMs = 0; sdmap_bytesRead = 0;
@@ -278,6 +292,7 @@ bool sdmap_refresh(lv_obj_t * img, double lat, double lon)
                       sdmap_dirs[sdmap_activeSet], sdmap_zoom, SDMAP_MIN_ZOOM);
         if (map_no_data_label != NULL)
             lv_obj_clear_flag(map_no_data_label, LV_OBJ_FLAG_HIDDEN);
+        sdmap_lastValid = false;   // TD-14: nothing was composed, next call must not be skipped
         return false;
     }
     if (useZoom != sdmap_zoom)
@@ -299,6 +314,21 @@ bool sdmap_refresh(lv_obj_t * img, double lat, double lon)
     }
     const int vw = sdmap_viewW, vh = sdmap_viewH;
 
+    // TD-14: skip the compose when the view is identical to the last one --
+    // this absorbs the bubbled VALUE_CHANGED duplicate from the tab bar
+    // (see tabview_event_cb()) and any other same-view repeat call. A real
+    // change always moves at least one key: set_map() bumps sdmap_activeSet,
+    // zoom in/out bumps sdmap_zoom, and a pan or a new fix changes lat/lon.
+    if (sdmap_buf != nullptr && sdmap_lastValid &&
+        sdmap_activeSet == sdmap_lastComposedSet &&
+        sdmap_zoom == sdmap_lastComposedZoom &&
+        lat == sdmap_lastComposedLat && lon == sdmap_lastComposedLon &&
+        vw == sdmap_lastComposedVw && vh == sdmap_lastComposedVh)
+    {
+        Serial.printf("[ SDMAP ]...Karte unveraendert, Aufbau uebersprungen from=%s\n", why);
+        return true;
+    }
+
     // Global pixel coordinates (tile index * 256 + pixel in tile) of the own position.
     double gx = sdmap_lon2xf(lon, sdmap_zoom) * SDMAP_TILE_PX;
     double gy = sdmap_lat2yf(lat, sdmap_zoom) * SDMAP_TILE_PX;
@@ -318,6 +348,7 @@ bool sdmap_refresh(lv_obj_t * img, double lat, double lon)
             Serial.println("[ SDMAP ]...ps_malloc fuer Kartenbild fehlgeschlagen");
             if (map_no_data_label != NULL)
                 lv_obj_clear_flag(map_no_data_label, LV_OBJ_FLAG_HIDDEN);
+            sdmap_lastValid = false;   // TD-14: nothing was composed, next call must not be skipped
             return false;
         }
     }
@@ -379,9 +410,18 @@ bool sdmap_refresh(lv_obj_t * img, double lat, double lon)
         if (nMissing == nTiles) lv_obj_clear_flag(map_no_data_label, LV_OBJ_FLAG_HIDDEN);
         else                    lv_obj_add_flag(map_no_data_label, LV_OBJ_FLAG_HIDDEN);
     }
-    Serial.printf("[ SDMAP ]...Karte zusammengesetzt: zoom %d, Kacheln %d (fehlend %d), %dx%d px, %lu ms (read %lu ms / %lu KB, decode %lu ms)\n",
+    Serial.printf("[ SDMAP ]...Karte zusammengesetzt: zoom %d, Kacheln %d (fehlend %d), %dx%d px, %lu ms (read %lu ms / %lu KB, decode %lu ms) from=%s\n",
                   sdmap_zoom, nTiles, nMissing, vw, vh, (unsigned long)(millis() - t0),
-                  (unsigned long)sdmap_tReadMs, (unsigned long)(sdmap_bytesRead / 1024), (unsigned long)sdmap_tDecodeMs);
+                  (unsigned long)sdmap_tReadMs, (unsigned long)(sdmap_bytesRead / 1024), (unsigned long)sdmap_tDecodeMs, why);
+
+    // TD-14: remember the key of the view just composed for the guard above.
+    sdmap_lastComposedSet  = sdmap_activeSet;
+    sdmap_lastComposedZoom = sdmap_zoom;
+    sdmap_lastComposedLat  = lat;
+    sdmap_lastComposedLon  = lon;
+    sdmap_lastComposedVw   = vw;
+    sdmap_lastComposedVh   = vh;
+    sdmap_lastValid        = true;
     return true;
 }
 

--- a/src/t-deck/tdeck_sdmap.h
+++ b/src/t-deck/tdeck_sdmap.h
@@ -24,7 +24,8 @@ int  sdmap_get_set_count();
 const char * sdmap_get_set_name(int idx);
 
 // Laedt die passende Kachel fuer lat/lon beim aktuellen Zoom und zeigt sie in img an.
-bool sdmap_refresh(lv_obj_t * img, double lat, double lon);
+// `why` names the caller in the "Karte zusammengesetzt" log line (TD-14 attribution).
+bool sdmap_refresh(lv_obj_t * img, double lat, double lon, const char * why = "?");
 
 // Verschiebt lat/lon um (dxPx, dyPx) Bildschirmpixel beim aktuellen Zoom (TD-07 Pan).
 void sdmap_pan_latlon(double * lat, double * lon, int dxPx, int dyPx);

--- a/src/track_warning.h
+++ b/src/track_warning.h
@@ -1,0 +1,22 @@
+#pragma once
+
+// TRK-01 (BACKLOG) — Warnhinweis, wenn Track (SmartBeaconing) aktiv ist.
+//
+// Track drueckt die Beacon-Kadenz einer einzelnen Station auf bis zu 10 s
+// herunter, gegen einen Kanal, der im Mittel etwa ein Paket alle 8 s traegt.
+// Eine Handvoll Track-Nutzer reicht damit aus, eine Zelle fuer alle anderen
+// zuzufahren — genau das Bild, das aus dem Feld als "Paketverlust" gemeldet
+// wird. Bisher war der Schalter an keiner Stelle mit dieser Kosteninformation
+// versehen: die WebGUI beschrieb ihn als "enable display of SmartBeaconing",
+// --track on quittierte kommentarlos, und ein Knoten, der mit gesetztem Flag
+// bootet, schwieg dazu dauerhaft.
+//
+// Der Wortlaut ist vom Operator fixiert und wird nicht abgeschwaecht.
+//
+// Zwei Varianten, weil der Kontext unterschiedlich viel verraet:
+//  - Auf Serial/Netconsole steht die Zeile allein im Log; ohne das Praefix
+//    "Track on - " ist nicht erkennbar, welche Einstellung sie ausgeloest hat.
+//  - In der WebGUI steht der Hinweis direkt neben dem Track-Switch, dort ist
+//    die Herkunft offensichtlich und das Praefix nur Rauschen.
+#define TRACK_WARNING_TEXT   "degraded MeshCom RX performance, packetloss likely"
+#define TRACK_WARNING_SERIAL "Track on - " TRACK_WARNING_TEXT

--- a/src/txring_functions.cpp
+++ b/src/txring_functions.cpp
@@ -272,6 +272,45 @@ int txRingDepth(void)
 }
 
 /**
+ * WQ-01 (2026-09-05): queue panel on the rxlog web page. Per-priority
+ * occupancy count for the TX ring, using the exact same lock-free scan as
+ * txRingDepth() above (both indices read once into locals, walk from iRead
+ * to iWrite wrapping at MAX_RING, occupied == ringBuffer[i][0] > 0) -- see
+ * that function's doc comment for the counting rationale (occupied slots,
+ * not index distance) and the lock-free tradeoff.
+ *
+ * out[0] receives the total occupied count (identical to txRingDepth());
+ * out[1..5] receive the occupied count broken down by ringPriority[i]
+ * (MSG_PRIO_CRITICAL..MSG_PRIO_BACKGROUND, i.e. 1..5). An occupied slot
+ * whose priority is outside 1..5 only bumps out[0] -- defensive, since
+ * getMessagePriority() never returns such a value today.
+ *
+ * No printf, no lock, no writes to the ring itself -- read-only, same as
+ * txRingDepth().
+ */
+void txRingPrioCounts(uint8_t out[6])
+{
+    memset(out, 0, 6 * sizeof(out[0]));
+
+    int w = (int)(uint8_t)iWrite;
+    int r = (int)(uint8_t)iRead;
+    int i = r;
+    while(i != w)
+    {
+        if(ringBuffer[i][0] > 0)
+        {
+            out[0]++;
+            uint8_t prio = ringPriority[i];
+            if(prio >= 1 && prio <= 5)
+                out[prio]++;
+        }
+        i++;
+        if(i >= MAX_RING)
+            i = 0;
+    }
+}
+
+/**
  * BP-03 (DJ8MEH-RCA 2026-08-31, Teil 2): sweep the whole ring and drop every
  * BACKGROUND (HEY, prio 5) entry older than RING_BG_MAX_AGE_MS
  * (configuration_global.h). A priority-starved HEY parked at iRead behind a

--- a/src/txring_functions.h
+++ b/src/txring_functions.h
@@ -34,6 +34,18 @@ void advanceIReadPastEmpty(void);
 // both after an enqueue and on the per-loop drain check.
 int txRingDepth(void);
 
+// WQ-01 (2026-09-05): queue panel on the rxlog web page. Same occupied-slot
+// scan as txRingDepth() (see its doc comment for the counting rationale),
+// split out per priority so the panel can show "N queued, of which K
+// critical/high/normal/low/background" without five separate ring walks.
+// out[0] = total occupied slots (identical to txRingDepth()); out[1..5] =
+// occupied slots whose ringPriority[] is MSG_PRIO_CRITICAL..MSG_PRIO_BACKGROUND
+// (1..5, configuration_global.h). An occupied slot whose priority somehow
+// falls outside 1..5 is counted in out[0] only, not in any out[1..5] bucket
+// -- defensive, not reachable via getMessagePriority() today. Read-only,
+// lock-free, same as txRingDepth(): caller must pass a 6-element array.
+void txRingPrioCounts(uint8_t out[6]);
+
 // BP-03 (DJ8MEH-RCA 2026-08-31, Teil 2): sweep the whole ring and drop any
 // BACKGROUND (HEY, prio 5) entry older than RING_BG_MAX_AGE_MS
 // (configuration_global.h). Deliberately its own function, NOT folded into

--- a/src/udp_functions.cpp
+++ b/src/udp_functions.cpp
@@ -11,6 +11,7 @@
 #include <command_functions.h>
 #include <loop_functions_extern.h>
 #include <dedup_functions.h>
+#include "ack_attribution.h"
 #include <lora_functions.h>
 #include <time_functions.h>
 #include <lora_setchip.h>
@@ -403,25 +404,21 @@ void getMeshComUDPpacket(unsigned char inc_udp_buffer[UDP_TX_BUF_SIZE], int pack
 
                     uint8_t print_buff[30];
 
-                    print_buff[0]=0x41;
-                    print_buff[1]=msg_counter & 0xFF;
-                    print_buff[2]=(msg_counter >> 8) & 0xFF;
-                    print_buff[3]=(msg_counter >> 16) & 0xFF;
-                    print_buff[4]=(msg_counter >> 24) & 0xFF;
-                    print_buff[5]=0x01;  // ACK
-                    print_buff[6]=0x00;
-                    
+                    uint8_t ack_status = 0x01;  // ACK
+
                     int iackcheck = checkOwnTx(msg_counter);
                     if(iackcheck >= 0)
                     {
                         own_msg_id[iackcheck][4] = 0x02;   // 02...ACK
-                        print_buff[5]=0x02;  // 02...ACK
+                        ack_status = 0x02;  // 02...ACK
                       }
+
+                    uint16_t plen = buildAckPhoneFrame(print_buff, msg_counter, ack_status, aprsmsg.msg_source_call.c_str());
 
                     if(bDisplayInfo)
                       printfdeb("[UDP-MSGID] ack_msg_id:%02X%02X%02X%02X ACK...%02X\n", print_buff[4], print_buff[3], print_buff[2], print_buff[1], print_buff[5]);
 
-                    addBLEOutBuffer(print_buff, 7);
+                    addBLEOutBuffer(print_buff, plen);
 
                     if(strcmp(source_call, meshcom_settings.node_call) == 0)
                         bUDPtoLoraSend=false;

--- a/src/web_functions/web_functions.cpp
+++ b/src/web_functions/web_functions.cpp
@@ -18,6 +18,9 @@
 #include <maxhop.h>         // CS-02: drop-down values for the text hop limit
 #include <config_json.h>   // CS-03: config download/upload as one JSON object
 #include <ArduinoJson.h>    // JSN-01: call_function()/setparam()/getparam() JSON escaping
+#include <txring_functions.h> // WQ-01: LoRa queue panel -- txRingPrioCounts()
+#include <setlog_lines.h>      // WQ-01: LoRa queue panel -- setlogDedupWindowMin()
+#include "track_warning.h"    // TRK-01: Warnhinweis-Text neben dem Track-Switch
 
 #include "web_UIComponents.h"
 #include "web_setup.h"
@@ -853,7 +856,7 @@ void deliver_scaffold(bool bget_password)
     // this function is used for login and logout
     web_client.println("function login(pwd){var xhttp = new XMLHttpRequest(); xhttp.onreadystatechange=function(){if(this.readyState==4 && this.status==200){window.location.reload(true);}};xhttp.open(\"GET\",\"?nodepassword=\"+pwd,true);xhttp.send();}\n");
     // this function is used to load content depending on the navigation button pressed
-    web_client.println("function loadPage(page,sender,useSpinner) {cpage=page;csender=sender;if(useSpinner){document.getElementById(\"content_layer\").innerHTML=\"<span class=\\\"loader\\\"></span>\"};var xhttp = new XMLHttpRequest(); xhttp.onreadystatechange=function(){if(this.readyState==4 && this.status==200){document.getElementById(\"content_layer\").innerHTML=this.responseText;}};xhttp.open(\"GET\",\"?page=\"+page,true);xhttp.send();Array.from(document.querySelectorAll('.nav_button.nbactive ')).forEach((el) => el.classList.remove('nbactive')); sender.classList.add('nbactive');}\n");
+    web_client.println("function loadPage(page,sender,useSpinner) {cpage=page;csender=sender;if(useSpinner){document.getElementById(\"content_layer\").innerHTML=\"<span class=\\\"loader\\\"></span>\"};var xhttp = new XMLHttpRequest(); xhttp.onreadystatechange=function(){if(this.readyState==4 && this.status==200){document.getElementById(\"content_layer\").innerHTML=this.responseText;mcRenderQueue();if(page=='messages' && document.getElementById('messages_panel'))mcRenderHistory();}};xhttp.open(\"GET\",\"?page=\"+page,true);xhttp.send();Array.from(document.querySelectorAll('.nav_button.nbactive ')).forEach((el) => el.classList.remove('nbactive')); sender.classList.add('nbactive');}\n");
     // this function is used to send a message from the browser via node to the mesh
     //
     // BP-09: the input fields used to be cleared unconditionally, right after
@@ -868,10 +871,73 @@ void deliver_scaffold(bool bget_password)
     web_client.println("function sendMessage() {var xhttp=new XMLHttpRequest();xhttp.onreadystatechange=function(){if(this.readyState==4 && this.status==200 && this.responseText.indexOf(\"sendmessage ok\")>=0){document.getElementById(\"sendcall\").value=\"\"; document.getElementById(\"messagetext\").value=\"\"; updateCharsLeft();}};xhttp.open(\"GET\",\"/?sendmessage&tocall=\"+encodeURIComponent(document.getElementById(\"sendcall\").value)+\"&message=\"+encodeURIComponent(document.getElementById(\"messagetext\").value),true);xhttp.send();}\n");
     // this functions is counting and displaying the amount of chars left that the user can use to write a message
     web_client.println("function updateCharsLeft() {let maxlength=149;if(document.getElementById(\"sendcall\").value.length>0) {maxlength-=(document.getElementById(\"sendcall\").value.length)+2;}let msglength=document.getElementById(\"messagetext\").value.length;if(msglength>maxlength){document.getElementById(\"messagetext\").value=document.getElementById(\"messagetext\").value.substring(0,maxlength);msglength=maxlength;}document.getElementById(\"indicator_charsleft\").innerHTML=maxlength-msglength;}\n");
+    // MC-msg-history: BLEtoPhoneBuff/MAX_RING is only 20 slots and is shared
+    // with positions and acks, so a handful of new messages can push an old
+    // message out of the node's own ring within minutes. The browser tab
+    // keeps every message it has seen for the life of the page in
+    // mcHistory/mcSeen (capped at MC_HIST_MAX, oldest dropped first) so
+    // switching Info -> Messages -> Info -> Messages does not lose messages
+    // that scrolled out of the node's ring. This is browser memory only --
+    // node RAM is unchanged, and persisting the history to localStorage is
+    // deferred (not implemented in this round).
+    web_client.println("var mcSeen={};");
+    web_client.println("var mcHistory=[];");
+    web_client.println("var MC_HIST_MAX=200;");
+    // MC-msg-tabs: this and the rest of the mcTab* functions live in the
+    // scaffold rather than sub_page_messages() because sub-pages are
+    // injected via innerHTML and their own <script> tags never run.
+    web_client.println("var mcTabSel='all';");
+    web_client.println("try{var mcTabStored=localStorage.getItem('mcTab');if(mcTabStored!=null)mcTabSel=mcTabStored;}catch(e){}");
+    // MC-msg-badges: unread-state model. mcReadIds is a session-only set of
+    // message ids the operator has definitely seen -- it survives while
+    // mcHistory holds the entry, but not a browser restart. mcWm holds, per
+    // tab key, a unix-time watermark below which everything on that tab
+    // counts as read; it is the only read-state that is persisted
+    // (localStorage 'mcWm'), because persisting the exact id set across days
+    // of ring turnover would grow without bound. A message is unread for a
+    // tab key when it is inbound (an own message-send is never unread), it
+    // matches that key's dst filter, its id has not been marked read this
+    // session, and its ts is strictly greater than that key's watermark --
+    // equal timestamps fall back to the id set, since an unsynced node clock
+    // can hand two independent messages the same second. Viewing "All"
+    // raises every tab's watermark to the newest message seen, because
+    // looking at the merged stream is defined as having read everything in
+    // it, not only the "all" tab itself.
+    web_client.println("var mcReadIds={};");
+    web_client.println("var mcWm={};");
+    web_client.println("try{var mcWmStored=localStorage.getItem('mcWm');if(mcWmStored!=null)mcWm=JSON.parse(mcWmStored);}catch(e){}if(typeof mcWm!=='object' || mcWm===null)mcWm={};");
+    web_client.println("function mcSaveWm(){try{localStorage.setItem('mcWm',JSON.stringify(mcWm));}catch(e){}}");
+    web_client.println("function mcTabMatchKey(key,dst){if(key=='all')return true;if(key=='*')return dst=='*';if(key=='dm')return dst!='*' && !/^[0-9]+$/.test(dst);return dst==key;}");
+    web_client.println("function mcTabMatch(dst){return mcTabMatchKey(mcTabSel,dst);}");
+    web_client.println("function mcUnreadCount(key){var wm=mcWm[key]||0;var n=0;for(var i=0;i<mcHistory.length;i++){var m=mcHistory[i];if(m.rx && mcTabMatchKey(key,m.dst) && !mcReadIds[m.id] && m.ts>wm)n++;}return n;}");
+    // seeds the watermark of any tab key that has never had one (first visit
+    // to this browser, or a group number just added in setup) to the newest
+    // ts already known, so first load never shows a wall of unread badges
+    web_client.println("function mcSeedWm(){var btns=document.querySelectorAll('#mctabs .mctab');if(btns.length==0)return;var maxTs=0;for(var i=0;i<mcHistory.length;i++){if(mcHistory[i].ts>maxTs)maxTs=mcHistory[i].ts;}var changed=false;for(var j=0;j<btns.length;j++){var key=btns[j].getAttribute('data-tab');if(!(key in mcWm)){mcWm[key]=maxTs;changed=true;}}if(changed)mcSaveWm();}");
+    // marks every history entry on the currently selected tab as read; viewing
+    // 'all' counts as having read every tab, so its watermark propagates to
+    // every configured tab key, not only 'all' itself
+    web_client.println("function mcMarkRead(){if(document.visibilityState==='hidden')return;var maxTs=0;var changed=false;for(var i=0;i<mcHistory.length;i++){var m=mcHistory[i];if(mcTabMatchKey(mcTabSel,m.dst)){if(!mcReadIds[m.id]){mcReadIds[m.id]=true;changed=true;}if(m.ts>maxTs)maxTs=m.ts;}}if(maxTs>(mcWm[mcTabSel]||0)){mcWm[mcTabSel]=maxTs;changed=true;}if(mcTabSel=='all'){var btns=document.querySelectorAll('#mctabs .mctab');for(var j=0;j<btns.length;j++){var key=btns[j].getAttribute('data-tab');if(maxTs>(mcWm[key]||0)){mcWm[key]=maxTs;changed=true;}}}if(changed)mcSaveWm();}");
+    // the tab bar is re-rendered by the server on every loadPage('messages'),
+    // so badges are painted here on every call, never once at page load
+    web_client.println("function mcApplyTab(){var panel=document.getElementById('messages_panel');if(!panel)return;var els=panel.querySelectorAll('.message[data-dst]');for(var i=0;i<els.length;i++){els[i].hidden=!mcTabMatch(els[i].getAttribute('data-dst'));}mcSeedWm();mcMarkRead();var btns=document.querySelectorAll('#mctabs .mctab');for(var j=0;j<btns.length;j++){var key=btns[j].getAttribute('data-tab');btns[j].classList.toggle('mctab-on',key==mcTabSel);var label=key=='all'?'All':(key=='dm'?'DM':key);var cnt=mcUnreadCount(key);btns[j].innerHTML=label+(cnt>0?' <span class=\"mcbadge\">'+cnt+'</span>':'');btns[j].classList.toggle('mctab-new',cnt>0);}}");
+    web_client.println("function mcTab(btn){mcTabSel=btn.getAttribute('data-tab');try{localStorage.setItem('mcTab',mcTabSel);}catch(e){}var sc=document.getElementById('sendcall');if(sc){if(/^[0-9]+$/.test(mcTabSel))sc.value=mcTabSel;else if(mcTabSel=='*')sc.value='';}if(typeof updateCharsLeft==='function' && sc)updateCharsLeft();mcApplyTab();}");
+    // messages that arrive while the tab is hidden must not count as read
+    // until the operator actually comes back to look at them
+    web_client.println("document.addEventListener('visibilitychange',function(){if(cpage=='messages')mcApplyTab();});");
+    web_client.println("function mcHistIndex(id){for(var i=0;i<mcHistory.length;i++){if(mcHistory[i].id==id)return i;}return -1;}");
+    web_client.println("function mcMergeEntry(el){var id=el.getAttribute('data-id');var html=el.outerHTML;var dst=el.getAttribute('data-dst')||'';var ts=parseInt(el.getAttribute('data-ts'))||0;var rx=el.classList.contains('message-received');var idx=mcHistIndex(id);if(idx<0){mcHistory.push({id:id,html:html,dst:dst,ts:ts,rx:rx});mcSeen[id]=true;if(mcHistory.length>MC_HIST_MAX){var dropped=mcHistory.shift();delete mcSeen[dropped.id];}}else{mcHistory[idx].html=html;mcHistory[idx].dst=dst;mcHistory[idx].ts=ts;mcHistory[idx].rx=rx;}}");
+    web_client.println("function mcRemovePlaceholder(panel){var kids=panel.children;for(var i=kids.length-1;i>=0;i--){if(kids[i].tagName=='P')panel.removeChild(kids[i]);}}");
     // this function is an ayncronous loader that is used to update the received messages without re-loading the whole page, it will re-call itself after a timeout as long as the message-page is displayed
-    web_client.println("function updateMessages() {var xhttp=new XMLHttpRequest();xhttp.onreadystatechange=function(){if(this.readyState==4 && this.status==200){if(document.getElementById(\"messages_panel\")!=null)document.getElementById(\"messages_panel\").innerHTML=decodeURIComponent(this.responseText);}};setTimeout(function(){xhttp.open(\"GET\",\"/?getmessages\",true);xhttp.send();},1000);}\n");
+    // it merges the response into mcHistory/mcSeen instead of overwriting the panel outright, so a message already on screen keeps its DOM position when only its ack mark changed
+    web_client.println("function mcProcessMessages(text,panel){var tmpl=document.createElement('template');tmpl.innerHTML=text;var els=tmpl.content.querySelectorAll('.message[data-id]');for(var i=0;i<els.length;i++){var el=els[i];var id=el.getAttribute('data-id');var existed=mcSeen.hasOwnProperty(id);mcMergeEntry(el);if(existed){var old=panel.querySelector('.message[data-id=\"'+id+'\"]');if(old)old.replaceWith(el);}else{panel.appendChild(el);}}mcRemovePlaceholder(panel);if(mcHistory.length==0)panel.innerHTML='<p>No messages available.</p>';if(typeof mcApplyTab==='function')mcApplyTab();}");
+    web_client.println("function updateMessages() {var xhttp=new XMLHttpRequest();xhttp.onreadystatechange=function(){if(this.readyState==4 && this.status==200){var panel=document.getElementById('messages_panel');if(panel!=null)mcProcessMessages(decodeURIComponent(this.responseText),panel);}};setTimeout(function(){xhttp.open('GET','/?getmessages',true);xhttp.send();},1000);}\n");
+    // rebuilds #messages_panel from mcHistory when the messages page is (re-)injected by loadPage(); first merges the server-rendered entries already sitting in the panel into mcHistory (same dedupe as mcProcessMessages) so nothing the server just sent is lost, then renders the full remembered history in order
+    web_client.println("function mcRenderHistory(){var panel=document.getElementById('messages_panel');if(!panel)return;var els=panel.querySelectorAll('.message[data-id]');for(var i=0;i<els.length;i++){mcMergeEntry(els[i]);}var html='';for(var j=0;j<mcHistory.length;j++){html+=mcHistory[j].html;}panel.innerHTML=html.length>0?html:'<p>No messages available.</p>';if(typeof mcApplyTab==='function')mcApplyTab();}");
     //  this function sends a parameter:value request to the backend
-    web_client.println("function setvalue(param,value,refresh) {fetch(\"/setparam/?\"+param+\"=\"+encodeURIComponent(value)).then(function(response){return response.json();}).then(function(jsonResponse){if(jsonResponse['returncode']==1)alert(\"Value could not be set.\");if(jsonResponse['returncode']==2)alert(\"Parameter unknown to node.\");if(jsonResponse['returncode']>0){loadPage(cpage,csender,false)}if(refresh)loadPage(cpage,csender,false);});}\n");
+    // TRK-01: bei Erfolg (returncode==0, die Seite wird hier NICHT neu geladen) den Warnhinweis
+    // "<id>_warn" live ein-/ausblenden -- generisch ueber param, damit kuenftige Switches denselben Mechanismus erben
+    web_client.println("function setvalue(param,value,refresh) {fetch(\"/setparam/?\"+param+\"=\"+encodeURIComponent(value)).then(function(response){return response.json();}).then(function(jsonResponse){if(jsonResponse['returncode']==1)alert(\"Value could not be set.\");if(jsonResponse['returncode']==2)alert(\"Parameter unknown to node.\");if(jsonResponse['returncode']==0){var w=document.getElementById(param+\"_warn\");if(w)w.style.display=(value==\"on\")?\"\":\"none\";}if(jsonResponse['returncode']>0){loadPage(cpage,csender,false)}if(refresh)loadPage(cpage,csender,false);});}\n");
     // this function invokes a function call to the backend passing the function name and an optional parameter (e.g. sendpos)
     web_client.println("function callfunction(functionname,functionparameter){fetch(\"/callfunction/?\"+functionname+\"=\"+functionparameter).then(function(response){return response.json();}).then(function (jsonResponse) {/*Nothing todo yet.*/})}\n");
     // CS-03: config restore. Lives here and not in the setup page, because the
@@ -880,6 +946,90 @@ void deliver_scaffold(bool bget_password)
 
     // This function is used to toggle a css class so setup cars can collapse / expand
     web_client.println("function togglecard(element){element.parentElement.classList.toggle(\"cardopen\");}");
+
+    // WQ-01: LoRa Queue panel on the rxlog page. rxlog is fetched by loadPage()
+    // and injected with innerHTML, which never runs a <script> tag it carries,
+    // so the rendering logic has to live here in the scaffold instead and be
+    // invoked from loadPage() after each fragment swap (that covers both the
+    // initial page load and the 10s autorefresh). The fragment itself only
+    // emits an empty #mcq div carrying data-* attributes; all markup below is
+    // built from those. JS strings use single quotes and HTML attribute
+    // values are written unquoted (none of them ever contain a space) so
+    // nothing here needs quote-escaping in the C string literals.
+    web_client.println("var mcQueueOpen=true;");
+    web_client.println("function mcQueueToggle(btn){mcQueueOpen=!mcQueueOpen;var b=document.getElementById('mcq');if(b)b.hidden=!mcQueueOpen;if(btn)btn.textContent=mcQueueOpen?'hide':'show';}");
+    web_client.println("function mcRenderQueue(){");
+    web_client.println("var d=document.getElementById('mcq');");
+    web_client.println("if(!d)return;");
+    web_client.println("var p=[0,0,0,0,0,0];");
+    web_client.println("for(var i=1;i<=5;i++){p[i]=parseInt(d.getAttribute('data-p'+i))||0;}");
+    web_client.println("var ring=parseInt(d.getAttribute('data-ring'))||0;");
+    web_client.println("var used=parseInt(d.getAttribute('data-p0'))||0;");
+    web_client.println("var bp=parseInt(d.getAttribute('data-bp'))||0;");
+    web_client.println("var bpname=d.getAttribute('data-bpname')||'';");
+    web_client.println("var qrs=parseInt(d.getAttribute('data-qrs'))||0;");
+    web_client.println("var qrsf=parseInt(d.getAttribute('data-qrsf'))||qrs;");
+    web_client.println("var qrt=parseInt(d.getAttribute('data-qrt'))||0;");
+    web_client.println("var win=parseInt(d.getAttribute('data-win'))||0;");
+    web_client.println("var rx=parseInt(d.getAttribute('data-rx'))||0;");
+    web_client.println("var tx=parseInt(d.getAttribute('data-tx'))||0;");
+    web_client.println("var intv=parseInt(d.getAttribute('data-int'))||300;");
+    web_client.println("var newid=parseInt(d.getAttribute('data-newid'))||0;");
+    web_client.println("var dup=parseInt(d.getAttribute('data-dup'))||0;");
+    web_client.println("var dwin=parseInt(d.getAttribute('data-dwin'))||0;");
+    web_client.println("var age=parseInt(d.getAttribute('data-age'))||0;");
+    web_client.println("var empty=ring-used;");
+    web_client.println("if(empty<0)empty=0;");
+    web_client.println("var qrsPct=ring>0?(qrs/ring*100):0;");
+    web_client.println("var qrsfPct=ring>0?(qrsf/ring*100):0;");
+    web_client.println("var qrtPct=ring>0?(qrt/ring*100):0;");
+    web_client.println("var colors=['#A2182F','#E07B39','#3B7DD8','#6FA96F','#9E9E9E'];");
+    web_client.println("var names=['crit','high','normal','low','bg'];");
+    web_client.println("var html='';");
+    web_client.println("html+='<div class=font-bold>TX ring</div>';");
+    web_client.println("html+='<div class=mcq-barwrap><div class=mcq-bar>';");
+    web_client.println("for(var pr=1;pr<=5;pr++){for(var c=0;c<p[pr];c++){html+='<div class=mcq-cell style=background:'+colors[pr-1]+'></div>';}}");
+    web_client.println("for(var c2=0;c2<empty;c2++){html+='<div class=mcq-cell-empty></div>';}");
+    web_client.println("html+='</div>';");
+    web_client.println("html+='<div class=mcq-tick-faint style=left:'+qrsPct+'%></div>';");
+    web_client.println("html+='<div class=mcq-tick style=left:'+qrsfPct+'%></div>';");
+    web_client.println("html+='<div class=mcq-tick style=left:'+qrtPct+'%></div>';");
+    web_client.println("html+='</div>';");
+    web_client.println("html+='<div class=mcq-ticklabels>';");
+    web_client.println("html+='<span class=font-small style=position:absolute;left:'+qrsfPct+'%;transform:translateX(-50%)>QRS</span>';");
+    web_client.println("html+='<span class=font-small style=position:absolute;left:'+qrtPct+'%;transform:translateX(-50%)>QRT</span>';");
+    web_client.println("html+='</div>';");
+    web_client.println("html+='<div class=mcq-legend>'+used+'/'+ring+' queued&nbsp;|&nbsp;';");
+    web_client.println("for(var pr2=1;pr2<=5;pr2++){html+='<span class=mcq-swatch style=background:'+colors[pr2-1]+'></span>'+names[pr2-1]+' '+p[pr2]+' ';}");
+    web_client.println("html+='</div>';");
+    web_client.println("var bpcolor=(bp==0)?'#3B9E4F':((bp==1)?'#E07B39':'#A2182F');");
+    web_client.println("html+='<div class=font-bold>Back-pressure: <span style=color:'+bpcolor+'>'+bpname+'</span></div>';");
+    web_client.println("html+='<div class=font-small>(QRS forecast at&nbsp;'+qrsf+' for your next msgs, line&nbsp;&ge;'+qrs+', QRT at&nbsp;&ge;'+qrt+' of '+ring+')</div>';");
+    web_client.println("if(win==0){");
+    web_client.println("html+='<div class=font-bold>Dedup window: n/a (no completed 5-min window yet)</div>';");
+    web_client.println("}else if(dwin==0){");
+    web_client.println("html+='<div class=font-bold>Dedup window: n/a (no new ids in the last window)</div>';");
+    web_client.println("}else{");
+    web_client.println("var dwc=(dwin<40||dwin>48)?'#E07B39':'inherit';");
+    web_client.println("html+='<div class=font-bold>Dedup window:&nbsp;&asymp;<span style=color:'+dwc+'>'+dwin+'</span> min</div>';");
+    web_client.println("html+='<div class=font-small>('+newid+' new ids, '+dup+' dups in last '+Math.round(intv/60)+' min; safe corridor 40-48 min)</div>';");
+    web_client.println("}");
+    web_client.println("html+='<div class=font-bold>Channel utilisation (last 5 min)</div>';");
+    web_client.println("if(win==0){");
+    web_client.println("html+='<div class=font-small>n/a</div>';");
+    web_client.println("}else{");
+    web_client.println("var rxPct=rx/(intv*1000)*100;if(rxPct>100)rxPct=100;");
+    web_client.println("var txPct=tx/(intv*1000)*100;if(txPct>100)txPct=100;");
+    web_client.println("var totPct=(rx+tx)/(intv*1000)*100;if(totPct>100)totPct=100;");
+    web_client.println("html+='<div class=mcq-util-row><span class=mcq-util-label>rx '+rxPct.toFixed(1)+'%</span><div class=mcq-util-track><div style=height:100%;width:'+rxPct+'%;background:#3B7DD8></div></div></div>';");
+    web_client.println("html+='<div class=mcq-util-row><span class=mcq-util-label>tx '+txPct.toFixed(1)+'%</span><div class=mcq-util-track><div style=height:100%;width:'+txPct+'%;background:#A2182F></div></div></div>';");
+    web_client.println("html+='<div class=font-small>total '+totPct.toFixed(1)+'% ('+age+' s ago)</div>';");
+    web_client.println("}");
+    web_client.println("d.innerHTML=html;");
+    web_client.println("var btn=document.getElementById('mcqtogglebtn');");
+    web_client.println("d.hidden=!mcQueueOpen;");
+    web_client.println("if(btn)btn.textContent=mcQueueOpen?'hide':'show';");
+    web_client.println("}");
 
     web_client.println("</script>\n\n");
 
@@ -971,6 +1121,28 @@ void deliver_scaffold(bool bget_password)
     web_client.println(".collapsablecard>div {max-height:0px;-webkit-transition:opacity .15s .0s,max-height .25s .10s;transition:opacity .15s .0s,max-height .25s .10s,margin .0s .50s;	opacity:0.0;overflow:hidden;margin:0px;}\n");
     web_client.println(".cardopen>div {-webkit-transition:opacity .15s .10s,max-height .25s .0s;transition:opacity .15s .10s,max-height .25s .0s;max-height:1000px;opacity:1;margin:7px;}\n");
     web_client.println(".cardopen>span:first-of-type {display:none;}\n");
+
+    // content definitions -> WQ-01 LoRa Queue panel (rxlog page)
+    web_client.println(".mcq-toggle {position:absolute;right:8px;top:-1px;transform:translateY(-50%);z-index:10;border:solid 1px var(--mcgray);background:#fff;border-radius:5px;padding:1px 8px;cursor:pointer;}\n");
+    web_client.println(".mcq-barwrap {position:relative;}\n");
+    web_client.println(".mcq-bar {display:flex;flex-direction:row;gap:1px;height:14px;margin:4px 0 2px 0;}\n");
+    web_client.println(".mcq-cell {flex:1;height:14px;}\n");
+    web_client.println(".mcq-cell-empty {flex:1;height:14px;background:#ECECEC;border:1px solid #d0d0d0;box-sizing:border-box;}\n");
+    web_client.println(".mcq-tick {position:absolute;top:0;bottom:0;width:1px;background:#000;opacity:0.5;}\n");
+    web_client.println(".mcq-tick-faint {position:absolute;top:0;bottom:0;width:1px;background:#000;opacity:0.15;}\n");
+    web_client.println(".mcq-ticklabels {position:relative;height:12px;font-size:x-small;margin:0 0 8px 0;}\n");
+    web_client.println(".mcq-legend {font-size:x-small;margin:0 0 8px 0;}\n");
+    web_client.println(".mcq-swatch {display:inline-block;width:8px;height:8px;margin:0 3px 0 6px;border-radius:2px;vertical-align:middle;}\n");
+    web_client.println(".mcq-util-row {display:flex;align-items:center;gap:6px;margin:2px 0;}\n");
+    web_client.println(".mcq-util-label {display:inline-block;min-width:60px;}\n");
+    web_client.println(".mcq-util-track {flex:1;height:10px;background:#ECECEC;border-radius:4px;overflow:hidden;}\n");
+
+    // content definitions -> message-page tab bar
+    web_client.println("#mctabs {margin:6px 0;}\n");
+    web_client.println("#content_inner .mctab {display:inline-flex;align-items:center;border:solid 1px var(--mcgray);background-color:var(--mcbg);border-radius:5px;padding:2px 8px;margin-right:4px;cursor:pointer;}\n");
+    web_client.println("#content_inner .mctab-new {background-color:var(--mclightgreen);}\n");
+    web_client.println("#content_inner .mctab-on {background-color:var(--mclightblue);}\n");
+    web_client.println(".mcbadge {font-size:x-small;font-weight:bold;margin-left:4px;}\n");
 
     web_client.println("</style>\n\n");
 
@@ -1129,11 +1301,45 @@ void sub_page_rxlog()
 {
     int iRead = RAWLoRaRead;
     _create_meshcom_subheader("RX Log");
+
+    // WQ-01: LoRa Queue panel. This fragment only carries data-* attributes;
+    // mcRenderQueue() (scaffold JS, see deliver_scaffold()) turns them into
+    // the bars/text, because a <script> tag injected via innerHTML never
+    // runs. stat_last_window_ms == 0 means no 5-min window has completed
+    // since boot -- data-win covers that for the JS side.
+    uint8_t mcqPrio[6] = {0};
+    txRingPrioCounts(mcqPrio);
+    uint32_t mcqDedupWin = setlogDedupWindowMin(stat_last_window.newid, PRIO_STAT_INTERVAL_S, MAX_DEDUP_RING);
+    uint32_t mcqAgeS = 0;
+    if (stat_last_window_ms != 0)
+    {
+        mcqAgeS = (millis() - stat_last_window_ms) / 1000UL;
+    }
+
+    // WQ-01: the card lives inside #content_inner so it shares the 4 % left
+    // margin of the log lines; fixed 600 px wide (max-width:100% keeps it on
+    // a phone screen), it does not scale with the page.
     web_client.println("<div id=\"content_inner\" class=\"logoutput\">");
+    web_client.println("<div class=\"cardlayout\" style=\"width:600px;max-width:100%;box-sizing:border-box;\">");
+    web_client.println("<label class=\"cardlabel\">LoRa Queue</label>");
+    web_client.println("<button id=\"mcqtogglebtn\" class=\"mcq-toggle\" onclick=\"mcQueueToggle(this)\">hide</button>");
+    web_client.printf("<div id=\"mcq\" data-ring=\"%u\" data-p0=\"%u\" data-p1=\"%u\" data-p2=\"%u\" data-p3=\"%u\"\n",
+                       (unsigned int)MAX_RING, (unsigned int)mcqPrio[0], (unsigned int)mcqPrio[1], (unsigned int)mcqPrio[2], (unsigned int)mcqPrio[3]);
+    web_client.printf(" data-p4=\"%u\" data-p5=\"%u\" data-bp=\"%d\" data-bpname=\"%s\" data-qrs=\"%d\" data-qrsf=\"%d\" data-qrt=\"%d\"\n",
+                       (unsigned int)mcqPrio[4], (unsigned int)mcqPrio[5], bpCurrentState(), bpStateName(), bpQrsThreshold(), bpQrsForecast((int)mcqPrio[0]), bpRefuseThreshold());
+    web_client.printf(" data-win=\"%d\" data-rx=\"%lu\" data-tx=\"%lu\" data-int=\"%d\" data-newid=\"%lu\"\n",
+                       (stat_last_window_ms != 0) ? 1 : 0, (unsigned long)stat_last_window.rx_ms, (unsigned long)stat_last_window.tx_ms,
+                       (int)PRIO_STAT_INTERVAL_S, (unsigned long)stat_last_window.newid);
+    web_client.printf(" data-dup=\"%lu\" data-dedup=\"%u\" data-dwin=\"%lu\" data-age=\"%lu\"></div>\n",
+                       (unsigned long)stat_last_window.dup, (unsigned int)MAX_DEDUP_RING, (unsigned long)mcqDedupWin, (unsigned long)mcqAgeS);
+    web_client.println("</div>");
+
     web_client.println("<div style=\"overflow:scroll;\">");
     do
     {
-        web_client.printf("<p class=\"font-small no-wrap\"><%i>%s</nobr></td></tr>\n", iRead, ringbufferRAWLoraRX[iRead]);
+        // WQ-01: normal text size (was font-small) -- the page uses three sizes only:
+        // title, normal (log lines, panel text), small (legend, notes, tick labels).
+        web_client.printf("<p class=\"no-wrap\"><%i>%s</p>\n", iRead, ringbufferRAWLoraRX[iRead]);
         iRead = increment_mod(iRead, MAX_LOG);
     } while (RAWLoRaRead != iRead);
     web_client.println("</div></div>");
@@ -1314,6 +1520,21 @@ void sub_page_messages()
     _create_meshcom_subheader("Messages");
     web_client.println("<div id=\"content_inner\">");
 
+    // tab bar filtering the panel below by data-dst; mcTab()/mcApplyTab() in
+    // the scaffold do the actual filtering (sub-page <script> never runs)
+    web_client.println("<div id=\"mctabs\">");
+    web_client.println("<button class=\"mctab mctab-on\" data-tab=\"all\" onclick=\"mcTab(this)\">All</button>");
+    web_client.println("<button class=\"mctab\" data-tab=\"*\" onclick=\"mcTab(this)\">*</button>");
+    for (int i = 0; i < (int)sizeof(meshcom_settings.node_gcb) / (int)sizeof(meshcom_settings.node_gcb[0]); i++)
+    {
+        if (meshcom_settings.node_gcb[i] > 0 && meshcom_settings.node_gcb[i] < 100000)
+        {
+            web_client.printf("<button class=\"mctab\" data-tab=\"%i\" onclick=\"mcTab(this)\">%i</button>\n", meshcom_settings.node_gcb[i], meshcom_settings.node_gcb[i]);
+        }
+    }
+    web_client.println("<button class=\"mctab\" data-tab=\"dm\" onclick=\"mcTab(this)\">DM</button>");
+    web_client.println("</div>");
+
     // this is where the asynchronous received messages will be displayed
     web_client.println("<div id=\"messages_panel\" class=\"mw-600\">");
     sub_content_messages(); // deliver all known messages
@@ -1463,7 +1684,7 @@ void sub_page_setup()
     web_client.println("</div><div class=\"grid grid2\">");
 
     _create_setup_switch_element("gps", "GPS", "enable GPS", bGPSON);                                  // create Switch-Element inclucing Label and Description
-    _create_setup_switch_element("track", "Track", "enable display of SmartBeaconing", bDisplayTrack); // create Switch-Element inclucing Label and Description
+    _create_setup_switch_element("track", "Track", "enable display of SmartBeaconing", bDisplayTrack, TRACK_WARNING_TEXT, bDisplayTrack); // create Switch-Element inclucing Label and Description; TRK-01: Warnhinweis neben dem Switch
 
     web_client.println("</div></div>");
 
@@ -1600,19 +1821,28 @@ void sub_page_setup()
  * ###########################################################################################################################
  * This will only deliver the preformatted messages to be loaded asyncronous into the WebUI scaffold
  */
+// The ring has no reader cursor of its own. toPhoneRead only advances when a
+// BLE client with an active "hello" session drains a slot, which happens
+// within ~100 ms of the write -- following toPhoneRead here reliably finds
+// an empty window while a phone is connected. toPhoneWrite always points at
+// the oldest surviving slot (the writer fills it, then wraps toPhoneWrite
+// forward), so scan the full ring from there instead. Upstream origin
+// 87c6c200.
 void sub_content_messages()
 {
-    int iRead = toPhoneRead;
+    int rendered = 0;
+    int iStart = toPhoneWrite; // snapshot: the writer may advance it while we scan
+
     if (bDEBUG)
-        Serial.printf("toPhoneWrite:%i toPhoneRead:%i\n", toPhoneWrite, toPhoneRead);
+        Serial.printf("toPhoneWrite:%i\n", iStart);
 
-    if (toPhoneWrite == 0)
+    for (int i = 0; i < MAX_RING; i++)
     {
-        web_client.printf("<p>No messages available.</p>");
-    }
+        int iRead = (iStart + i) % MAX_RING;
 
-    while (toPhoneWrite != iRead)
-    {
+        if (BLEtoPhoneBuff[iRead][0] == 0) // 0 = slot never written since reboot
+            continue;
+
         if (bDEBUG)
             Serial.printf("iRead:%i [1]:%02X\n", iRead, BLEtoPhoneBuff[iRead][1]);
 
@@ -1660,7 +1890,10 @@ void sub_content_messages()
             // Textmessage
             if (msg_type_b_lora == 0x3A)
             {
-                if (aprsmsg.msg_payload.indexOf(":ack") < 1)
+                // {CET} time beacons sit in the ring for the phone app's clock
+                // sync; they are not operator traffic and would light the tab
+                // badges on every beacon, so the web list skips them
+                if (aprsmsg.msg_payload.indexOf(":ack") < 1 && !aprsmsg.msg_payload.startsWith("{CET}"))
                 {
                     String msgtxt = aprsmsg.msg_payload;
                     if (bDEBUG)
@@ -1674,10 +1907,12 @@ void sub_content_messages()
                     String msg_source_path_esc = htmlEscape(aprsmsg.msg_source_path);
                     String msg_destination_path_esc = htmlEscape(aprsmsg.msg_destination_path);
 
-                    // messages by others
+                    // own messages (source == us): the browser's DM tab keys on the destination call
                     if (is_equ(meshcom_settings.node_call, aprsmsg.msg_source_call.c_str()))
                     {
-                        web_client.printf("<div class=\"message message-send\"><div>");
+                        String dst_esc = htmlEscape(aprsmsg.msg_destination_call);
+
+                        web_client.printf("<div class=\"message message-send\" data-id=\"%u\" data-dst=\"%s\" data-ts=\"%lu\"><div>", aprsmsg.msg_id, dst_esc.c_str(), unix_time);
 
                         web_client.printf("<p class=\"font-small font-bold\">%s", ccheck.c_str());
                         web_client.printf("<a target=\"_blank\" href=\"https://aprs.fi/?call=%s\">%s</a>", msg_source_path_esc.c_str(), msg_source_path_esc.c_str());
@@ -1687,10 +1922,26 @@ void sub_content_messages()
                         web_client.printf("<p class=\"font-normal\">%s</p>", msgtxt_esc.c_str());
                         web_client.printf("</div></div>");
                     }
-                    // own messages
+                    // messages by others: "*" and group numbers key on the destination call as-is,
+                    // a DM to us keys on the source call so the DM tab shows both directions
                     else
                     {
-                        web_client.printf("<div class=\"message message-received\"><div>");
+                        bool isGroupDst = is_equ(aprsmsg.msg_destination_call.c_str(), "*");
+                        if (!isGroupDst && aprsmsg.msg_destination_call.length() > 0)
+                        {
+                            isGroupDst = true;
+                            for (unsigned int ci = 0; ci < aprsmsg.msg_destination_call.length(); ci++)
+                            {
+                                if (!isDigit(aprsmsg.msg_destination_call.charAt(ci)))
+                                {
+                                    isGroupDst = false;
+                                    break;
+                                }
+                            }
+                        }
+                        String dst_esc = htmlEscape(isGroupDst ? aprsmsg.msg_destination_call : aprsmsg.msg_source_call);
+
+                        web_client.printf("<div class=\"message message-received\" data-id=\"%u\" data-dst=\"%s\" data-ts=\"%lu\"><div>", aprsmsg.msg_id, dst_esc.c_str(), unix_time);
 
                         web_client.printf("<p class=\"font-small font-bold\">%s", ccheck.c_str());
                         web_client.printf("<a target=\"_blank\" href=\"https://aprs.fi/?call=%s\">%s</a>", msg_source_path_esc.c_str(), msg_source_path_esc.c_str());
@@ -1700,13 +1951,18 @@ void sub_content_messages()
                         web_client.printf("<p class=\"font-normal\">%s</p>", msgtxt_esc.c_str());
                         web_client.printf("</div></div>");
                     }
+
+                    rendered++;
                 }
             }
         }
-        iRead++;
-        if (iRead >= MAX_RING)
-            iRead = 0;
     }
+
+    if (rendered == 0)
+    {
+        web_client.printf("<p>No messages available.</p>");
+    }
+
     web_client.println(); // The HTTP response ends with another blank line
 }
 
@@ -1850,7 +2106,12 @@ void sub_page_info()
         web_client.printf("<tr><td>Battery</td><td>%.3fV (%d%%) max %.3fV</td></tr>\n", global_batt / 1000.0, global_proz, meshcom_settings.node_maxv);
     web_client.printf("<tr><td>Settings</td><td>");
     web_client.printf("Gateway: %s<br>", (bGATEWAY ? "on" : "off"));
-    web_client.printf("Analog: %s<br>", (bAnalogCheck ? "on" : "off"));
+    if (!bAnalogCheck)
+        web_client.printf("Analog: off<br>");
+    else if (meshcom_settings.node_analog_pin <= 0 || meshcom_settings.node_analog_pin >= 99)
+        web_client.printf("Analog: on (GPIO not set, measurement paused)<br>");
+    else
+        web_client.printf("Analog: on (GPIO %i)<br>", meshcom_settings.node_analog_pin);
     web_client.printf("Mesh: %s<br>", (bMESH ? "on" : "off"));
     web_client.printf("Routing: %s<br>", (bVIA ? "on" : "off"));
     web_client.printf("Button: %s<br>", (bButtonCheck ? "on" : "off"));
@@ -1928,7 +2189,10 @@ void sub_page_info()
     if (bAnalogCheck)
     {
         web_client.println("<tr><td>Analog</td><td>");
-        web_client.printf("ANALOG GPIO: %i<br>>", meshcom_settings.node_analog_pin);
+        if (meshcom_settings.node_analog_pin <= 0 || meshcom_settings.node_analog_pin >= 99)
+            web_client.printf("ANALOG GPIO: not set (measurement paused)<br>");
+        else
+            web_client.printf("ANALOG GPIO: %i<br>", meshcom_settings.node_analog_pin);
         web_client.printf("Factor: %.4fV<br>", meshcom_settings.node_analog_faktor);
         web_client.printf("Value: %.2fV<br>", fAnalogValue);
         web_client.printf("</td></tr>\n");
@@ -2143,10 +2407,17 @@ void _create_setup_textinput_element(const char id[], const char labelText[], St
  * @param labelText the text in the label
  * @param descriptionText the smaller text in brackets
  * @param checked TRUE, if the switch should be displayed as activated
+ * @param warnText TRK-01: optionaler Warnhinweis-Text neben dem Switch; nullptr = kein Hinweis
+ * @param warnVisible TRK-01: TRUE, wenn der Warnhinweis beim Seitenaufbau sichtbar sein soll
  */
-void _create_setup_switch_element(const char id[], const char labelText[], const char descriptionText[], bool checked)
+void _create_setup_switch_element(const char id[], const char labelText[], const char descriptionText[], bool checked, const char warnText[], bool warnVisible)
 {
-    web_client.printf("<label for=\"%s\">%s <span class=\"font-small\">(%s)</span></label>\n", id, labelText, descriptionText);
+    web_client.printf("<label for=\"%s\">%s <span class=\"font-small\">(%s)</span>", id, labelText, descriptionText);
+    if (warnText != nullptr)
+    { // TRK-01: zweiter Span mit der id "<id>_warn", damit setvalue() ihn live umschalten kann
+        web_client.printf("<span id=\"%s_warn\" class=\"font-small\" style=\"color:var(--mcred)%s\"> %s</span>", id, warnVisible ? "" : ";display:none", warnText);
+    }
+    web_client.println("</label>");
     web_client.printf("<input type=\"checkbox\" role=\"switch\" id=\"%s\" %s onchange=\"setvalue(this.id,this.checked?'on':'off',false)\"/>\n", id, checked ? "checked" : "");
 }
 

--- a/src/web_functions/web_functions.h
+++ b/src/web_functions/web_functions.h
@@ -44,7 +44,7 @@ void sub_page_mcp23017();       // mcp23017 page
 // related functions
 void send_http_header(uint16_t http_status_code, uint8_t response_type);        // create and send a HTML Header 
 void _create_setup_textinput_element(const char id[], const char labelText[], String inputValue, const char placeHolder[], const char parameterName[], uint8_t maxlength, bool isPassword, bool needConfirm);  // create and send a textinput element used in setup
-void _create_setup_switch_element(const char id[], const char labelText[], const char descriptionText[], bool checked);     // create and send a switch element used in setup
+void _create_setup_switch_element(const char id[], const char labelText[], const char descriptionText[], bool checked, const char warnText[] = nullptr, bool warnVisible = false);     // create and send a switch element used in setup; TRK-01: optional Warnhinweis neben dem Switch
 void _create_meshcom_subheader(String title);                                   // create the sub-page sub-header ( that header containing the date, time and title)
 void _create_button_component(bool needConfirm, String confirmText, String onClickHandler, String buttonCaption);
 


### PR DESCRIPTION
Sammel-PR mit den Firmware-Aenderungen des Forks seit PR #1125 (Stand v4.35s.09.09), als ein Commit auf dem aktuellen `dev` (674413ce). Nur `src/`, keine Docs, Tests oder Tools. Safeboot-Quellen und die vorgebauten Safeboot-Images sind bewusst nicht enthalten. `FLASH_STRUCT_VERSION` bleibt 20260724, Node-Einstellungen bleiben erhalten.

## Was wurde geaendert

### 1. `--deepsleep` schlaeft auf jedem Board wirklich (Issue #962)

- Neu `src/esp32/esp32_sleep.{h,cpp}`: `esp32EnterDeepSleep()` -- Funk in Sleep (`loraDeepSleep()`), Display in Power-Save, PMU-Schienen fuer LoRa und GPS aus, GPS-/ADC-Pins aus, Button-Wake (ext1) auf dem zur Laufzeit konfigurierten Pin (`--button`), dann `esp_deep_sleep_start()`. T-Deck/T-Deck Plus schalten TFT und die gemeinsame LoRa/GPS/Tastatur-Schiene ab, T-Beam-1W die Radio-LDO.
- Neu `src/nrf52/nrf52_sleep.{h,cpp}`: `nrf52EnterDeepSleep()` fuer RAK4631, Heltec T114 und T-Echo -- `Radio.Sleep()`, Advertising stoppen, Display aus, Peripherie-Schiene aus (RAK `WB_IO2`, T114 `PIN_VEXT_CTL`, T-Echo `Power_On_Pin`), Serial/Wire/SPI beenden, dann `systemOff()` bzw. `sd_power_system_off()`. `Serial1.end()` nur, wenn der Port begonnen wurde (`Uart::end()` haengt sonst endlos); der Pin-Lookup fuer `systemOff()` ist gegen `PINS_COUNT` geprueft.
- `src/esp32/esp32_pmu.{h,cpp}`: neu `pmuSleepRails()`, schaltet genau die Kanaele ab, die `setupPMU()` als LoRa/GPS belegt (AXP192: LDO2/LDO3; AXP2101: ALDO2/ALDO3, Supreme ALDO3/ALDO4).
- `src/lora_functions.{h,cpp}`: `loraDeepSleep()` (`radio.sleep()`) unter demselben Chip-Guard wie das `radio`-Objekt, WP_DISP-Boards ausgenommen.
- `src/command_functions.cpp`: der `--deepsleep`-Handler ruft auf ESP32 (ausser WP_DISP) `esp32EnterDeepSleep()`, auf nRF52 `nrf52EnterDeepSleep()`. Der alte T114-Toggle (`bDEEP_SLEEP`, zweiter Aufruf zum Aufwecken) und der Heltec-V3-Vext-Block sind entfallen.
- `src/nrf52/nrf52_functions.cpp`: `boardPWROff()` (T-Echo Long-Press) ruft `nrf52EnterDeepSleep()`.
- `src/t-deck/tdeck_main.cpp`, `src/esp32/esp32_main.cpp`: `gpio_hold_dis()` / `gpio_deep_sleep_hold_dis()` beim Boot fuer `TDECK_POWERON`, `TDECK_TFT_BACKLIGHT`, `RADIO_LDO_EN` (T-Beam-1W) und `PIN_LORA_NSS` (Wireless Paper / E213), bevor die Pins neu konfiguriert werden.

### 2. ACK-Frames an das Telefon tragen das Rufzeichen des Quittierenden

- Neu `src/ack_attribution.h`: `buildAckPhoneFrame()`, `ackWireAppendixLen()`, `ackWireHash()`, `ackMsgIdFromNode()` -- reine Funktionen ohne String/Heap. Das BLE-Statusframe (0x41) bekommt an Byte 6 eine Laengenangabe und bis zu 10 Zeichen `[A-Z0-9-]`; bei Laenge 0 ist das Frame byteidentisch mit heute, die offizielle App ist nicht betroffen.
- `src/lora_functions.cpp`: `handleACK()` akzeptiert und relayt ein 15-Byte-ACK mit 22-Bit-Node-Hash; alle vier Emit-Stellen (heard, Peer-ACK, Gateway-ACK, Server-ACK) bauen das Telefon-Frame ueber `buildAckPhoneFrame()`. Node-ACK (heard) traegt den letzten Hop, Peer-ACK den Partner.
- `src/udp_functions.cpp`, `src/loop_functions.cpp` (`sendMessage()`): dieselbe Frame-Erzeugung fuer Server-ACK und "Server erreicht".
- `src/command_functions.cpp`: neues fluechtiges Session-Flag `--ackinfo on|off` (nie im Flash; `--info` zeigt es). `src/esp32/esp32_main.cpp`, `src/nrf52/nrf52_ble.cpp`: wird bei jedem BLE-Disconnect/Connect auf `false` gesetzt.
- Gateway-Fix (ACK-01): `own_msg_id[]` haelt auf einem Gateway auch fremde msg_ids, die nur vom Server nach LoRa weitergereicht wurden. Der BLE-Emit in `handleACK()` und `OnRxDone()` ist jetzt mit `ackMsgIdFromNode(msg_id, _GW_ID)` auf eigene msg_ids begrenzt; die Statusschreibungen (`own_msg_id[][4]`) bleiben unveraendert, damit die Web-RX-Log-Haken weiter funktionieren.

### 3. Back-Pressure: Echo-Schutz (BP-11)

- `src/backpressure.h`: neu `bpIsOwnWording()` -- erkennt exakt die vier Notice-Texte und die zwei Nack-Praefixe (`QRT NOT SENT - `, `QTA NOT SENT - `), die diese Firmware selbst erzeugt.
- `src/loop_functions.cpp` (`sendMessage()`): ein Client (App, Web, EXTUDP-Peer), der eine solche Meldung als neue Nachricht zurueckschickt, wird nach dem `{ZIEL}`-Parse still verworfen (`BP_SEND_INVALID`, Marker `[BP];echo`), ohne Nack, ohne Notice, ohne msg_id.
- `src/bp_notice_frame.h`: Kommentar korrigiert -- `msg_app_offline` ist kein Sendeverbot, das Frame bleibt lokal, weil es nie in den TX-Ring geschrieben wird.

### 4. Web-GUI

- LoRa-Queue-Panel auf der RX-Log-Seite (WQ-01/WQ-02): `src/web_functions/web_functions.cpp` (`sub_page_rxlog()`, Scaffold-JS `mcRenderQueue()`) zeigt TX-Ring-Belegung je Prioritaet, Back-Pressure-Zustand mit Schwellen, QRS-Prognose fuer die naechsten eigenen Nachrichten, effektives Dedup-Fenster und das letzte 5-Minuten-STAT-Fenster (Kanalauslastung, neue IDs, Duplikate). Dafuer neu: `txRingPrioCounts()` in `src/txring_functions.{h,cpp}` (gleicher lock-freier Scan wie `txRingDepth()`), `setlogDedupWindowMin()` in `src/setlog_lines.{h,cpp}`, die Getter `bpCurrentState()/bpRefuseThreshold()/bpQrsThreshold()/bpQrsForecast()/bpStateName()` sowie die Kopie `stat_last_window` in `src/loop_functions.cpp` / `loop_functions_extern.h`.
- Messages-Seite: `sub_content_messages()` liest jetzt den ganzen `BLEtoPhoneBuff`-Ring ab `toPhoneWrite` statt das Fenster zwischen Telefon-Cursor und Schreibzeiger -- mit verbundener App war das Fenster in ~100 ms leer und die Seite zeigte nichts (Upstream `87c6c200`). Jeder Eintrag traegt `data-id`, `data-dst`, `data-ts`; der Browser haelt eine History (200 Eintraege), eine Tab-Leiste (All, `*`, je Gruppe, DM) filtert und setzt die Zielgruppe im Sendefeld vor, ungelesene Nachrichten faerben den Tab und tragen einen Zaehler (Watermark pro Tab in `localStorage`). `{CET}`-Zeitbeacons werden wie `:ack` uebersprungen.
- `_create_setup_switch_element()` (`web_functions.{h,cpp}`) hat zwei neue Default-Parameter fuer einen Warnhinweis neben dem Switch; `setvalue()` blendet ihn bei Erfolg live ein/aus.
- Info-Seite: Analog-Eingang zeigt "GPIO not set, measurement paused", wenn der Pin auf 99 steht.

### 5. Hoehe: Barometer-Referenz, GPS-Filter, Fusion (GPS-05b/07/08/09)

- `src/bmx280.{h,cpp}`: neu `getPressALTf()` (float); die Referenz `fBasePress` wird selbst aus dem aktuellen QFE gesetzt, sobald `fBaseAltidude` existiert. Bisher war die barometrische Hoehe nach jedem Neustart 0, bis jemand `--setpress` tippte. Bewusst nicht persistiert (kein neues Struct-Feld). `getPressALT()` rundet nur noch.
- `src/gps_filter.h`: Innovations-Gate 15 m -> 30 m, Re-Seed nach 60 statt 10 Verwerfungen. Mit den alten Werten re-seedete der Filter auf einem stationaeren Heltec V3 20-mal in 1,9 h und lieferte keine Verbesserung gegenueber dem Rohsignal.
- Neu `src/alt_fusion.{h,cpp}`: Komplementaerfilter GPS-Tiefpass plus Barometer-Hochpass (ein Pol, tau 30 min), Arduino-frei.
- `src/gps_functions.cpp` (`WZ_GPS_Loop()`): auf Boards mit BMx280 und scharfer Druckreferenz wird der fusionierte Wert nach `node_alt` geschrieben; alle anderen Boards und die erste Minute nach dem Boot behalten den reinen Kalman-Wert. Reset der Fusion an denselben Stellen wie der Kalman-Reset.
- `src/command_functions.cpp`: `--setpress`-Hilfetext ohne Argument (der Handler hat nie eines geparst).

### 6. MCP23017 Port A geht in die Luft: `/D=` (Issue #1076)

- Neu `src/mcp17_bits.h`: `mcp17PortABits()` formt Port A als acht Zeichen, GPA0 zuerst, Ausgangspins lesen `0`.
- `src/loop_functions.cpp`: `PositionToAPRS()` haengt `/D=01001100` an das Positionsbeacon, `sendTelemetry()` setzt denselben String in den Digital-Slot des `T#`-Frames (beide Zweige). Nur wenn `bMCP23017` gesetzt ist; Nodes ohne Chip erzeugen byteidentische Frames.
- `src/aprs_functions.cpp`, `src/aprs_structures.h`: `decodeAPRSPOS()` parst `/D=` nach `aprsPosition.din` (genau acht Binaerziffern oder leer).
- Neu `src/extern_tele_json.h`: `externTeleJsonNode()` / `externTeleJsonLora()` bauen das EXTUDP-`tele`-Datagramm; optionaler Key `din`, weggelassen ohne Chip.

### 7. EXTUDP `tele` fuer relayte Nodes: `qfe` traegt den Druck (TLM-04)

- `src/extudp_functions.cpp` (`sendExtern()`): bisher landete die `/F=`-Druckhoehe in Metern unter `qfe`, der echte `/P=`-Druck fehlte. Jetzt `qfe` = Stationsdruck, die Hoehe unter dem neuen Key `pressure_alt` (nur `lora`-Form, `node`-Form unveraendert). Builder in `extern_tele_json.h`.

### 8. Text-Filter: Einzelbyte-Umlaute ueberleben (CHR-03)

- `src/charset_filter.{h,cpp}`: ein Byte, das nicht Teil einer gueltigen UTF-8-Sequenz ist, wird als Legacy-Einzelbyte (Latin-1/CP1252, Bereich 0x80-0xFF) unveraendert durchgereicht statt geloescht. Sender wie PinPoint schicken `ue` als 0xFC; bisher kam "Gruesse" als "Gre" an. Eine wohlgeformte, aber ungueltige Sequenz (Overlong, Surrogat, > U+10FFFF) wird jetzt komplett verworfen, nicht nur das Lead-Byte. Der Filter entfernt weiterhin nur Bytes, transkodiert nichts; die Ausgabe ist nicht mehr garantiert gueltiges UTF-8.

### 9. TX-Leistung nach Flash-Reset (Issue #1132)

- `src/settings_sanitize.{h,cpp}`: neu `resolve_tx_power()` -- behandelt beide "nicht gesetzt"-Sentinels, 0 und -20 (Default seit Upstream 50c1ce59).
- `src/command_functions.cpp` (`sendNodeSetting()`), `src/nrf52/nrf52_main.cpp`: ein RAK4631 sendet nach Flash-Reset wieder mit 22 dBm, und die App zeigt diesen Wert statt -20 dBm.

### 10. ESP32-S3 Native-USB (CDC-01/CDC-02)

- `src/net_console.cpp` (`MeshSerialClass::begin()`), `src/esp32/esp32_main.cpp`: `setTxBufferSize(4096)` vor dem ersten `begin()` (einmalig; T5-ePaper/T-Deck Pro rufen `begin()` zweimal), danach `setTxTimeoutMs(0)`. Der Core hebt das TX-Timeout beim ersten Host-Read auf 100 ms und senkt es nie wieder; ohne Host blockierte jeder Print, der nicht in den 256-B-Ring passte, die Hauptschleife um 100 ms (T-Deck: Cursor und Touch froren im Takt der GPS-Zeilen). Ein Resize nach `begin()` liess `tx_ring_buf` kurz NULL, waehrend die ISR laeuft -- `assert failed: xRingbufferReceiveUpToFromISR`, Reboot-Schleife beim Port-Oeffnen.
- `src/instrument.{h,cpp}`: Loop-Gap-Zaehler werden in RTC-Speicher gespiegelt und beim naechsten Boot als `[INSTR-PREV]` ausgegeben (nur in Messbuilds, siehe 11).

### 11. Bench-Instrumentierung nicht mehr im normalen Build (INS-01)

- `src/instrument.h`: `INSTRUMENT_ENABLED` ist jetzt standardmaessig 0; ein Messbuild entsteht mit `-D INSTRUMENT_ENABLED=1`. Feldknoten druckten `[INSTR-LOOP];gap;...` ungefragt, Nutzer meldeten das als Fehler.
- `src/command_functions.cpp`: `--wifistat`, `--udpstat`, `--udplog` (ESP32) und `--ethstat`, `--udplog` (nRF52) sind aus dem Instrument-Block in einen eigenen, immer vorhandenen Abschnitt gezogen -- ein Gateway-Betreiber muss den UDP/WiFi/Ethernet-Pfad ohne Sonderbuild loggen koennen. `--help` listet die Bench-Kommandos nur noch, wo sie existieren.

### 12. Weitere Korrekturen

- `src/loop_functions.cpp`: T-Beam Supreme (`BOARD_TBEAM_V3`) OLED auf `U8G2_..._F_HW_I2C` mit Vollbildpuffer (Wire, Pins 17/18). Software-I2C mit 1-Seiten-Puffer kostete ~570 ms pro Bild auf der Hauptschleife (Feldmessung, 4x/min). Nicht auf Supreme-Hardware verifiziert.
- `src/adc_functions.cpp`, `src/loop_functions.cpp` (`initAnalogPin()`), `src/command_functions.cpp` (`--info`): mit `--analog on` und Pin 99 lief `analogReadRaw(99)` alle 2 ms und der Core loggte `Pin 99 is not ADC pin!` hunderte Male pro Sekunde. Messung pausiert bei Pin 99, eine Zeile beim Boot nennt den Board-Default.
- T-Deck: `src/t-deck/tdeck_main.cpp` (`mouse_read()`) -- der Trackball-Taster liefert nur noch auf der Druckflanke einen Puls (bisher zwei LVGL-Klicks pro Druck, der Drawer ging auf und wieder zu). `src/t-deck/event_functions.cpp` -- Send/Save-Handler wechseln ohne Animation zum Message-Tab (ein zweiter Druck waehrend der Scroll-Animation liess das Bild halb stehen); `tabview_event_cb()` verwirft das von der Tab-Leiste hochgeblubberte doppelte `VALUE_CHANGED`. `src/t-deck/tdeck_sdmap.{h,cpp}` -- `sdmap_refresh()` ueberspringt einen Aufbau, dessen Set/Zoom/Zentrum/Viewport dem letzten gleicht, und bekommt einen `why`-Parameter fuer das Log; damit wird die SD-Karte beim Tab-Wechsel einmal statt zweimal zusammengesetzt (718 ms statt 1337 ms Loop-Gap).
- Track-Warnhinweis (TRK-01): neu `src/track_warning.h`; `--track on` (`command_functions.cpp`), der Boot mit gesetztem Flag (`esp32_main.cpp`, `nrf52_main.cpp`) und der Web-Switch (`web_functions.cpp`) nennen den Preis: `degraded MeshCom RX performance, packetloss likely`. Kein Eingriff in die Beacon-Kadenz.
- `src/configuration_global.h`: `FLASH_VERSION` 20260909 (rein informativ, `FLASH_STRUCT_VERSION` unveraendert).

## Warum

- Deepsleep: bis auf Wireless Paper / E213 fiel jedes ESP32-Board mit LoRa in RX, Display an und (T-Beam) PMU-Schienen an in `esp_deep_sleep_start()`; auf dem RAK4631 tat `--deepsleep` gar nichts, auf dem T114 war es ein Soft-Off mit lebendem BLE/Funk/USB. Nach dem Aufwachen blieben gehaltene GPIOs gelatcht, sodass T-Deck ohne SD/Tastatur/LoRa und Wireless Paper ohne Funk hochkamen, bis der Strom weg war.
- ACK-Herkunft: die App konnte bisher nicht sagen, wer quittiert hat. Auf Gateways gingen ausserdem pro Tag ~150 Statusframes mit fremden msg_ids an das Telefon, die die App verwarf.
- BP-11: Feldfall (2026-09-04) mit fuenf gestapelten `QRT NOT SENT - `-Praefixen und neun Frames in drei Sekunden in der Luft, weil ein Client die eigene Meldung des Nodes zurueckschickte.
- Web-GUI: die Messages-Seite war mit verbundener App leer; das Queue-Panel macht Ring, Back-Pressure und Kanalauslastung ohne serielle Konsole sichtbar.
- Hoehe: Bench 2 h stationaer (Heltec V3): sd der gemeldeten Hoehe 6,6 m statt 17,2 m, 30-s-Allan-Abweichung 0,22 m statt 4,87 m. Barometer-Hoehe war nach jedem Reboot 0.
- `/D=` und `qfe`: Upstream-Wunsch #1076 bzw. falscher Wert (Meter statt hPa) auf Dashboards fuer relayte BME680-Nodes.
- CHR-03: Umlaute von Einzelbyte-Sendern kamen geloescht an, eine Nachricht aus drei Umlauten kam leer an.
- #1132: RAK4631 sendete nach Flash-Reset mit dem Sentinel -20 dBm.
- CDC: T-Deck-Cursor fror ohne USB-Host; 9 von 30 Port-Oeffnungen waehrend des Boots endeten in einer Reboot-Schleife (nach dem Fix 0 von 80).
- INS-01: Nutzer meldeten `[INSTR-LOOP]`-Zeilen als Fehler; die vier Feld-Diagnosekommandos waren als Kollateralschaden ebenfalls verschwunden.

## Getestet

- Gebaut auf `dev` 674413ce: heltec_wifi_lora_32_V3, E22-DevKitC, E22_XML-DevKitC, ttgo_tbeam, ttgo_tbeam_supreme, t_deck, t_deck_plus, wiscore_rak4631 (alle gruen):

| Env | RAM | Flash |
|---|---|---|
| heltec_wifi_lora_32_V3 | 35.5 % (116244 B) | 42.7 % (1454201 B) |
| E22-DevKitC | 21.2 % (113112 B) | 46.1 % (1567581 B) |
| E22_XML-DevKitC | 23.2 % (123416 B) | 52.5 % (1785913 B) |
| ttgo_tbeam | 8.7 % (114264 B) | 47.7 % (1622025 B) |
| ttgo_tbeam_supreme | 35.6 % (116572 B) | 43.8 % (1489577 B) |
| t_deck | 41.2 % (135156 B) | 17.3 % (2180849 B) |
| t_deck_plus | 41.2 % (135156 B) | 17.3 % (2180565 B) |
| wiscore_rak4631 | 35.7 % (88844 B) | 81.5 % (664712 B) |
- Hardware (auf dem Fork-Stand, nicht auf diesem Merge-Baum): DK5EN-98 (Heltec V3 Gateway: Queue-Panel, Messages-Tabs, TRK-01, BP-11 vier von fuenf Faellen), DK5EN-93 (Heltec V3: Hoehenfusion 2 h, `/D=` per Frame-Injektion, ADC-01), DK5EN-14 (T-Deck Plus: Deepsleep/Wake, Trackball, Tab-Wechsel, CDC 80 Port-Oeffnungen), DK5EN-90 (RAK4631: Deepsleep System OFF, #1132).
- Nicht hardware-getestet: T-Beam Supreme OLED (kein Board), Wireless Paper / E213 `gpio_hold_dis` (compile-only), T-Beam-1W, Heltec T114, T-Echo Deepsleep (compile-only), MCP23017-Sendepfad (kein Chip am Tisch, nativ geprueft).

## Hinweise fuer den Reviewer

- Der Ring-Scan in `sub_content_messages()` liest `BLEtoPhoneBuff` ohne Lock, wie bisher; der Schreibzeiger wird einmal als Snapshot gelesen.
- `charset_filter` gibt nach CHR-03 kein garantiert gueltiges UTF-8 mehr aus; die Entscheidung ist im Header dokumentiert.
- `ALT_FUSION_TAU_MS` (30 min) ist eine Konstante; ein laengeres tau (2 h) haette im Replay eine bessere Langzeitstabilitaet, ist aber noch nicht auf Hardware belegt.
- Item Deepsleep auf Vision Master E290: das Display haelt sein letztes Bild durch den Sleep, keine Hardware zum Pruefen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
