### PR TITLE
fix: 4.35t Feldfixes: Deepsleep-Taste, T-Deck Keylock, Supreme OLED

### DIFF
--- a/src/command_functions.cpp
+++ b/src/command_functions.cpp
@@ -1104,6 +1104,10 @@ void commandAction(char *umsg_text, bool ble)
             // GPIO (ESP32-S3 ext1); 99 = kein Button -> nur GPIO0.
             uint64_t wake_mask = (1ULL << 0);
             if (iButtonPin < 22) wake_mask |= (1ULL << iButtonPin);
+            // Per Long-Press ausgeloest ist die Taste hier noch gedrueckt (attachLongPressStart);
+            // ein ANY_LOW-Wake auf einem bereits LOW liegenden Pin feuert sofort. Bisher hat nur
+            // der E-Ink-Refresh oben die Zeit bis zum Loslassen ueberbrueckt -- jetzt explizit.
+            esp32WaitButtonRelease();
             esp_sleep_enable_ext1_wakeup(wake_mask, ESP_EXT1_WAKEUP_ANY_LOW);
             // Schlafstrom senken. Kurzes Settle, damit der E-Ink-Voll-Refresh aus wpShowDeepSleep()
             // sicher fertig ist, dann prepareToSleep(): SX1262 -> SLEEP (sonst Dauer-RX ~5 mA),

--- a/src/esp32/esp32_functions.cpp
+++ b/src/esp32/esp32_functions.cpp
@@ -214,6 +214,16 @@ void initDisplay()
         u8g2->setBusClock(400000);
     #endif
 
+    #if defined(BOARD_TBEAM_V3)
+        // OLED auf demselben Wire-Bus wie PMU, RTC und BME280; der Sensorpfad
+        // faehrt 100 kHz. u8g2 wuerde fuer den SH1106 sonst vor jedem Transfer
+        // 400 kHz setzen (i2c_bus_clock_100kHz = 4). 100 kHz passend zum Rest
+        // des Busses; ein Bild kostet damit ~100 ms statt 570 ms mit
+        // Software-I2C (Feldmeldung T-Beam Supreme 4.35t, siehe den
+        // Konstruktor in loop_functions.cpp).
+        u8g2->setBusClock(100000);
+    #endif
+
     u8g2->begin();
 
     #if defined(BOARD_HELTEC_V3) || defined(BOARD_HELTEC_V4) || defined(BOARD_STICK_V3)

--- a/src/esp32/esp32_sleep.cpp
+++ b/src/esp32/esp32_sleep.cpp
@@ -19,6 +19,13 @@
 // instead of this variable would ignore a user's remapped pin.
 extern uint8_t iButtonPin;
 
+// `--button on|off` (node_sset bit 0x0010, loop_functions.cpp). Only when it
+// is on does init_onebutton() configure iButtonPin (INPUT_PULLUP) and attach
+// PressLong(); with it off the pin is unconfigured and may float LOW
+// (RAK4631 WB_IO6 does), so a release wait there would only burn its 10 s
+// bound on every --deepsleep -- and no long press can have brought us here.
+extern bool bButtonCheck;
+
 #if defined(BOARD_T_DECK) || defined(BOARD_T_DECK_PLUS)
 #include <t-deck/lv_obj_functions.h>
 #endif
@@ -34,6 +41,33 @@ extern uint8_t iButtonPin;
 #include <U8g2lib.h>
 extern U8G2 *u8g2;
 #endif
+
+void esp32WaitButtonRelease()
+{
+    // PressLong() (onebutton_functions.cpp) is attached with
+    // attachLongPressStart(), so it fires 800 ms into the press and the
+    // operator's finger is still on the button when --deepsleep gets here.
+    // The ext1 wake armed below (ANY_LOW / ALL_LOW on that very pin) is
+    // then already true at esp_deep_sleep_start(): the chip wakes at once
+    // and reboots (RESET_REASON=5 DEEPSLEEP), and from the outside the node
+    // "cannot be switched off" -- field report, Heltec V3 on v4.35t. On
+    // v4.35s no wake source was armed at all, which is why the same press
+    // used to leave the node dark until reset. Wait for the release first.
+    // Bounded so that a pin stuck LOW, or a `--button` remapped to a LOW
+    // GPIO, still lets a serial/BLE --deepsleep go through; a pin that is
+    // HIGH on entry costs nothing. Only with `--button on` has OneButton
+    // configured the pin INPUT_PULLUP (init_onebutton()), so digitalRead()
+    // is meaningful there and only there.
+    if (!bButtonCheck || iButtonPin == 99)
+        return;
+    if (digitalRead(iButtonPin) != LOW)
+        return;
+
+    uint32_t t0 = millis();
+    while (digitalRead(iButtonPin) == LOW && millis() - t0 < 10000)
+        delay(10);
+    delay(100);   // contact bounce after release
+}
 
 void esp32EnterDeepSleep()
 {
@@ -178,6 +212,8 @@ void esp32EnterDeepSleep()
     // (A second bit for GPIO0 was deliberately not added: on classic ESP32
     // ALL_LOW requires every masked pin low simultaneously, so a two-pin
     // mask would make a single button press unable to wake the node.)
+    esp32WaitButtonRelease();
+
     if (iButtonPin != 99)
     {
         esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);

--- a/src/esp32/esp32_sleep.h
+++ b/src/esp32/esp32_sleep.h
@@ -13,4 +13,13 @@
 // deliberately out-of-scope piece of work).
 void esp32EnterDeepSleep();
 
+// Blocks (bounded, 10 s) until the runtime wake button (iButtonPin) reads
+// HIGH, then a short debounce. Called right before a button wake source is
+// armed, in esp32EnterDeepSleep() and in the WP_DISP --deepsleep branch:
+// a long press reaches --deepsleep via OneButton's attachLongPressStart()
+// with the button still held, and an ext1 low-level wake on a pin that is
+// already LOW fires the instant deep sleep starts. No-op when no button is
+// configured (99) or the pin is not pressed (serial/BLE --deepsleep).
+void esp32WaitButtonRelease();
+
 #endif

--- a/src/loop_functions.cpp
+++ b/src/loop_functions.cpp
@@ -385,11 +385,21 @@ U8G2 *u8g2;
     // T-Beam Supreme, [INSTR-LOOP];gap;...;in;display_tick, 4x/min beim
     // 15-s-Uhr-Refresh). Anders als dort liegt das OLED hier auf DEMSELBEN
     // Bus wie PMU/RTC/Sensoren (SDA_PIN 17 / SCL_PIN 18), also Wire statt
-    // Wire1 -- u8g2 ruft Wire.begin(17, 18) mit genau diesen Pins auf.
-    // Vollbild-Puffer (_F_) statt _1_: ein Transfer je Bild, und ein
+    // Wire1. Vollbild-Puffer (_F_) statt _1_: ein Transfer je Bild, und ein
     // unveraendertes Bild kann uebersprungen werden (TM-10).
-    U8G2_SSD1306_128X64_NONAME_F_HW_I2C u8g2_1(U8G2_R0, U8X8_PIN_NONE, 18, 17);
-    U8G2_SH1106_128X64_NONAME_F_HW_I2C u8g2_2(U8G2_R0, U8X8_PIN_NONE, 18, 17);
+    //
+    // Keine Pins an den Konstruktor: mit expliziten clock/data-Pins ruft u8g2
+    // in U8X8_MSG_GPIO_AND_DELAY_INIT (U8x8lib.cpp) pinMode(OUTPUT) auf genau
+    // den Pins, die der I2C-Controller seit Wire.begin(17, 18) im Setup schon
+    // besitzt, und haengt sie damit vom Peripheral ab; das anschliessende
+    // Wire.begin(17, 18) aus u8g2 ist auf dem laufenden Bus ein No-op. Der
+    // Controller startet die Init-Sequenz dann auf einem Bus, den er nicht
+    // mehr treibt: 4.35t blieb auf dem T-Beam Supreme in u8g2->begin()
+    // stehen (Feldmeldung, zwei Knoten, Bus davor mit ACK auf 0x3C). Ohne
+    // Pins bleibt u8g2 bei Wire.begin() ohne Argumente und fasst keine
+    // GPIOs an -- dasselbe Muster wie T-Beam v1.2 und RAK oben.
+    U8G2_SSD1306_128X64_NONAME_F_HW_I2C u8g2_1(U8G2_R0);
+    U8G2_SH1106_128X64_NONAME_F_HW_I2C u8g2_2(U8G2_R0);
 #elif defined(BOARD_TBEAM_1W)
     DISPLAY_MODEL u8g2_1(U8G2_R0, U8X8_PIN_NONE);  //RESET CLOCK DATA
     DISPLAY_MODEL u8g2_2(U8G2_R0, U8X8_PIN_NONE);

--- a/src/nrf52/nrf52_sleep.cpp
+++ b/src/nrf52/nrf52_sleep.cpp
@@ -36,6 +36,12 @@ extern void Batterie_Vide_logo(void);
 // (esp32_main.cpp:890-896, esp32_sleep.cpp) for the identical purpose.
 extern uint8_t iButtonPin;
 
+// `--button on|off` (node_sset bit 0x0010). Only then has init_onebutton()
+// configured iButtonPin INPUT_PULLUP and attached the long press; with it
+// off the pin is unconfigured and floats (RAK4631 WB_IO6 reads LOW), so the
+// release wait below would only burn its 10 s bound on every --deepsleep.
+extern bool bButtonCheck;
+
 void nrf52EnterDeepSleep()
 {
     // (a) Radio to sleep first, so it stops burning RX current while the rest
@@ -112,6 +118,25 @@ void nrf52EnterDeepSleep()
     // map. A node with no button configured, or misconfigured with
     // `--button` above 47, wakes only on RESET or USB plug-in (VBUS
     // DETECT), which sd_power_system_off() still honours.
+    //
+    // The long-press path (PressLong(), onebutton_functions.cpp, attached
+    // with attachLongPressStart()) reaches this point with the button still
+    // held. systemOff(pin, LOW) arms a LOW-level sense on that very pin, so
+    // System OFF would end the moment it starts and the node reboots
+    // instead of sleeping -- the same flaw the ESP32 helper had (field
+    // report, Heltec V3 on v4.35t; Heltec T114 and T-Echo share this path).
+    // Wait for the release first, bounded so a stuck-LOW pin or a serial/BLE
+    // --deepsleep still sleeps. Only with `--button on` has OneButton
+    // configured the pin INPUT_PULLUP, so digitalRead() is meaningful there
+    // and only there.
+    if (bButtonCheck && iButtonPin < PINS_COUNT && digitalRead(iButtonPin) == LOW)
+    {
+        uint32_t t0 = millis();
+        while (digitalRead(iButtonPin) == LOW && millis() - t0 < 10000)
+            delay(10);
+        delay(100);   // contact bounce after release
+    }
+
     if (iButtonPin < PINS_COUNT)
     {
         systemOff(iButtonPin, LOW);   // active-low button, internal pull-up configured by systemOff() itself

--- a/src/t-deck/lv_obj_functions.cpp
+++ b/src/t-deck/lv_obj_functions.cpp
@@ -2126,17 +2126,13 @@ void tft_on()
     // Ensure we have a valid brightness to restore
     if(pre_sleep_brightness_level == 0) pre_sleep_brightness_level = BRIGHTNESS_STEPS;
 
+    // Keyboard backlight: resetBrightness() -> setBrightness() already syncs
+    // it from node_kbllightlock (tdeck_helpers.cpp). The "force sync" block
+    // that used to follow here tested node_keyboardlock instead (inverted
+    // since the v4.35p keyboard-light switch) and lit the keyboard at 150
+    // whenever the panel woke with the keylock engaged -- i.e. on every
+    // incoming message, the only wake source not gated by the keylock.
     resetBrightness();
-
-    // Force sync keyboard backlight
-    if (meshcom_settings.node_keyboardlock)
-    {
-        if (bDEBUG)
-            Serial.println("[TDECK]...tft_on: turn on keyboard backlight");
-
-        // turn on keyboard backlight
-        setKeyboardBacklight(150);
-    }
 
     tdeck_tft_timer = millis();
     if (bDEBUG)


### PR DESCRIPTION
Drei Feldmeldungen gegen 4.35t (Stand `dev` c17c07c0), drei Commits, nur `src/`. Alle drei sind Folgen von PR #1135. `FLASH_STRUCT_VERSION` unveraendert, Node-Einstellungen bleiben erhalten.

## Was wurde geaendert

### 1. Long-Press-Deepsleep: Taste erst loslassen lassen, dann als Wake-Quelle armieren

- `src/esp32/esp32_sleep.{h,cpp}`: neu `esp32WaitButtonRelease()`. Liest `iButtonPin`; ist der Pin LOW, wird bis zum Loslassen gewartet (begrenzt auf 10 s, dann 100 ms Entprellung). Nur aktiv bei `--button on` (`bButtonCheck`), denn nur dann hat `init_onebutton()` den Pin als `INPUT_PULLUP` konfiguriert; bei `--button off` ist der Pin unkonfiguriert und kann LOW floaten (RAK4631 `WB_IO6` tut das). Kein Button (99) oder Pin bereits HIGH (`--deepsleep` per Serial/BLE): sofortige Rueckkehr. `esp32EnterDeepSleep()` ruft die Funktion direkt vor dem ext1-Armieren, also nach Funk-Sleep und Display-aus.
- `src/command_functions.cpp`: der WP_DISP-Zweig (Wireless Paper, Vision Master E213) ruft `esp32WaitButtonRelease()` vor `esp_sleep_enable_ext1_wakeup()`.
- `src/nrf52/nrf52_sleep.cpp`: gleicher Warteblock inline vor `systemOff(iButtonPin, LOW)`, unter derselben `PINS_COUNT`-Pruefung wie das Armieren, ebenfalls an `bButtonCheck` gebunden.

### 2. T-Deck: Tastaturbeleuchtung bei aktivem Keylock

- `src/t-deck/lv_obj_functions.cpp`, `tft_on()`: der Block "Force sync keyboard backlight" (`if (node_keyboardlock) setKeyboardBacklight(150)`) ist entfernt. `resetBrightness()` -> `setBrightness()` (`tdeck_helpers.cpp`) synchronisiert das Tastaturlicht bereits aus der echten Einstellung `node_kbllightlock`.

### 3. T-Beam Supreme: u8g2-Konstruktor ohne I2C-Pins, Bus-Takt 100 kHz

- `src/loop_functions.cpp`, Zweig `BOARD_TBEAM_V3`: beide Konstruktoren ohne Pins (`U8G2_..._F_HW_I2C(U8G2_R0)` statt `(U8G2_R0, U8X8_PIN_NONE, 18, 17)`).
- `src/esp32/esp32_functions.cpp`, `initDisplay()`: `u8g2->setBusClock(100000)` vor `u8g2->begin()` fuer `BOARD_TBEAM_V3`.

## Warum

### 1. Heltec V3 (und alle Long-Press-Deepsleep-Boards) lassen sich per Taste nicht mehr ausschalten

Auf 4.35s schaltet ein langer Druck auf die PRG-Taste (GPIO0) den Node aus, das OLED bleibt dunkel bis zum Reset. Auf 4.35t geht das OLED kurz aus und der Node bootet sofort wieder (`[BOOT] RESET_REASON=5 DEEPSLEEP`). Gemeldet fuer Heltec V3; derselbe Pfad gilt fuer Heltec V2/V4, Wireless Stick V3, Wireless Tracker, TLORA V2.1.6 sowie Heltec T114 und T-Echo.

PR #1135 hat den `--deepsleep`-Rumpf in `esp32EnterDeepSleep()` / `nrf52EnterDeepSleep()` zusammengezogen und dabei erstmals die Bedientaste als Wake-Quelle armiert (ext1 `ANY_LOW` bzw. `systemOff(pin, LOW)`). `PressLong()` in `src/onebutton_functions.cpp` haengt an `attachLongPressStart()` und feuert 800 ms nach Druckbeginn, nicht beim Loslassen. Bis `esp_deep_sleep_start()` vergehen dann rund 50 ms, der Finger liegt noch auf der Taste, der Pin ist LOW, die Wake-Bedingung ist beim Einschlafen bereits erfuellt: der Chip wacht sofort auf und bootet. Auf 4.35s war keine Wake-Quelle armiert, deshalb blieb der Node dunkel. Wireless Paper und E213 armieren die Taste in ihrem eigenen Zweig genauso; dort ueberbrueckte bisher nur der E-Ink-Refresh (~300 ms) die Zeit bis zum Loslassen.

Die Alternative, `PressLong()` an `attachLongPressStop()` zu haengen, wuerde das Verhalten des Long-Press auf jedem Board aendern und den Fall `--deepsleep` per Serial/BLE bei zufaellig gedrueckter Taste nicht abdecken.

### 2. T-Deck: Tastaturlicht geht bei aktivem Keylock mit jeder Nachricht an

Keylock aktiv (SYM+K), Tastaturlicht aus: bei jeder eingehenden Nachricht leuchtet die Tastatur mit Stufe 150 auf, geht nach dem Display-Timeout wieder aus und wiederholt das bei der naechsten Nachricht. `tft_on()` enthielt seit `583782a9b` (v4.35p Tastaturlicht-Schalter) eine invertierte Bedingung: `if (node_keyboardlock) setKeyboardBacklight(150)`; vorher stand dort `if (!node_keyboardlock) { if (kbd_light_on) ... }`. Tastatur, Trackball und Touch rufen `tft_on()` nur ohne Keylock (`tdeck_main.cpp`), die Nachricht (`msg_focus_and_alert()`) ist die einzige Weckquelle, die auch bei Keylock durchkommt. Ohne Keylock aendert sich nichts: Tastaturlicht an folgt weiter dem Display, Tastaturlicht aus bleibt aus.

### 3. T-Beam Supreme bootet mit 4.35t nicht

4.35t bleibt auf dem T-Beam Supreme (`BOARD_TBEAM_V3`) nach `[INIT]...Auto detecting display:` stehen: kein LoRa, kein BLE, keine Antwort auf `--info`, Display dunkel. Zwei Knoten betroffen, 4.35s bootet auf denselben Knoten.

PR #1135 hat das Supreme-OLED von Software-I2C auf Hardware-I2C umgestellt und dabei die Pins an den u8g2-Konstruktor gegeben. Mit expliziten clock/data-Pins fuehrt u8g2 in `U8X8_MSG_GPIO_AND_DELAY_INIT` (`U8x8lib.cpp`) `pinMode(pin, OUTPUT)` auf beiden Pins aus; `pinMode` haengt den Ausgang ueber `gpio_config` auf `SIG_GPIO_OUT_IDX` um und trennt die Pins vom I2C-Controller, der sie seit `Wire.begin(17, 18)` im Setup besitzt. Das anschliessende `Wire.begin(17, 18)` aus u8g2 ist auf dem laufenden Bus ein No-op ("bus already initialized"), der Controller startet die Init-Sequenz auf einem Bus, den er nicht mehr treibt, und `u8g2->begin()` haengt. Ein Diagnose-Build zeigt das Panel unmittelbar davor mit ACK auf 0x3C. Der Supreme war das einzige S3-Board mit diesem Muster; Heltec V3/V4/Stick V3 nutzen den Konstruktor ohne Pins plus `Wire1.setPins()`, T-Beam v1.2 und RAK den Konstruktor ohne Pins. 100 kHz passt zum Sensorpfad (BME280) auf demselben Bus; u8g2 wuerde fuer den SH1106 sonst 400 kHz setzen. Ein Bild kostet damit rund 100 ms statt 570 ms mit Software-I2C, der Gewinn aus PR #1135 bleibt.

## Getestet

- Build sauber: Heltec V3, T-Deck Plus, RAK4631, Wireless Paper, Vision Master E213, Heltec T114, T-Echo, T-Beam classic, T-Beam Supreme.
- Heltec V3 (DK5EN-93): `--deepsleep` ueber Serial bei unberuehrter Taste schlaeft sofort (letzte Ausgabe `Disbling Vext` nach 0,2 s), kein Reboot in 15 s, Wecken per Reset. Long-Press mit gehaltener Taste (`--button on`), zwei Zyklen am Stueck: `GO to deepsleep` um 21:36:20, Node dunkel und dunkel nach dem Loslassen, Wecken per Tastendruck um 21:36:25 mit `RESET_REASON=8 DEEPSLEEP`, zweiter Long-Press um 21:36:35, Node bleibt dunkel. Auf 4.35t bootete derselbe Knoten sofort wieder.
- RAK4631 (DK5EN-90): `--deepsleep` ueber Serial geht in System OFF (USB-Port verschwindet). Ohne die `bButtonCheck`-Bedingung dauerte das 12,6 s, weil `WB_IO6` bei `--button off` nie konfiguriert ist und LOW liest; mit der Bedingung sofort.
- T-Deck Plus (DK5EN-14), Bench-Szenario (Keylock per SYM+K-Tastencode, Nachricht per Inject, Beobachtung der Schreibzugriffe auf den Tastatur-Controller): vorher `150` nach jeder Nachricht, nachher kein Schreibzugriff, Panel weckt in beiden Faellen. Handtest auf demselben Geraet: KBL aus, SYM+K, Nachricht per LoRa -> Display weckt, Tastatur bleibt dunkel; SYM+K entsperrt wieder.
- T-Beam Supreme: kein Board auf der Bench, Fix nur compile-verifiziert. Der Diagnose-Build hat den Haenger in `u8g2->begin()` und den intakten Bus davor gezeigt; die Feldbestaetigung des Fix-Builds steht aus.
- Heltec T114, T-Echo, Wireless Paper, E213: compile-verifiziert.

## Hinweise fuer den Reviewer

- Alle drei Aenderungen sind Folgen von PR #1135 (Deepsleep-Helfer, T-Deck-Tastaturlicht-Schalter aus v4.35p, Supreme-OLED auf Hardware-I2C).
- Vorbestehend und hier nicht angefasst: bei `--button off` wird die (unkonfigurierte) Taste weiterhin als Wake-Quelle armiert, wie seit PR #1135.
